### PR TITLE
Split Travis checks into different jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,30 +13,48 @@ env:
     - PYTHONPATH=$(pwd)
     - COVERAGE_PROCESS_START="$(pwd)/tox.ini"
 
+cache:
+  directories:
+    - $HOME/.cache/pip
+
 install:
   - pip install pipenv codecov
-  - pipenv install --dev --deploy
-  - sudo apt-get install -y gdb  # install gdb
-  - make testcert.cert
 
-before_script:
-  - ulimit -c unlimited -S       # enable core dumps
 
-after_failure:
-  - PYTHON_EXECUTABLE=$(python3 -c "import sys; print(sys.executable)")
-  - COREFILE=$(find . -maxdepth 1 -name "core*" | head -n 1) # find core file
-  - if [[ -f "$COREFILE" ]]; then
-        gdb -c "$COREFILE" $PYTHON_EXECUTABLE -ex "thread apply all bt" -ex "set pagination 0" -batch;
-    fi
+jobs:
+  include:
+    - stage: "Checks"
+      name: "Lint"
+      script:
+        - pipenv lock --dev --requirements > dev-reqs.txt
+        - cat dev-reqs.txt
+        - pip install -r dev-reqs.txt
+        - make lint
+    - name: "pipenv check"
+      script:
+        - pipenv check || (sleep 60; pipenv check) || (sleep 60; pipenv check)
+    - stage: "Tests"
+      name: "Unit Tests"
+      before_script:
+        - ulimit -c unlimited -S       # enable core dumps
+      script:
+        - pipenv lock --requirements > reqs.txt
+        - pip install -r reqs.txt
+        - sudo apt-get install -y gdb  # install gdb
+        - make testcert.cert
+        - coverage erase
+        - ./test.py -s
+        - ls -la
+        - coverage combine
+      after_success:
+        - codecov
+      after_failure:
+        - PYTHON_EXECUTABLE=$(python3 -c "import sys; print(sys.executable)")
+        - COREFILE=$(find . -maxdepth 1 -name "core*" | head -n 1) # find core file
+        - if [[ -f "$COREFILE" ]]; then
+              gdb -c "$COREFILE" $PYTHON_EXECUTABLE -ex "thread apply all bt" -ex "set pagination 0" -batch;
+          fi
 
-script:
-  - make lint
-  - pipenv check
-  - coverage erase
-  - coverage run ./test.py -s
-  - ls -la  # Allows us to visually inspect we produced a bunch of .coverage files
-  - coverage combine
-
-# Push the results back to codecov
-after_success:
-  - codecov
+stages:
+  - check
+  - test

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,18 +23,16 @@ install:
 
 jobs:
   include:
-    - stage: "Checks"
+    - stage: "Tests"
       name: "Lint"
       script:
         - pipenv lock --dev --requirements > dev-reqs.txt
-        - cat dev-reqs.txt
         - pip install -r dev-reqs.txt
         - make lint
     - name: "pipenv check"
       script:
         - pipenv check || (sleep 60; pipenv check) || (sleep 60; pipenv check)
-    - stage: "Tests"
-      name: "Unit Tests"
+    - name: "Unit Tests"
       before_script:
         - ulimit -c unlimited -S       # enable core dumps
       script:
@@ -54,7 +52,3 @@ jobs:
         - if [[ -f "$COREFILE" ]]; then
               gdb -c "$COREFILE" $PYTHON_EXECUTABLE -ex "thread apply all bt" -ex "set pagination 0" -batch;
           fi
-
-stages:
-  - check
-  - test


### PR DESCRIPTION
## Motivation and Context
We recently have been experiencing intermittent failures of the `pipenv check` check, presumably because of transient network problems. We want a mechanism to retry individual checks that fail rather than have to restart all tests. We also want to retry `pipenv check` a couple of times after a brief wait when it fails

## Approach
For the `pipenv check` retry we use bash OR (`pipenv check || (sleep 60; pipenv check)`)

In order to enable re-running individual failed tests, we update the TravisCI configuration and create a single tests "Stage" that has three named jobs: lint, pipenv check, and Unit Tests. 

## How Has This Been Tested?
- Tested on this branch that tests pass
- Tested on [`alex-multistage-travis-test`](https://github.com/APrioriInvestments/nativepython/commits/alex-multistage-travis-test) that when the lint job fails, there is a way to restart it without having to restart the other jobs

## Screenshots or console output (if appropriate)
- Failing lint (notice the three jobs):
![image](https://user-images.githubusercontent.com/1581907/61079244-6d230180-a3f0-11e9-9e67-fb893b6b1754.png)

- Chance to rerun just the lint job
![image](https://user-images.githubusercontent.com/1581907/61079311-90e64780-a3f0-11e9-9fdf-365218466ca9.png)
