### PR TITLE
Add named tuple replacing function

### DIFF
--- a/typed_python/PyCompositeTypeInstance.hpp
+++ b/typed_python/PyCompositeTypeInstance.hpp
@@ -118,4 +118,12 @@ public:
     static void mirrorTypeInformationIntoPyTypeConcrete(NamedTuple* tupleT, PyTypeObject* pyType);
 
     int tp_setattr_concrete(PyObject* attrName, PyObject* attrVal);
+
+    static PyMethodDef* typeMethodsConcrete(Type* t);
+
+    static PyObject* replacing(PyObject* o, PyObject* args, PyObject* kwargs);
+
+private:
+
+    static int findElementIndex(const std::vector<std::string>& container, const std::string &element);
 };

--- a/typed_python/PyConstDictInstance.cpp
+++ b/typed_python/PyConstDictInstance.cpp
@@ -292,7 +292,7 @@ PyObject* PyConstDictInstance::mp_subscript_concrete(PyObject* item) {
     return NULL;
 }
 
-PyMethodDef* PyConstDictInstance::typeMethodsConcrete() {
+PyMethodDef* PyConstDictInstance::typeMethodsConcrete(Type* t) {
     return new PyMethodDef [5] {
         {"get", (PyCFunction)PyConstDictInstance::constDictGet, METH_VARARGS, NULL},
         {"items", (PyCFunction)PyConstDictInstance::constDictItems, METH_NOARGS, NULL},

--- a/typed_python/PyConstDictInstance.hpp
+++ b/typed_python/PyConstDictInstance.hpp
@@ -44,7 +44,7 @@ public:
 
     static PyObject* constDictGet(PyObject* o, PyObject* args);
 
-    static PyMethodDef* typeMethodsConcrete();
+    static PyMethodDef* typeMethodsConcrete(Type* t);
 
     static void mirrorTypeInformationIntoPyTypeConcrete(ConstDictType* constDictT, PyTypeObject* pyType);
 

--- a/typed_python/PyDictInstance.cpp
+++ b/typed_python/PyDictInstance.cpp
@@ -272,7 +272,7 @@ int PyDictInstance::mp_ass_subscript_concrete(PyObject* item, PyObject* value) {
     }
 }
 
-PyMethodDef* PyDictInstance::typeMethodsConcrete() {
+PyMethodDef* PyDictInstance::typeMethodsConcrete(Type* t) {
     return new PyMethodDef [5] {
         {"get", (PyCFunction)PyDictInstance::dictGet, METH_VARARGS, NULL},
         {"items", (PyCFunction)PyDictInstance::dictItems, METH_NOARGS, NULL},

--- a/typed_python/PyDictInstance.hpp
+++ b/typed_python/PyDictInstance.hpp
@@ -50,7 +50,7 @@ public:
 
     static PyObject* dictGet(PyObject* o, PyObject* args);
 
-    static PyMethodDef* typeMethodsConcrete();
+    static PyMethodDef* typeMethodsConcrete(Type* t);
 
     static void mirrorTypeInformationIntoPyTypeConcrete(DictType* dictT, PyTypeObject* pyType);
 

--- a/typed_python/PyForwardInstance.hpp
+++ b/typed_python/PyForwardInstance.hpp
@@ -103,7 +103,7 @@ public:
         return res;
     }
 
-    static PyMethodDef* typeMethodsConcrete() {
+    static PyMethodDef* typeMethodsConcrete(Type* t) {
         return new PyMethodDef [4] {
             {"define", (PyCFunction)PyForwardInstance::forwardDefine, METH_VARARGS | METH_CLASS, NULL},
             {"get", (PyCFunction)PyForwardInstance::forwardGet, METH_VARARGS | METH_CLASS, NULL},

--- a/typed_python/PyInstance.cpp
+++ b/typed_python/PyInstance.cpp
@@ -63,11 +63,11 @@ PyMethodDef* PyInstance::typeMethods(Type* t) {
     return specializeStatic(t->getTypeCategory(), [&](auto* concrete_null_ptr) {
         typedef typename std::remove_reference<decltype(*concrete_null_ptr)>::type py_instance_type;
 
-        return py_instance_type::typeMethodsConcrete();
+        return py_instance_type::typeMethodsConcrete(t);
     });
 }
 
-PyMethodDef* PyInstance::typeMethodsConcrete() {
+PyMethodDef* PyInstance::typeMethodsConcrete(Type* t) {
     return new PyMethodDef [2] {
         {NULL, NULL}
     };

--- a/typed_python/PyInstance.hpp
+++ b/typed_python/PyInstance.hpp
@@ -314,7 +314,7 @@ public:
 
     static PyMethodDef* typeMethods(Type* t);
 
-    static PyMethodDef* typeMethodsConcrete();
+    static PyMethodDef* typeMethodsConcrete(Type* t);
 
     static void tp_dealloc(PyObject* self);
 

--- a/typed_python/PyPointerToInstance.cpp
+++ b/typed_python/PyPointerToInstance.cpp
@@ -163,7 +163,7 @@ PyObject* PyPointerToInstance::pyOperatorConcrete(PyObject* rhs, const char* op,
     return ((PyInstance*)this)->pyOperatorConcrete(rhs, op, opErr);
 }
 
-PyMethodDef* PyPointerToInstance::typeMethodsConcrete() {
+PyMethodDef* PyPointerToInstance::typeMethodsConcrete(Type* t) {
     return new PyMethodDef [5] {
         {"initialize", (PyCFunction)PyPointerToInstance::pointerInitialize, METH_VARARGS, NULL},
         {"set", (PyCFunction)PyPointerToInstance::pointerSet, METH_VARARGS, NULL},

--- a/typed_python/PyPointerToInstance.hpp
+++ b/typed_python/PyPointerToInstance.hpp
@@ -42,5 +42,5 @@ public:
         return true;
     }
 
-    static PyMethodDef* typeMethodsConcrete();
+    static PyMethodDef* typeMethodsConcrete(Type* t);
 };

--- a/typed_python/PyTupleOrListOfInstance.cpp
+++ b/typed_python/PyTupleOrListOfInstance.cpp
@@ -479,7 +479,7 @@ PyObject* PyTupleOrListOfInstance::mp_subscript_concrete(PyObject* item) {
     return NULL;
 }
 
-PyMethodDef* PyTupleOfInstance::typeMethodsConcrete() {
+PyMethodDef* PyTupleOfInstance::typeMethodsConcrete(Type* t) {
     return new PyMethodDef [3] {
         {"toArray", (PyCFunction)PyTupleOrListOfInstance::toArray, METH_VARARGS, NULL},
         {NULL, NULL}
@@ -775,7 +775,7 @@ int PyListOfInstance::mp_ass_subscript_concrete(PyObject* item, PyObject* value)
     return ((PyInstance*)this)->mp_ass_subscript_concrete(item, value);
 }
 
-PyMethodDef* PyListOfInstance::typeMethodsConcrete() {
+PyMethodDef* PyListOfInstance::typeMethodsConcrete(Type* t) {
     return new PyMethodDef [12] {
         {"toArray", (PyCFunction)PyTupleOrListOfInstance::toArray, METH_VARARGS, NULL},
         {"append", (PyCFunction)PyListOfInstance::listAppend, METH_VARARGS, NULL},

--- a/typed_python/PyTupleOrListOfInstance.hpp
+++ b/typed_python/PyTupleOrListOfInstance.hpp
@@ -71,7 +71,7 @@ public:
 
     int mp_ass_subscript_concrete(PyObject* item, PyObject* value);
 
-    static PyMethodDef* typeMethodsConcrete();
+    static PyMethodDef* typeMethodsConcrete(Type* t);
 
     static void constructFromPythonArgumentsConcrete(ListOfType* t, uint8_t* data, PyObject* args, PyObject* kwargs);
 
@@ -109,7 +109,7 @@ public:
 
     TupleOfType* type();
 
-    static PyMethodDef* typeMethodsConcrete();
+    static PyMethodDef* typeMethodsConcrete(Type* t);
 
     static bool compare_to_python_concrete(TupleOfType* tupT, instance_ptr self, PyObject* other, bool exact, int pyComparisonOp) {
         auto convert = [&](char cmpValue) { return cmpResultToBoolForPyOrdering(pyComparisonOp, cmpValue); };


### PR DESCRIPTION
Add NamedTuple::replacing function.

Description is in the ticket #114.

## Motivation and Context
The `NamedTuple` will be able to use the function like `t.replacing(k1=v1, k2=v2, ...)`, which returns a copy of the tuple with member 'k1' replaced with value 'v1', etc.

## How Has This Been Tested?
There are new tests for checking the function, including compiler integration, and reference counts.

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.