### PR TITLE
KeyAction Cell

### DIFF
--- a/object_database/web/cells/__init__.py
+++ b/object_database/web/cells/__init__.py
@@ -62,6 +62,8 @@ from object_database.web.cells.cells import (
 
 from object_database.web.cells.views.split_view import SplitView
 
+from .non_display.key_action import KeyAction
+
 from object_database.web.cells.CellsTestMixin import CellsTestMixin
 
 from object_database.web.cells.util import waitForCellsCondition

--- a/object_database/web/cells/cells.py
+++ b/object_database/web/cells/cells.py
@@ -462,6 +462,7 @@ class Cells:
 
         res = {
             'id': cell.identity,
+            'shouldDisplay': cell.shouldDisplay,
             'replacements': replaceDict,
             'component_name': cell.__class__.__name__,  # TODO: TEMP replace when ready
             'replacement_keys': [k for k in cell.children.keys()],
@@ -614,6 +615,7 @@ class Cell:
         self.children = {}  # local node def to global node def
         self.namedChildren = {}  # The explicitly named version for front-end (refactoring)
         self.contents = ""  # some contents containing a local node def
+        self.shouldDisplay = True  # Whether or not this is a cell that will be displayed
         self._identity = None
         self._tag = None
         self._nowrap = None

--- a/object_database/web/cells/non_display/key_action.py
+++ b/object_database/web/cells/non_display/key_action.py
@@ -1,0 +1,79 @@
+"""KeyAction Cell
+
+Listens key-combo press events from the UI"""
+from ..cells import Cell
+
+"""A class for adding Key combination event listeners
+
+to the frontend UI.
+
+Notes
+-----
+There are two types of keys you can register.
+(1) Single alphanumeric and typed symbolic keys,
+    such as:
+        `i`, `2`, `K`, `?`, etc
+(2) Modifier key plus (1) key values pressed
+    together, like pressing `Control` and `K`, etc.
+
+The possible modifier keys are:
+    `Alt`, `Control`, `Meta`, and `Shift`
+
+The way to register a `keyCmd` in the constructor for this
+class is to provide just the single character corresponding
+to the key, or, if it's a combo, to format the combo like:
+    `<modifier>+<alphanum/symbol-character>`
+For example:
+    `Alt+1`, `Control+i`, `Meta+?` etc
+
+Note also that `Ctrl` and `Control` will both work for
+the control modifier key.
+
+"""
+
+
+class KeyAction(Cell):
+    """
+    Parameters
+    __________
+    keyCmd str: A string of a key combo like `Alt+i`, `Meta+D`
+                or event single keys like `X`.
+    callback func: A function that will be called with the
+                event response dictionary data as the sole arg.
+    wantedInfo list of str: A list of keys on the UI keydown event object
+                whose values should be sent back to the Cell in the response
+                message. Optional; defaults to None.
+    priority int: The priority level of the event response.
+    stopsPropagation bool: Whether or not this KeyAction should fire and then
+                stop other KeyActions with the same keyCmd from firing
+
+    Notes
+    -----
+    For an explanation of possible `keyCmd` values, see the class comment.
+
+    For possible `wantedInfo` key names (which map to JS event data on the
+    front end), see the MDN docs here:
+    https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent
+    """
+    def __init__(self, keyCmd, callback, wantedInfo=None, priority=4, stopsPropagation=False):
+        super().__init__()
+        self.shouldDisplay = False
+        self.keyCmd = keyCmd
+        self.callback = callback
+        self.wantedInfo = wantedInfo
+        self.priority = priority
+        self.stopsPropagation = stopsPropagation
+
+        assert 1 <= self.priority <= 4
+
+    def recalculate(self):
+        self.exportData = {
+            'keyCombo': self.keyCmd,
+            'wantedEventKeys': self.wantedInfo,
+            'priority': self.priority,
+            'stopsPropagation': self.stopsPropagation
+        }
+
+    def onMessage(self, messageFrame):
+        messageFrame['data']['keyCmd'] = self.keyCmd
+        self.callback(messageFrame['data'])

--- a/object_database/web/cells_demo/key_action.py
+++ b/object_database/web/cells_demo/key_action.py
@@ -1,0 +1,34 @@
+#   Coyright 2017-2019 Nativepython Authors
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+from object_database.web import cells as cells
+from object_database.web.CellsTestPage import CellsTestPage
+
+
+class PressAltT(CellsTestPage):
+
+    def cell(self):
+        lastKeystroke = cells.Slot()
+        subCell = cells.Subscribed(lambda: lastKeystroke.get())
+        card = cells.Card(
+            subCell,
+            cells.Text("Press Alt+t to update timestamp from browser")
+        )
+
+        return cells.Sequence([
+            card,
+            cells.KeyAction('Alt+t', lambda x: lastKeystroke.set(x['timeStamp']), ['timeStamp'])])
+
+    def text(self):
+        return "Should print the current timestamp in the card when pushing Alt+t"

--- a/object_database/web/content/CellHandler.js
+++ b/object_database/web/content/CellHandler.js
@@ -128,6 +128,7 @@ class CellHandler {
             this.cells["page_root"] = document.getElementById("page_root");
             this.cells["holding_pen"] = document.getElementById("holding_pen");
         }
+
 	// With the exception of `page_root` and `holding_pen` id nodes, all
 	// elements in this.cells are virtual. Dependig on whether we are adding a
 	// new node, or manipulating an existing, we neeed to work with the underlying
@@ -181,6 +182,16 @@ class CellHandler {
                 var velement = component.render();
                 newComponents.push(component);
 	    }
+
+            // If the incoming message describes a Cell that
+            // is not for display, then we should return from
+            // the method here.
+            if(!message.shouldDisplay){
+                if(component){
+                    component.componentDidLoad();
+                }
+                return;
+            }
 
             // Install the element into the dom
             if(cell === undefined){

--- a/object_database/web/content/ComponentRegistry.js
+++ b/object_database/web/content/ComponentRegistry.js
@@ -22,6 +22,7 @@ import {ContextualDisplay} from './components/ContextualDisplay';
 import {Dropdown} from './components/Dropdown';
 import {Expands} from './components/Expands';
 import {HeaderBar} from './components/HeaderBar';
+import {KeyAction} from './components/KeyAction';
 import {LoadContentsFromUrl} from './components/LoadContentsFromUrl';
 import {LargePendingDownloadDisplay} from './components/LargePendingDownloadDisplay';
 import {Main} from './components/Main';
@@ -68,6 +69,7 @@ const ComponentRegistry = {
     Dropdown,
     Expands,
     HeaderBar,
+    KeyAction,
     LoadContentsFromUrl,
     LargePendingDownloadDisplay,
     Main,

--- a/object_database/web/content/components/CodeEditor.js
+++ b/object_database/web/content/components/CodeEditor.js
@@ -16,6 +16,11 @@ class CodeEditor extends Component {
         this.setupEditor = this.setupEditor.bind(this);
         this.setupKeybindings = this.setupKeybindings.bind(this);
         this.changeHandler = this.changeHandler.bind(this);
+
+        // Used to register and deregister
+        // any global KeyListener instance
+        this._onBlur = this._onBlur.bind(this);
+        this._onFocus = this._onFocus.bind(this);
     }
 
     componentDidLoad() {
@@ -86,6 +91,8 @@ class CodeEditor extends Component {
 	var editorId = this.props.id;
 	var editor = this.editor;
 	var SERVER_UPDATE_DELAY_MS = this.SERVER_UPDATE_DELAY_MS;
+        this.editor.on('focus', this._onFocus);
+        this.editor.on('blur', this._onBlur);
         this.editor.session.on(
             "change",
             function(delta) {
@@ -150,6 +157,18 @@ class CodeEditor extends Component {
                 }
             );
         });
+    }
+
+    _onBlur(event){
+        if(this.constructor.keyListener){
+            this.constructor.keyListener.start();
+        }
+    }
+
+    _onFocus(event){
+        if(this.constructor.keyListener){
+            this.constructor.keyListener.pause();
+        }
     }
 }
 

--- a/object_database/web/content/components/Component.js
+++ b/object_database/web/content/components/Component.js
@@ -4,6 +4,7 @@
  * Cell classes on JS side.
  */
 import {ReplacementsHandler} from './util/ReplacementsHandler';
+import {KeyListener} from './util/KeyListener';
 import {PropTypes} from './util/PropertyValidator';
 import {h} from 'maquette';
 

--- a/object_database/web/content/components/KeyAction.js
+++ b/object_database/web/content/components/KeyAction.js
@@ -1,0 +1,48 @@
+/**
+ * KeyAction Cell component
+ * ------------------------
+ * This component matches the unique
+ * non-display Cell KeyAction, which
+ * uses the Component class level
+ * KeyListener object to globally
+ * register certain key combinations
+ * that should trigger at the global
+ * level.
+ */
+import {Component} from './Component';
+
+class KeyAction extends Component {
+    constructor(props, ...args){
+        super(props, ...args);
+
+        // Bind component methods
+        this.registerKeyAction = this.registerKeyAction.bind(this);
+    }
+
+    componentDidLoad(){
+        this.registerKeyAction();
+    }
+
+    render(){
+        // This is a non-display cell
+        // and does not add any elements
+        // to the DOM.
+        return null;
+    }
+
+    registerKeyAction(){
+        if(this.constructor.keyListener){
+            this.constructor.keyListener.register(
+                this.props.extraData['keyCombo'],
+                this.props.extraData['wantedEventKeys'],
+                this.props.id,
+                this.props.extraData['priority'],
+                this.props.extraData['stopsPropagation']
+            );
+        } else {
+            throw new Error(`KeyAction(${this.props.id}) attempted to register with the KeyListener but there was no contstructor instance found!`);
+        }
+    }
+}
+
+export {KeyAction, KeyAction as default};

--- a/object_database/web/content/components/util/KeyListener.js
+++ b/object_database/web/content/components/util/KeyListener.js
@@ -1,0 +1,341 @@
+/**
+ * A Global Key Event Handler
+ * and registry.
+ * --------------------------
+ * This module represents a set of classes whose
+ * instances will comprise a global keypress
+ * event registry.
+ * `KeyListener` is the main combination and event
+ * binding mechanism.
+ * `KeyBinding` is a specific key combination plus
+ * listener that will be managed by `KeyListener`
+ * Here we can register different key combinations,
+ * like 'Alt+i' 'Ctrl+x' 'Meta+D' etc.
+ * `KeyBinding` listeners can be stored with
+ * an optional priority level, and those listeners
+ * will be fired before all others.
+ * See class comments for `KeyListener` and
+ * `KeyBinding` for more information.
+ */
+
+/**
+ * A simple mapping from common
+ * modifier key strings to the
+ * respective keys on a keyup/down
+ * event object.
+ */
+const modKeyMap = {
+    'Shift': 'shiftKey',
+    'Alt': 'altKey',
+    'Meta': 'metaKey',
+    'Control': 'ctrlKey',
+    'Ctrl': 'ctrlKey'
+};
+
+
+/**
+ * A class whose instances manage keypress
+ * event listeners on the global window object.
+ * Note that particular keycombo/listener combinations
+ * are stored internally as instances of `KeyBinding`.
+ * This class should be initialized only once on a given
+ * page.
+ */
+class KeyListener {
+    /**
+     * Creates a new `KeyListener` instance.
+     * @param {DOMElement} target - The target element
+     * to which we will bind all key event listeners.
+     * defaults to `window.document.body`
+     * @param {CellSocket} cellSocket - An instance
+     * of `CellSocket` so that we can create socket
+     * event listeners. By default, we send the event data
+     * over the `cellSocket` when a key event happens.
+     */
+    constructor(target, cellSocket){
+        this._target = target | window.document.body;
+        this.socket = cellSocket;
+        this.listenersByPriority = {
+            '1': [],
+            '2': [],
+            '3': [],
+            '4': []
+        };
+        this.listenersByCellId = {};
+
+        // Bind methods
+        this.start = this.start.bind(this);
+        this.pause = this.pause.bind(this);
+        this.mainListener = this.mainListener.bind(this);
+        this.privRegister = this.privRegister.bind(this);
+        this.register = this.register.bind(this);
+        this.deregister = this.deregister.bind(this);
+        this.makeListenerFor = this.makeListenerFor.bind(this);
+    }
+
+    /**
+     * Tells the instance to begin listening for keydown events.
+     * This method will bind the instance's single main listener,
+     * `mainListener` to the specified target object, either the
+     * passed in value or the stored internal one from construction.
+     * The idea here is that we can easily stop and start all of the
+     * constituent listeners simply by adding / removing this single
+     * listener.
+     * @param {DOMElement} target - A target DOMElement to which
+     * we will bind the global keydown listener. If not passed, will
+     * use the target specified at instantiation.
+     * @param {CellSocket} socket - A `CellSocket` instance that
+     * will handle all constituent listener responses. Will use
+     * the internal value from instantiation if nothing is passed.
+     */
+    start(target, socket){
+        if(target){
+            this._target = target;
+        }
+        if(socket){
+            this.socket = socket;
+        }
+        this._target.addEventListener('keydown', this.mainListener);
+    }
+
+    /**
+     * Stops global listening for keydown events.
+     * In practice, this method simply removes the single
+     * listener from the target DOMElement.
+     * To resume, one can simply call `start()` again without
+     * arguments.
+     */
+    pause(){
+        this._target.removeEventListener('keydown', this.mainListener);
+    }
+
+    /**
+     * The main keydown event listener that is attached
+     * to the target DOMElement when `start()` is called.
+     * Cycles through the different listeners by priority level,
+     * in order from 1 to 4. If at any point a keybinging
+     * wants to stop propagation, this listener will return
+     * from itself and stop calling the rest of the listeners.
+     * @param {KeyEvent} event - A keydown event object.
+     */
+    mainListener(event){
+        for(let i = 1; i < 5; i++){
+            let level = i.toString();
+            let bindings = this.listenersByPriority[level];
+            for(var j = 0; j < bindings.length; j++){
+                let currentBinding = bindings[j];
+                let shouldStop = currentBinding.handle(event);
+                if(shouldStop){
+                    return;
+                }
+            }
+        }
+    }
+
+    /**
+     * Private method that will create a new `KeyBinding` and add
+     * it to the appropriate priority level along with a function/listener
+     * and other information.
+     * @param {String} command - A key combination command like `Alt+i` or just `I`.
+     * @param {Function} listener - A function that will be called as the listener
+     * for this command.
+     * @param {String|Number} cellId - The ID of the Cell object that is handling
+     * this particular key combination.
+     * @param {Number} priority - the priority level for the handler. Can be in range
+     * 1 to 4.
+     * @param {Boolean} stopsPropagation - Whether or not the listener, once triggered,
+     * should stop further listeners of this key combination from firing.
+     */
+    privRegister(command, listener, cellId, priority=4, stopsPropagation=false){
+        let binding = new KeyBinding(
+            command,
+            listener,
+            priority,
+            stopsPropagation
+        );
+        if(this.listenersByCellId[cellId]){
+            this.listenersByCellId[cellId].push(binding);
+        } else {
+            this.listenersByCellId[cellId] = [binding];
+        }
+        this.listenersByPriority[priority].push(binding);
+    }
+
+    /**
+     * Public method for registering a new kebinding and listener.
+     * Uses `makeListener` internally to make a function that will
+     * make an appropriate socket call with the `desiredInfo` attached.
+     * Uses `privRegister` internally to set up priority levels etc.
+     * @param {String} command - A key combination command like `Alt+i` or
+     * `Meta+D` etc
+     * @param {[String]} desiredInfo - An array of keys on the keydown event
+     * object whose values should be sent back over the socket with the response
+     * event data.
+     * @param {String|Number} cellId - The ID of the Cell that owns this particular
+     * key listener.
+     * @param {Number} priority - The priority level of the listener. Can be in range
+     * 1 to 4.
+     * @param {Boolean} stopsPropagation - Whether or not the listener, once triggered,
+     * should stop all other listeners on this command from also firing.
+     */
+    register(command, desiredInfo, cellId, priority=4, stopsPropagation=false){
+        let listener = this.makeListenerFor(cellId, desiredInfo);
+        this.privRegister(command, listener, cellId, priority, stopsPropagation);
+    }
+
+    /**
+     * Removes all listeners from the registry
+     * that match the provided Cell ID.
+     * @param {String|Number} cellId - The ID of the cell whose
+     * listener should be removed from the registry.
+     */
+    deregister(cellId){
+        let found = this.listenersByCellId[cellId];
+        if(found){
+            Object.keys(this.listenersByPriority).forEach(priorityLevel => {
+                let current = this.listenersByPriority[priorityLevel];
+                let updated = current.filter(item => {
+                    return !found.includes(item);
+                });
+                this.listenersByPriority[priorityLevel] = current;
+            });
+            delete this.listenersByCellId[cellId];
+        }
+    }
+
+    /**
+     * Creates a listener function that will send a correctly
+     * formatted response over the `CellSocket`.
+     * @param {String|Number} cellId - The ID of the Cell that owns
+     * the listener function and keybinding
+     * @param {[String]} desiredData - An array of string/keys on
+     * the keydown event object whose values should be included
+     * in the data sent back over the socket.
+     */
+    makeListenerFor(cellId, desiredData){
+        if(this.socket){
+            let currentSocket = this.socket;
+            return function(event){
+                let responseData = {};
+                desiredData.forEach(key => {
+                    responseData[key] = event[key];
+                });
+
+                currentSocket.sendString(JSON.stringify({
+                    event: 'keypress',
+                    target_cell: cellId,
+                    data: responseData
+                }));
+            };
+        } else {
+            return function(event){
+                console.warn(`Default keyhandler for Cell ${cellId}`);
+            };
+        }
+    }
+
+}
+
+/**
+ * A class whose instances represent a combination of key commands
+ * (like `Alt+i`, `I`, `Meta+D` etc), listeners for keydown, priority
+ * level, and whether or not the binding should stop other bindings with
+ * the same command from being triggered.
+ * It's primary consumer is `KeyListener`, whose instances register
+ * all key events as `KeyBinding` objects.
+ */
+class KeyBinding {
+    /**
+      * @param {String} command - A key combo command string like `Alt+i`,
+      * `X`, `Meta+D`, etc.
+      * @param {Function} listener - A function that serves as the event
+      * listener, which will be triggered when the command is pressed.
+      * Will be passed the normal keydown event object.
+      * @param {Number} priority - The priority level of the binding. Can
+      * be in range 1 through 4.
+      * @param {Boolean} stopsPropagation - Whether or not this keybinding, once
+      * its listener has fired, should stop other keybindings with the same
+      * command from firing.
+      */
+    constructor(command, listener, priority=4, stopsPropagation=false){
+        this.command = command;
+        this.listener = listener;
+        this.priority = priority;
+        this.stopsPropagation = stopsPropagation;
+        this.commandKeys = this.command.split("+");
+
+        // Bind instance methods
+        this.handle = this.handle.bind(this);
+        this.handleSingleKey = this.handleSingleKey.bind(this);
+        this.handleComboKey = this.handleComboKey.bind(this);
+    }
+
+    /**
+     * For a given keydown event, attempt to "handle" it
+     * by calling this object's listener.
+     * Note that if there is only one command key (ie the command
+     * is a single character without a modifier key like `X`)
+     * we call `handleSingleKey`. Otherwise calls `handleComboKey`.
+     * @param {KeyEvent} event - A keydown event object
+     * @returns {Boolean} - Will return true if the keybinding
+     * both has its listener called and requires that propagation
+     * stops. false in all other cases.
+     */
+    handle(event){
+        if(this.commandKeys.length == 0){
+            return false;
+        } else if(this.commandKeys.length == 1){
+            return this.handleSingleKey(event, this.commandKeys[0]);
+        } else {
+            return this.handleComboKey(event);
+        }
+    }
+
+    /**
+     * Determines if this KeyBinding's
+     * single trigger key matches that of the
+     * passed in event. If so, that means we have
+     * a match and the listener should fire.
+     * @param {KeyEvent} event - A keydown event
+     * object that we will check for a match with.
+     * @param {String} keyName - The name of this
+     * instance's first `commandKey` value.
+     * @returns {Boolean} - If there is a match,
+     * we return true if this instance asks to
+     * stop propagation. Returns false in all
+     * other cases.
+     */
+    handleSingleKey(event, keyName){
+        if(event.key == keyName){
+            this.listener(event);
+            return this.stopsPropagation;
+        } else {
+            return false;
+        }
+    }
+
+    /**
+     * Attempts to "handle" (ie call listener for)
+     * cases where this instance uses a modifier key
+     * and has a combo command like `Alt+i` or `Meta+D`.
+     * Will attempts to match the internal `commandKey`
+     * parts to the passed-in event object and, if there
+     * is a match, will call the listener.
+     * @param {KeyEvent} event - A keydown event object
+     * @returns {Boolean} - Will return true only if
+     * this binding is a match to the event and it is
+     * also asking to stop propagation. False in all
+     * other cases.
+     */
+    handleComboKey(event){
+        let mappedModifier = modKeyMap[this.commandKeys[0]];
+        let modKeyDown = event[mappedModifier];
+        if(modKeyDown){
+            return this.handleSingleKey(event, this.commandKeys[1]);
+        } else {
+            return false;
+        }
+    }
+}
+
+export {KeyListener, KeyListener as default};

--- a/object_database/web/content/main.js
+++ b/object_database/web/content/main.js
@@ -4,6 +4,8 @@ const h = maquette.h;
 import {CellHandler} from './CellHandler';
 import {CellSocket} from './CellSocket';
 import {ComponentRegistry} from './ComponentRegistry';
+import {KeyListener} from './components/util/KeyListener';
+import {Component} from './components/Component';
 
 /**
  * Globals
@@ -49,6 +51,10 @@ window.cellHandler = cellHandler;
 document.addEventListener('DOMContentLoaded', () => {
     projector.append(document.body, initialRender);
     cellSocket.connect();
+    Component.keyListener = new KeyListener();
+    window._keyListener = Component.keyListener;
+    Component.keyListener.start(document, cellSocket);
+    window._keyListener = Component.keyListener;
 });
 
 // TESTING; REMOVE


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
This PR implements a KeyAction Cell, Component, and front-end infrastructure for binding key combo events in the UI.

## Motivation and Context
<!-- Why is this change required? -->
Issue #112 identified the need to a Cell that could bind key combinations to some action.
  
*NOTE: Together, let's make some examples that are more real-world in the playground just to test this out*
<!-- What problem does it solve? -->
<!--  If it fixes an open issue, please link to the issue here.-->

## Approach
<!-- Describe your changes in reasonable detail -->
### Cells / Backend ###
On the backend, we introduce a new cell class called `KeyAction`, whose constructor looks like this:
```python
def __init__(self, keyCmd, callback, wantedInfo=None, priority=4, stopsPropagation=False):
```
where a given `keyCmd` is the string representation of either a single key (`"X"`) or a modifier key and other key combination (`"Alt+i", "Meta+D", "Ctrl+Y", etc`). In the UI, when this key command is pressed, an event will occur and data about it will be sent back to the host `KeyAction` cell over the socket. `KeyAction` will then pass that information to any `callback` parameter that was provided to it, either a lambda or other function that takes a dictionary as the sole arg.
  
### Front End Implementation ###
#### `KeyListener` ####
We introduce a new class / singleton called `KeyListener` that knows how to bind these key combinations and add them to the global event listening space in the browser. Because of the way key events work on elements, this needs to be done at the highest scoped level.
  
`KeyListener` has two useful methods: `start()` which binds a single global listener to all `keydown` events and then re-routes all constituent key combo listeners, and `pause()` which removes that single global listener. Together these can be used to start and stop listening for *any* cell-produced key events as needed. By default, we `start` once the dom content has loaded (see the `main.js` file).
  
In `main.js`, we create a singleton of `KeyListener` and then add it as a class-level property on `Component`, such that all components can access it as needed via `someComponent.constructor.keyListener`. This is, in fact, how the corresponding `KeyAction` component works.
  
#### `KeyAction` Component ####
The component `KeyAction` is a simple wrapper for the Cell data. It uses the `constructor.keyListener` method described above to bind a keybinding/listener based on the properties specified by the corresponding Cell.

### On Non-Displayedness ###
Because `KeyAction` does not have any visual component on its own, it does not create any visible UI structure on the front end. This means we have created a new "kind" of cell -- a so called "non-display" Cell, that the UI needs to know to skip over when it comes to trying to make DOM elements in any cell creation handler.
  
In order to facilitate this, the parent `Cell` class was given a new property called `shouldDisplay` which is by default set to `True`. This information is now passed over the socket on any `updateMessageFor` composed message, and the front end then has all the info it needs.

## How Has This Been Tested?
<!-- Describe in reasonable detail how you tested your changes. -->
We have created a simple test in the Playground that will display a timestamp of when the `Alt+t` keycomo gets pressed.
<!-- If appropriate, include details of your testing environment, -->
<!-- tests ran to see how your change affects other areas of the code, etc. -->

## Screenshots or console output (if appropriate)
<!-- if not appropriate, remove this section -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Closes ##
#112 

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.