### PR TITLE
Fix showing error when type passed into refcount is wrong.

### DIFF
--- a/typed_python/_types.cpp
+++ b/typed_python/_types.cpp
@@ -656,8 +656,8 @@ PyObject *refcount(PyObject* nullValue, PyObject* args) {
             )) {
         PyErr_Format(
             PyExc_TypeError,
-            "first argument to refcount %S not a permitted Type",
-            a1
+            "first argument to refcount '%S' not a permitted Type",
+            (PyObject*)a1
             );
         return NULL;
     }

--- a/typed_python/types_test.py
+++ b/typed_python/types_test.py
@@ -171,6 +171,13 @@ class RandomValueProducer:
 
 class NativeTypesTests(unittest.TestCase):
 
+    def test_refcount_bug_with_simple_string(self):
+        with self.assertRaisesRegex(TypeError, "^first argument to refcount '111' not a permitted Type$"):
+            _types.refcount(111)
+
+        with self.assertRaisesRegex(TypeError, "^first argument to refcount 'aa' not a permitted Type$"):
+            _types.refcount('aa')
+
     def check_expected_performance(self, elapsed, expected=1.0):
         if os.environ.get('TRAVIS_CI', None) is not None:
             expected = 2 * expected


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Motivation and Context
There is a segmentation fault when argument passed to the refcount function is string or int.

## Approach
The change was to convert the argument to a string version, like it's expected by the `%S` format flag.

## How Has This Been Tested?
There is a new test which fails without the change.

