### PR TITLE
[set] initial impl of Set

### DIFF
--- a/typed_python/AllTypes.hpp
+++ b/typed_python/AllTypes.hpp
@@ -43,6 +43,7 @@
 #include "ClassType.hpp"
 #include "BoundMethodType.hpp"
 #include "EmbeddedMessageType.hpp"
+#include "SetType.hpp"
 
 #include "direct_types/all.hpp"
 #include "direct_types/GeneratedTypes.hpp"

--- a/typed_python/PyInstance.cpp
+++ b/typed_python/PyInstance.cpp
@@ -42,6 +42,7 @@
 #include "PyOneOfInstance.hpp"
 #include "PyForwardInstance.hpp"
 #include "PyEmbeddedMessageInstance.hpp"
+#include "PySetInstance.hpp"
 
 Type* PyInstance::type() {
     return extractTypeFrom(((PyObject*)this)->ob_type);
@@ -502,12 +503,13 @@ PySequenceMethods* PyInstance::sequenceMethodsFor(Type* t) {
             t->getTypeCategory() == Type::TypeCategory::catNamedTuple ||
             t->getTypeCategory() == Type::TypeCategory::catString ||
             t->getTypeCategory() == Type::TypeCategory::catBytes ||
+            t->getTypeCategory() == Type::TypeCategory::catSet ||
             t->getTypeCategory() == Type::TypeCategory::catDict ||
             t->getTypeCategory() == Type::TypeCategory::catConstDict) {
         PySequenceMethods* res =
             new PySequenceMethods {0,0,0,0,0,0,0,0};
 
-        if (t->getTypeCategory() == Type::TypeCategory::catConstDict || t->getTypeCategory() == Type::TypeCategory::catDict) {
+        if (t->getTypeCategory() == Type::TypeCategory::catConstDict || t->getTypeCategory() == Type::TypeCategory::catDict || t->getTypeCategory() == Type::TypeCategory::catSet) {
             res->sq_contains = (objobjproc)PyInstance::sq_contains;
         } else {
             res->sq_length = (lenfunc)PyInstance::mp_and_sq_length;
@@ -633,6 +635,7 @@ PyMappingMethods* PyInstance::mappingMethods(Type* t) {
 
     if (t->getTypeCategory() == Type::TypeCategory::catConstDict ||
         t->getTypeCategory() == Type::TypeCategory::catDict ||
+        t->getTypeCategory() == Type::TypeCategory::catSet ||
         t->getTypeCategory() == Type::TypeCategory::catTupleOf ||
         t->getTypeCategory() == Type::TypeCategory::catListOf ||
         t->getTypeCategory() == Type::TypeCategory::catClass) {
@@ -752,7 +755,8 @@ PyTypeObject* PyInstance::typeObjInternal(Type* inType) {
             .tp_richcompare = tp_richcompare,           // richcmpfunc
             .tp_weaklistoffset = 0,                     // Py_ssize_t
             .tp_iter = inType->getTypeCategory() == Type::TypeCategory::catConstDict ||
-                        inType->getTypeCategory() == Type::TypeCategory::catDict
+                        inType->getTypeCategory() == Type::TypeCategory::catDict || 
+                        inType->getTypeCategory() == Type::TypeCategory::catSet 
                          ?
                 PyInstance::tp_iter
             :   0,                                      // getiterfunc tp_iter;
@@ -1082,6 +1086,8 @@ PyObject* PyInstance::categoryToPyString(Type::TypeCategory cat) {
     if (cat == Type::TypeCategory::catListOf) { static PyObject* res = PyUnicode_FromString("ListOf"); return res; }
     if (cat == Type::TypeCategory::catNamedTuple) { static PyObject* res = PyUnicode_FromString("NamedTuple"); return res; }
     if (cat == Type::TypeCategory::catTuple) { static PyObject* res = PyUnicode_FromString("Tuple"); return res; }
+    if (cat == Type::TypeCategory::catSet) { static PyObject* res = PyUnicode_FromString("Set"); return res; }
+    if (cat == Type::TypeCategory::catConstDict) { static PyObject* res = PyUnicode_FromString("ConstDict"); return res; }
     if (cat == Type::TypeCategory::catDict) { static PyObject* res = PyUnicode_FromString("Dict"); return res; }
     if (cat == Type::TypeCategory::catConstDict) { static PyObject* res = PyUnicode_FromString("ConstDict"); return res; }
     if (cat == Type::TypeCategory::catAlternative) { static PyObject* res = PyUnicode_FromString("Alternative"); return res; }

--- a/typed_python/PyInstance.cpp
+++ b/typed_python/PyInstance.cpp
@@ -1087,7 +1087,6 @@ PyObject* PyInstance::categoryToPyString(Type::TypeCategory cat) {
     if (cat == Type::TypeCategory::catNamedTuple) { static PyObject* res = PyUnicode_FromString("NamedTuple"); return res; }
     if (cat == Type::TypeCategory::catTuple) { static PyObject* res = PyUnicode_FromString("Tuple"); return res; }
     if (cat == Type::TypeCategory::catSet) { static PyObject* res = PyUnicode_FromString("Set"); return res; }
-    if (cat == Type::TypeCategory::catConstDict) { static PyObject* res = PyUnicode_FromString("ConstDict"); return res; }
     if (cat == Type::TypeCategory::catDict) { static PyObject* res = PyUnicode_FromString("Dict"); return res; }
     if (cat == Type::TypeCategory::catConstDict) { static PyObject* res = PyUnicode_FromString("ConstDict"); return res; }
     if (cat == Type::TypeCategory::catAlternative) { static PyObject* res = PyUnicode_FromString("Alternative"); return res; }

--- a/typed_python/PyInstance.hpp
+++ b/typed_python/PyInstance.hpp
@@ -48,6 +48,7 @@ class PyPythonObjectOfTypeInstance;
 class PyOneOfInstance;
 class PyForwardInstance;
 class PyEmbeddedMessageInstance;
+class PySetInstance;
 
 template<class T>
 class PyRegisterTypeInstance;
@@ -104,6 +105,8 @@ public:
                 return f(*(PyConstDictInstance*)obj);
             case Type::TypeCategory::catDict:
                 return f(*(PyDictInstance*)obj);
+            case Type::TypeCategory::catSet:
+                return f(*(PySetInstance*)obj);
             case Type::TypeCategory::catAlternative:
                 return f(*(PyAlternativeInstance*)obj);
             case Type::TypeCategory::catConcreteAlternative:
@@ -177,6 +180,8 @@ public:
                 return f((PyConstDictInstance*)nullptr);
             case Type::TypeCategory::catDict:
                 return f((PyDictInstance*)nullptr);
+            case Type::TypeCategory::catSet:
+                return f((PySetInstance*)nullptr);
             case Type::TypeCategory::catAlternative:
                 return f((PyAlternativeInstance*)nullptr);
             case Type::TypeCategory::catConcreteAlternative:

--- a/typed_python/PySetInstance.cpp
+++ b/typed_python/PySetInstance.cpp
@@ -1,0 +1,246 @@
+/******************************************************************************
+   Copyright 2017-2019 Nativepython Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+******************************************************************************/
+
+#include "PySetInstance.hpp"
+
+PyMethodDef* PySetInstance::typeMethodsConcrete(Type* t) {
+    return new PyMethodDef[6]{{"add", (PyCFunction)PySetInstance::setAdd, METH_VARARGS, NULL},
+                              {"discard", (PyCFunction)PySetInstance::setDiscard, METH_VARARGS,
+                               NULL},
+                              {"remove", (PyCFunction)PySetInstance::setRemove, METH_VARARGS, NULL},
+                              {"clear", (PyCFunction)PySetInstance::setClear, METH_VARARGS, NULL},
+                              {NULL, NULL}};
+}
+
+PyObject* PySetInstance::try_remove(PyObject* o, PyObject* args, bool assertKeyError) {
+    PySetInstance* self_w = (PySetInstance*)o;
+    PyObjectHolder item(PyTuple_GetItem(args, 0));
+    Type* item_type = extractTypeFrom(item->ob_type);
+    Type* self_type = extractTypeFrom(o->ob_type);
+
+    if (self_type->getTypeCategory() == Type::TypeCategory::catSet) {
+        if (item_type == self_w->type()->keyType()) {
+            PyInstance* item_w = (PyInstance*)(PyObject*)item;
+            instance_ptr key = item_w->dataPtr();
+            bool found_and_discarded = self_w->type()->discard(self_w->dataPtr(), key);
+            if (assertKeyError && !found_and_discarded) {
+                PyErr_SetObject(PyExc_KeyError, item);
+                return NULL;
+            }
+        } else {
+            try {
+                Instance key(self_w->type()->keyType(), [&](instance_ptr data) {
+                    copyConstructFromPythonInstance(self_w->type()->keyType(), data, item);
+                });
+                bool found_and_discarded = self_w->type()->discard(self_w->dataPtr(), key.data());
+                if (assertKeyError && !found_and_discarded) {
+                    PyErr_SetObject(PyExc_KeyError, item);
+                    return NULL;
+                }
+            } catch (PythonExceptionSet& e) {
+                return NULL;
+            } catch (std::exception& e) {
+                PyErr_SetString(PyExc_TypeError, e.what());
+                return NULL;
+            }
+        }
+    } else {
+        PyErr_SetString(PyExc_TypeError, "Wrong type!");
+        return NULL;
+    }
+
+    Py_RETURN_NONE;
+}
+
+PyObject* PySetInstance::setRemove(PyObject* o, PyObject* args) {
+    if (PyTuple_Size(args) != 1) {
+        PyErr_SetString(PyExc_TypeError, "Set.remove takes one argument");
+        return NULL;
+    }
+
+    return try_remove(o, args, true);
+}
+
+PyObject* PySetInstance::setDiscard(PyObject* o, PyObject* args) {
+    if (PyTuple_Size(args) != 1) {
+        PyErr_SetString(PyExc_TypeError, "Set.discard takes one argument");
+        return NULL;
+    }
+
+    return try_remove(o, args, false);
+}
+
+PyObject* PySetInstance::setClear(PyObject* o, PyObject* args) {
+    if (PyTuple_Size(args) != 0) {
+        PyErr_SetString(PyExc_TypeError, "Set.clear takes no arguments");
+        return NULL;
+    }
+    PySetInstance* self_w = (PySetInstance*)o;
+    self_w->type()->clear(self_w->dataPtr());
+    Py_RETURN_NONE;
+}
+
+int PySetInstance::sq_contains_concrete(PyObject* item) {
+    Type* item_type = extractTypeFrom(Py_TYPE(item));
+    if (item_type == type()->keyType()) {
+        PyInstance* item_w = (PyInstance*)item;
+        instance_ptr i = type()->lookupKey(dataPtr(), item_w->dataPtr());
+        return i ? 1 : 0;
+    } else {
+        Instance key(type()->keyType(), [&](instance_ptr data) {
+            copyConstructFromPythonInstance(type()->keyType(), data, item);
+        });
+        instance_ptr i = type()->lookupKey(dataPtr(), key.data());
+        return i ? 1 : 0;
+    }
+}
+
+PyObject* PySetInstance::setAdd(PyObject* o, PyObject* args) {
+    PySetInstance* self_w = (PySetInstance*)o;
+    if (PyTuple_Size(args) != 1) {
+        PyErr_SetString(PyExc_TypeError, "Set.add takes one argument");
+        return NULL;
+    }
+
+    PyObjectHolder item(PyTuple_GetItem(args, 0));
+    Type* item_type = extractTypeFrom(item->ob_type);
+    Type* self_type = extractTypeFrom(o->ob_type);
+
+    if (self_type->getTypeCategory() == Type::TypeCategory::catSet) {
+        if (item_type == self_w->type()->keyType()) {
+            PyInstance* item_w = (PyInstance*)(PyObject*)item;
+            instance_ptr key = item_w->dataPtr();
+            if (try_insert_key(self_w, item, key) != 0)
+                return NULL;
+        } else {
+            try {
+                Instance key(self_w->type()->keyType(), [&](instance_ptr data) {
+                    copyConstructFromPythonInstance(self_w->type()->keyType(), data, item);
+                });
+                if (try_insert_key(self_w, item, key.data()) != 0)
+                    return NULL;
+            } catch (PythonExceptionSet& e) {
+                return NULL;
+            } catch (std::exception& e) {
+                PyErr_SetString(PyExc_TypeError, e.what());
+                return NULL;
+            }
+        }
+    } else {
+        PyErr_SetString(PyExc_TypeError, "Wrong type!");
+        return NULL;
+    }
+
+    Py_RETURN_NONE;
+}
+
+Py_ssize_t PySetInstance::mp_and_sq_length_concrete() {
+    return type()->size(dataPtr());
+}
+
+PyObject* PySetInstance::tp_iter_concrete() {
+    return createIteratorToSelf(mIteratorFlag);
+}
+
+PyObject* PySetInstance::tp_iternext_concrete() {
+    if (mIteratorOffset == 0) {
+        // search forward to find the first slot
+        while (mIteratorOffset < type()->slotCount(dataPtr())
+               && !type()->slotPopulated(dataPtr(), mIteratorOffset)) {
+            mIteratorOffset++;
+        }
+    }
+
+    if (mIteratorOffset >= type()->slotCount(dataPtr())) {
+        return NULL;
+    }
+
+    int32_t curSlot = mIteratorOffset;
+
+    mIteratorOffset++;
+    while (mIteratorOffset < type()->slotCount(dataPtr())
+           && !type()->slotPopulated(dataPtr(), mIteratorOffset)) {
+        mIteratorOffset++;
+    }
+
+    return extractPythonObject(type()->keyAtSlot(dataPtr(), curSlot), type()->keyType());
+}
+
+int PySetInstance::try_insert_key(PySetInstance* self, PyObject* pyKey, instance_ptr key) {
+    instance_ptr existingLoc = self->type()->lookupKey(self->dataPtr(), key);
+    if (!existingLoc)
+        self->type()->insertKey(self->dataPtr(), key);
+    return 0;
+}
+
+void PySetInstance::mirrorTypeInformationIntoPyTypeConcrete(SetType* setType,
+                                                            PyTypeObject* pyType) {
+    PyDict_SetItemString(pyType->tp_dict, "KeyType",
+                         typePtrToPyTypeRepresentation(setType->keyType()));
+}
+
+SetType* PySetInstance::type() {
+    return (SetType*)extractTypeFrom(((PyObject*)this)->ob_type);
+}
+
+void PySetInstance::copyConstructFromPythonInstanceConcrete(SetType* setType, instance_ptr tgt,
+                                                            PyObject* pyRepresentation,
+                                                            bool isExplicit) {
+    setType->constructor(tgt);
+    try {
+        if ((PyList_Check(pyRepresentation) || PySet_Check(pyRepresentation)
+             || PyBytes_Check(pyRepresentation) || PyTuple_Check(pyRepresentation))) {
+            PyObjectStealer iterator(PyObject_GetIter(pyRepresentation));
+            if (!iterator) {
+                throw PythonExceptionSet();
+            }
+
+            PyObject* item;
+            while ((item = PyObjectStealer(PyIter_Next(iterator)))) {
+                if (!item) {
+                    if (PyErr_Occurred()) {
+                        throw PythonExceptionSet();
+                    }
+                }
+
+                Instance key(setType->keyType(), [&](instance_ptr data) {
+                    copyConstructFromPythonInstance(setType->keyType(), data, item);
+                });
+
+                instance_ptr found = setType->lookupKey(tgt, key.data());
+                if (!found) {
+                    setType->insertKey(tgt, key.data());
+                }
+            }
+            return;
+        } else if (PyNumber_Check(pyRepresentation)) {
+            Instance key(setType->keyType(), [&](instance_ptr data) {
+                copyConstructFromPythonInstance(setType->keyType(), data, pyRepresentation);
+            });
+
+            instance_ptr found = setType->lookupKey(tgt, key.data());
+            if (!found) {
+                setType->insertKey(tgt, key.data());
+            }
+            return;
+        }
+
+    } catch (...) {
+        setType->destroy(tgt);
+        throw;
+    }
+    PyInstance::copyConstructFromPythonInstanceConcrete(setType, tgt, pyRepresentation, isExplicit);
+}

--- a/typed_python/PySetInstance.hpp
+++ b/typed_python/PySetInstance.hpp
@@ -1,0 +1,50 @@
+/******************************************************************************
+   Copyright 2017-2019 Nativepython Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+******************************************************************************/
+
+#pragma once
+
+#include "PyInstance.hpp"
+
+class PySetInstance : public PyInstance {
+  public:
+    using modeled_type = SetType;
+
+    // module definitions
+    static PyMethodDef* typeMethodsConcrete(Type* t);
+    static PyObject* setAdd(PyObject* o, PyObject* args);
+    static PyObject* setContains(PyObject* o, PyObject* args);
+    static PyObject* setDiscard(PyObject* o, PyObject* args);
+    static PyObject* setRemove(PyObject* o, PyObject* args);
+    static PyObject* setClear(PyObject* o, PyObject* args);
+    Py_ssize_t mp_and_sq_length_concrete();
+    int sq_contains_concrete(PyObject* item);
+    PyObject* tp_iter_concrete();
+    PyObject* tp_iternext_concrete();
+
+    static void copyConstructFromPythonInstanceConcrete(SetType* setType, instance_ptr tgt,
+                                                        PyObject* pyRepresentation,
+                                                        bool isExplicit);
+    static void mirrorTypeInformationIntoPyTypeConcrete(SetType* setType, PyTypeObject* pyType);
+    static bool pyValCouldBeOfTypeConcrete(modeled_type* type, PyObject* pyRepresentation, bool isExplicit) {
+        return true;
+    }
+
+  private:
+    static int try_insert_key(PySetInstance* self, PyObject* pyKey, instance_ptr key);
+    static PyObject* try_remove(PyObject* o, PyObject* args, bool assertKeyError = false);
+    SetType* type();
+};
+

--- a/typed_python/SetType.cpp
+++ b/typed_python/SetType.cpp
@@ -1,0 +1,184 @@
+#include "AllTypes.hpp"
+#include <iostream>
+#include <map>
+
+SetType* SetType::Make(Type* eltype) {
+    static std::mutex guard;
+    std::lock_guard<std::mutex> lg(guard);
+    static std::map<Type*, SetType*> m;
+    auto it = m.find(eltype);
+    if (it == m.end())
+        it = m.insert(std::make_pair(eltype, new SetType(eltype))).first;
+    return it->second;
+}
+
+bool SetType::discard(instance_ptr self, instance_ptr key) {
+    layout& record = **(layout**)self;
+    typed_python_hash_type keyHash = m_key_type->hash(key);
+    int32_t index = record.remove(m_bytes_per_el, keyHash, [&](instance_ptr ptr) {
+        return m_key_type->cmp(key, ptr, Py_EQ);
+    });
+    if (index >= 0) {
+        m_key_type->destroy(record.items + index * m_bytes_per_el);
+        return true;
+    }
+    return false;
+}
+
+void SetType::clear(instance_ptr self) {
+    layout& record = **(layout**)self;
+    for (long k = 0; k < record.items_reserved; k++) {
+        if (record.items_populated[k]) {
+            discard(self, keyAtSlot(self, k));
+        }
+    }
+}
+
+instance_ptr SetType::insertKey(instance_ptr self, instance_ptr key) {
+    layout& record = **(layout**)self;
+    typed_python_hash_type keyHash = m_key_type->hash(key);
+    int32_t slot = record.allocateNewSlot(m_bytes_per_el);
+    record.add(keyHash, slot);
+    m_key_type->copy_constructor(record.items + slot * m_bytes_per_el, key);
+    return record.items + slot * m_bytes_per_el;
+}
+
+instance_ptr SetType::lookupKey(instance_ptr self, instance_ptr key) const {
+    layout& record = **(layout**)self;
+    typed_python_hash_type keyHash = m_key_type->hash(key);
+    int32_t index = record.find(m_bytes_per_el, keyHash,
+                                [&](instance_ptr ptr) { return m_key_type->cmp(key, ptr, Py_EQ); });
+    if (index >= 0) {
+        return record.items + index * m_bytes_per_el;
+    }
+    return 0;
+}
+
+int64_t SetType::size(instance_ptr self) const {
+    layout& record = **(layout**)self;
+    return record.hash_table_count;
+}
+
+bool SetType::_updateAfterForwardTypesChanged() {
+    std::string name = "Set(" + m_key_type->name() + ")";
+    m_size = sizeof(void*);
+    m_is_default_constructible = true;
+    m_bytes_per_el = m_key_type->bytecount();
+
+    if (m_is_recursive) {
+        name = m_recursive_name;
+    }
+
+    bool anyChanged = name != m_name;
+    m_name = name;
+    return anyChanged;
+}
+
+int64_t SetType::refcount(instance_ptr self) const {
+    layout& record = **(layout**)self;
+    return record.refcount;
+}
+
+void SetType::constructor(instance_ptr self) {
+    (*(layout**)self) = (layout*)malloc(sizeof(layout));
+    layout& record = **(layout**)self;
+    new (&record) layout();
+    record.refcount += 1;
+}
+
+void SetType::destroy(instance_ptr self) {
+    layout& record = **(layout**)self;
+
+    if (record.refcount.fetch_sub(1) == 1) {
+        for (long k = 0; k < record.items_reserved; k++) {
+            if (record.items_populated[k]) {
+                m_key_type->destroy(record.items + m_bytes_per_el * k);
+            }
+        }
+
+        free(record.items);
+        free(record.items_populated);
+        free(record.hash_table_slots);
+        free(record.hash_table_hashes);
+        free(&record);
+    }
+}
+
+void SetType::copy_constructor(instance_ptr self, instance_ptr other) {
+    (*(layout**)self) = (*(layout**)other);
+    (*(layout**)self)->refcount++;
+}
+
+bool SetType::cmp(instance_ptr left, instance_ptr right, int pyComparisonOp,
+                  bool suppressExceptions) {
+    if (pyComparisonOp != Py_NE && pyComparisonOp != Py_EQ) {
+        throw std::runtime_error("Ordered comparison not supported between objects of type "
+                                 + name());
+    }
+
+    layout& l = **(layout**)left;
+    layout& r = **(layout**)right;
+
+    if (&l == &r) {
+        return cmpResultToBoolForPyOrdering(pyComparisonOp, 0);
+    }
+
+    if (l.hash_table_count != r.hash_table_count) {
+        return cmpResultToBoolForPyOrdering(pyComparisonOp, 1);
+    }
+
+    // check each item on the left to see if its in the right and has the same value
+    for (long k = 0; k < l.items_reserved; k++) {
+        if (l.items_populated[k]) {
+            instance_ptr key = l.items + m_bytes_per_el * k;
+            instance_ptr otherKey = lookupKey(right, key);
+            if (!otherKey) {
+                return cmpResultToBoolForPyOrdering(pyComparisonOp, 1);
+            }
+        }
+    }
+
+    return cmpResultToBoolForPyOrdering(pyComparisonOp, 0);
+}
+
+void SetType::repr(instance_ptr self, ReprAccumulator& stream) {
+    PushReprState isNew(stream, self);
+
+    if (!isNew) {
+        stream << m_name << "(" << (void*)self << ")";
+        return;
+    }
+
+    stream << "{";
+    layout& l = **(layout**)self;
+    bool isFirst = true;
+
+    for (long k = 0; k < l.items_reserved; k++) {
+        if (l.items_populated[k]) {
+            if (isFirst) {
+                isFirst = false;
+            } else {
+                stream << ", ";
+            }
+
+            m_key_type->repr(l.items + k * m_bytes_per_el, stream);
+        }
+    }
+
+    stream << "}";
+}
+
+int64_t SetType::slotCount(instance_ptr self) const {
+    layout& record = **(layout**)self;
+    return record.items_reserved;
+}
+
+bool SetType::slotPopulated(instance_ptr self, size_t offset) const {
+    layout& record = **(layout**)self;
+    return record.items_populated[offset];
+}
+
+instance_ptr SetType::keyAtSlot(instance_ptr self, size_t offset) const {
+    layout& record = **(layout**)self;
+    return record.items + m_bytes_per_el * offset;
+}

--- a/typed_python/SetType.hpp
+++ b/typed_python/SetType.hpp
@@ -382,6 +382,11 @@ class SetType : public Type {
         endOfConstructorInitialization();
     }
 
+    template<class visitor_type>
+    void _visitReferencedTypes(const visitor_type& visitor) {
+        visitor(m_key_type);
+    }
+
     instance_ptr insertKey(instance_ptr self, instance_ptr key);
     instance_ptr lookupKey(instance_ptr self, instance_ptr key) const;
     bool discard(instance_ptr self, instance_ptr key);
@@ -393,7 +398,8 @@ class SetType : public Type {
     int64_t refcount(instance_ptr self) const;
     bool _updateAfterForwardTypesChanged();
     int64_t size(instance_ptr self) const;
-    bool cmp(instance_ptr left, instance_ptr right, int pyComparisonOp, bool suppressExceptions = false);
+    bool cmp(instance_ptr left, instance_ptr right, int pyComparisonOp,
+             bool suppressExceptions = false);
     Type* keyType() const { return m_key_type; }
 
     // layout accessors

--- a/typed_python/SetType.hpp
+++ b/typed_python/SetType.hpp
@@ -1,0 +1,410 @@
+#pragma once
+
+#include "Type.hpp"
+
+class SetType : public Type {
+  public:
+    class layout {
+      public:
+        layout()
+            : refcount(0)
+            , items(nullptr)
+            , items_populated(nullptr)
+            , items_reserved(0)
+            , top_item_slot(0)
+            , hash_table_slots(nullptr)
+            , hash_table_hashes(nullptr)
+            , hash_table_size(0)
+            , hash_table_count(0)
+            , hash_table_empty_slots(0) {}
+
+        enum { EMPTY = -1, DELETED = -2 };
+
+        // return the index of the object indexed by 'hash', or -1
+        template <class eq_func>
+        int32_t find(int32_t kv_pair_size, int32_t hash, const eq_func& compare) {
+            if (!hash_table_slots) {
+                return -1;
+            }
+
+            int32_t offset = hash % hash_table_size;
+
+            while (true) {
+                // slot is empty
+                int32_t slot = hash_table_slots[offset];
+
+                if (slot == EMPTY) {
+                    return -1;
+                }
+
+                if (slot != DELETED && hash_table_hashes[offset] == hash
+                    && compare(items + kv_pair_size * slot)) {
+                    return slot;
+                }
+
+                offset = nextOffset(offset);
+            }
+        }
+
+        // linear search
+        int32_t nextOffset(int32_t offset) const {
+            offset += 1;
+            if (offset >= hash_table_size) {
+                offset = 0;
+            }
+            return offset;
+        }
+
+        // add an item to the hash table
+        void add(int32_t hash, int32_t slot) {
+            if (hash_table_count * 2 + 1 > hash_table_size
+                || hash_table_empty_slots < hash_table_size / 4 + 1) {
+                resizeTable();
+            }
+
+            int32_t offset = hash % hash_table_size;
+            while (true) {
+                if (hash_table_slots[offset] == EMPTY || hash_table_slots[offset] == DELETED) {
+                    if (hash_table_slots[offset] == EMPTY) {
+                        hash_table_empty_slots--;
+                    }
+
+                    hash_table_slots[offset] = slot;
+                    hash_table_hashes[offset] = hash;
+                    items_populated[slot] = 1;
+                    hash_table_count++;
+                    return;
+                }
+
+                offset = nextOffset(offset);
+            }
+        }
+
+        // remove an item with the given hash. returning the item slot where it lived.
+        //-1 if not found
+        template <class eq_func>
+        int32_t remove(int32_t kv_pair_size, int32_t hash, const eq_func& compare) {
+            if (!hash_table_slots) {
+                return -1;
+            }
+
+            if (items_reserved > (hash_table_count + 2) * 4) {
+                compressItemTable(kv_pair_size);
+            }
+
+            // compress the hashtable if it's really empty
+            if (hash_table_count < hash_table_size / 8) {
+                resizeTable();
+            }
+
+            int32_t offset = hash % hash_table_size;
+
+            while (true) {
+                int32_t slot = hash_table_slots[offset];
+
+                if (slot == EMPTY) {
+                    // we never found the item
+                    return -1;
+                }
+
+                if (slot != DELETED && compare(items + kv_pair_size * slot)) {
+                    items_populated[slot] = 0;
+
+                    hash_table_slots[offset] = DELETED;
+                    hash_table_hashes[offset] = -1;
+                    hash_table_count -= 1;
+
+                    return slot;
+                }
+
+                offset = nextOffset(offset);
+            }
+        }
+
+        void compressItemTable(size_t kv_pair_size) {
+            std::vector<int32_t> newItemPositions;
+            int32_t count_so_far = 0;
+
+            for (long k = 0; k < items_reserved; k++) {
+                if (items_populated[k]) {
+                    newItemPositions.push_back(count_so_far);
+
+                    if (k != count_so_far) {
+                        items_populated[count_so_far] = 1;
+                        items_populated[k] = 0;
+
+                        memcpy(items + kv_pair_size * count_so_far, items + kv_pair_size * k,
+                               kv_pair_size);
+                    }
+
+                    count_so_far++;
+                } else {
+                    newItemPositions.push_back(-1);
+                }
+            }
+
+            items_reserved = count_so_far;
+            items_populated = (uint8_t*)realloc(items_populated, count_so_far);
+            items = (uint8_t*)realloc(items, count_so_far * kv_pair_size);
+            top_item_slot = items_reserved;
+
+            for (long k = 0; k < hash_table_size; k++) {
+                if (hash_table_slots[k] >= 0) {
+                    if (hash_table_slots[k] >= newItemPositions.size()) {
+                        throw std::runtime_error("corrupt slot");
+                    }
+
+                    hash_table_slots[k] = newItemPositions[hash_table_slots[k]];
+
+                    if (hash_table_slots[k] < 0) {
+                        throw std::runtime_error("invalid slot");
+                    }
+                }
+            }
+
+            for (long k = 0; k < hash_table_size; k++) {
+                if (hash_table_slots[k] >= 0) {
+                    if (hash_table_slots[k] >= items_reserved) {
+                        throw std::runtime_error("failed during compression");
+                    }
+                }
+            }
+        }
+
+        int32_t allocateNewSlot(size_t kv_pair_size) {
+            if (!items) {
+                items = (uint8_t*)malloc(4 * kv_pair_size);
+                items_populated = (uint8_t*)malloc(4);
+                items_reserved = 4;
+                top_item_slot = 0;
+                for (long k = 0; k < items_reserved; k++) {
+                    items_populated[k] = 0;
+                }
+            }
+
+            while (top_item_slot >= items_reserved) {
+                size_t old_reserved = items_reserved;
+                items_reserved = items_reserved * 1.25 + 1;
+                items = (uint8_t*)realloc(items, kv_pair_size * items_reserved);
+                items_populated = (uint8_t*)realloc(items_populated, items_reserved);
+
+                for (long k = old_reserved; k < items_reserved; k++) {
+                    items_populated[k] = 0;
+                }
+            }
+
+            return top_item_slot++;
+        }
+
+        int32_t computeNextPrime(int32_t p) {
+            static std::vector<int32_t> primes;
+            if (!primes.size()) {
+                primes.push_back(2);
+            }
+
+            auto isprime = [&](int32_t candidate) {
+                for (auto d : primes) {
+                    if (candidate % d == 0) {
+                        return false;
+                    }
+                    if (d * d > candidate) {
+                        return true;
+                    }
+                }
+                throw std::logic_error("Expected to clear the primes list.");
+            };
+
+            while (true) {
+                while (primes.back() * primes.back() < p) {
+                    int32_t cur = primes.back() + 1;
+                    while (!isprime(cur)) {
+                        cur++;
+                    }
+                    primes.push_back(cur);
+                }
+
+                if (isprime(p)) {
+                    return p;
+                }
+
+                p++;
+            }
+        }
+
+
+        void resizeTable() {
+            if (!hash_table_slots) {
+                hash_table_slots = (int32_t*)malloc(7 * sizeof(int32_t));
+                hash_table_hashes = (int32_t*)malloc(7 * sizeof(int32_t));
+                hash_table_size = 7;
+                hash_table_count = 0;
+                hash_table_empty_slots = hash_table_size;
+
+                for (long k = 0; k < hash_table_size; k++) {
+                    hash_table_slots[k] = EMPTY;
+                    hash_table_hashes[k] = -1;
+                }
+            } else {
+                int32_t oldSize = hash_table_size;
+                int32_t* oldSlots = hash_table_slots;
+                int32_t* oldHashes = hash_table_hashes;
+
+                // make sure the table's not too small
+                hash_table_size = computeNextPrime(hash_table_count * 4 + 7);
+
+                hash_table_slots = (int32_t*)malloc(hash_table_size * sizeof(int32_t));
+                hash_table_hashes = (int32_t*)malloc(hash_table_size * sizeof(int32_t));
+
+                for (long k = 0; k < hash_table_size; k++) {
+                    hash_table_slots[k] = EMPTY;
+                    hash_table_hashes[k] = -1;
+                }
+
+                hash_table_count = 0;
+                hash_table_empty_slots = hash_table_size;
+
+                for (long k = 0; k < oldSize; k++) {
+                    if (oldSlots[k] != EMPTY && oldSlots[k] != DELETED) {
+                        add(oldHashes[k], oldSlots[k]);
+                    }
+                }
+
+                free(oldSlots);
+                free(oldHashes);
+            }
+        }
+
+
+        void prepareForDeserialization(uint32_t slotCount, size_t kv_pair_size) {
+            if (hash_table_size) {
+                throw std::runtime_error(
+                  "deserialization prepare should only be called on empty tables");
+            }
+
+            items_reserved = slotCount;
+            items_populated = (uint8_t*)malloc(slotCount);
+            items = (uint8_t*)malloc(slotCount * kv_pair_size);
+
+            for (long k = 0; k < items_reserved; k++) {
+                items_populated[k] = true;
+            }
+
+            top_item_slot = items_reserved;
+        }
+
+        template <class hash_fun_type>
+        void buildHashTableAfterDeserialization(size_t kv_pair_size,
+                                                const hash_fun_type& hash_fun) {
+            hash_table_size = computeNextPrime(items_reserved * 2.5 + 7);
+            hash_table_slots = (int32_t*)malloc(hash_table_size * sizeof(int32_t));
+            hash_table_hashes = (int32_t*)malloc(hash_table_size * sizeof(int32_t));
+            hash_table_count = 0;
+            hash_table_empty_slots = hash_table_size;
+
+            for (long k = 0; k < hash_table_size; k++) {
+                hash_table_slots[k] = EMPTY;
+                hash_table_hashes[k] = -1;
+            }
+
+            for (long k = 0; k < items_reserved; k++) {
+                add(hash_fun(items + kv_pair_size * k), k);
+            }
+        }
+
+
+        void checkInvariants(std::string reason) {
+            int64_t popCount = 0;
+            for (long k = 0; k < items_reserved; k++) {
+                if (items_populated[k]) {
+                    popCount++;
+                    if (top_item_slot <= k) {
+                        throw std::runtime_error(
+                          reason + ": top item slot should be greater than all populated items");
+                    }
+                }
+            }
+
+            if (popCount != hash_table_count) {
+                throw std::runtime_error(
+                  reason + ": populated item count is not the same as the hashtable count");
+            }
+
+            int64_t filledSlots = 0;
+            int64_t deletedSlots = 0;
+            for (long k = 0; k < hash_table_size; k++) {
+                if (hash_table_slots[k] == DELETED) {
+                    deletedSlots++;
+                } else if (hash_table_slots[k] != EMPTY) {
+                    filledSlots++;
+
+                    if (hash_table_slots[k] >= items_reserved) {
+                        throw std::runtime_error(
+                          reason + ": hash table has slot entry out of bounds with item list");
+                    }
+
+                    if (!items_populated[hash_table_slots[k]]) {
+                        throw std::runtime_error(reason + ": hash table points to unmarked slot");
+                    }
+                }
+            }
+
+            if (filledSlots != hash_table_count) {
+                throw std::runtime_error(
+                  reason + ": Filled slot count is not the same as the hashtable's known count");
+            }
+
+            if (hash_table_size - filledSlots - deletedSlots != hash_table_empty_slots) {
+                throw std::runtime_error(reason + ": empty slot count is not consistent");
+            }
+        }
+
+        std::atomic<int64_t> refcount;
+
+        uint8_t* items; // packed set of key_value pairs.
+        uint8_t* items_populated; // array of bool for whether populated
+        size_t items_reserved; // count of items reserved
+        size_t top_item_slot; // index of the next item slot to use
+
+        int32_t*
+          hash_table_slots; // a hashtable. each actual object hash to the slot it holds. -1 if
+                            // not populated.
+        int32_t*
+          hash_table_hashes; // a hashtable. each actual object hash to the slot it holds. -1 if
+                             // not populated.
+        size_t hash_table_size; // size of the table
+        size_t hash_table_count; // populated count of the table
+        size_t hash_table_empty_slots; // slots that are not empty in the table
+    };
+
+    SetType(Type* eltype)
+        : Type(TypeCategory::catSet)
+        , m_key_type(eltype) {
+        endOfConstructorInitialization();
+    }
+
+    instance_ptr insertKey(instance_ptr self, instance_ptr key);
+    instance_ptr lookupKey(instance_ptr self, instance_ptr key) const;
+    bool discard(instance_ptr self, instance_ptr key);
+    void clear(instance_ptr self);
+    void constructor(instance_ptr self);
+    void destroy(instance_ptr self);
+    void copy_constructor(instance_ptr self, instance_ptr other);
+    void repr(instance_ptr self, ReprAccumulator& stream);
+    int64_t refcount(instance_ptr self) const;
+    bool _updateAfterForwardTypesChanged();
+    int64_t size(instance_ptr self) const;
+    bool cmp(instance_ptr left, instance_ptr right, int pyComparisonOp, bool suppressExceptions = false);
+    Type* keyType() const { return m_key_type; }
+
+    // layout accessors
+    int64_t slotCount(instance_ptr self) const;
+    bool slotPopulated(instance_ptr self, size_t offset) const;
+    instance_ptr keyAtSlot(instance_ptr self, size_t offset) const;
+
+  public:
+    static SetType* Make(Type* eltype);
+
+  private:
+    Type* m_key_type;
+    size_t m_bytes_per_el;
+};

--- a/typed_python/Type.hpp
+++ b/typed_python/Type.hpp
@@ -70,6 +70,7 @@ class Function;
 class BoundMethod;
 class Forward;
 class EmbeddedMessageType;
+class SetType;
 
 typedef uint8_t* instance_ptr;
 
@@ -116,7 +117,8 @@ public:
         catHeldClass = 29,
         catFunction = 30,
         catForward = 31,
-        catEmbeddedMessage = 32
+        catEmbeddedMessage = 32,
+        catSet = 33
     };
 
     TypeCategory getTypeCategory() const {
@@ -157,7 +159,7 @@ public:
     If 'suppressExceptions', then don't generate exceptions when comparing objects of unlike type. Sort their
     type names instead.
     */
-    bool cmp(instance_ptr left, instance_ptr right, int pyComparisonOp, bool suppressExceptions);
+    bool cmp(instance_ptr left, instance_ptr right, int pyComparisonOp, bool suppressExceptions = false);
 
     typed_python_hash_type hash(instance_ptr left);
 
@@ -232,6 +234,8 @@ public:
                 return f(*(NamedTuple*)this);
             case catTuple:
                 return f(*(Tuple*)this);
+            case catSet:
+                return f(*(SetType*)this);
             case catDict:
                 return f(*(DictType*)this);
             case catConstDict:

--- a/typed_python/__init__.py
+++ b/typed_python/__init__.py
@@ -23,7 +23,7 @@ from typed_python._types import (
     Forward, TupleOf, ListOf, Tuple, NamedTuple, OneOf, ConstDict,
     Alternative, Value, serialize, deserialize, serializeStream, deserializeStream,
     PointerTo, Dict, validateSerializedObject, validateSerializedObjectStream, decodeSerializedObject,
-    getOrSetTypeResolver
+    getOrSetTypeResolver, Set
 )
 import typed_python._types as _types
 

--- a/typed_python/all.cpp
+++ b/typed_python/all.cpp
@@ -39,7 +39,9 @@ compile the entire group all at once.
 #include "PyFunctionInstance.cpp"
 #include "PyBoundMethodInstance.cpp"
 #include "PyGilState.cpp"
+#include "PySetInstance.cpp"
 
+#include "SetType.cpp"
 #include "AlternativeType.cpp"
 #include "BytesType.cpp"
 #include "ClassType.cpp"


### PR DESCRIPTION
Extend typed_python by adding a `Set` data structure/type function.

## Motivation and Context
The typed_python `Set` type function constructs a c++ "Type" object  that models the type and then wraps it in a `PyTypeObject` and exposes it to python.

## Approach
At a high level, a new constant in `Type.hpp` was created to model the category of `Set`. Since the `Set` model type is  binary compatible with `Dict(T,None)`, the implementation approach was simply curated to reflect the difference. Since the key/value pairs are packed into a hashtable and None is a data structure with 0 bytes, the interface was mostly portable with the exception of unique interface behavior that was added that is unique to operating a traditional python `set()`.

## How Has This Been Tested?
There are relevant tests in `types_test.py` that walkthrough testing basic set functionality such as iteration, common interface calls, refcounting. 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.