### PR TITLE
Improve arithmetic operator consistency.  Refs #109.

### DIFF
--- a/nativepython/native_ast_to_llvm.py
+++ b/nativepython/native_ast_to_llvm.py
@@ -888,10 +888,16 @@ class FunctionConverter:
                     if operand.native_type.matches.Int:
                         return TypedLLVMValue(self.builder.neg(operand.llvm_value), operand.native_type)
                     if operand.native_type.matches.Float:
-                        return TypedLLVMValue(
-                            self.builder.fmul(operand.llvm_value, llvmlite.ir.DoubleType()(-1.0)),
-                            operand.native_type
-                        )
+                        if operand.native_type.bits == 32:
+                            return TypedLLVMValue(
+                                self.builder.fmul(operand.llvm_value, llvmlite.ir.FloatType()(-1.0)),
+                                operand.native_type
+                            )
+                        else:
+                            return TypedLLVMValue(
+                                self.builder.fmul(operand.llvm_value, llvmlite.ir.DoubleType()(-1.0)),
+                                operand.native_type
+                            )
 
             assert False, "can't apply unary operand %s to %s" % (expr.op, str(operand.native_type))
 

--- a/nativepython/python_object_representation.py
+++ b/nativepython/python_object_representation.py
@@ -42,6 +42,7 @@ from nativepython.type_wrappers.arithmetic_wrapper import IntWrapper, FloatWrapp
 from nativepython.type_wrappers.string_wrapper import StringWrapper
 from nativepython.type_wrappers.bytes_wrapper import BytesWrapper
 from nativepython.type_wrappers.python_object_of_type_wrapper import PythonObjectOfTypeWrapper
+from nativepython.type_wrappers.abs_wrapper import AbsWrapper
 from types import ModuleType
 from typed_python._types import TypeFor, bytecount
 from typed_python import (
@@ -145,6 +146,9 @@ def pythonObjectRepresentation(context, f):
 
     if f is hash:
         return TypedExpression(context, native_ast.nullExpr, HashWrapper(), False)
+
+    if f is abs:
+        return TypedExpression(context, native_ast.nullExpr, AbsWrapper(), False)
 
     if f is range:
         return TypedExpression(context, native_ast.nullExpr, _RangeWrapper, False)

--- a/nativepython/type_wrappers/abs_wrapper.py
+++ b/nativepython/type_wrappers/abs_wrapper.py
@@ -1,0 +1,34 @@
+#   Coyright 2017-2019 Nativepython Authors
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+from nativepython.type_wrappers.wrapper import Wrapper
+import nativepython.native_ast as native_ast
+
+
+class AbsWrapper(Wrapper):
+    is_pod = True
+    is_empty = False
+    is_pass_by_ref = False
+
+    def __init__(self):
+        super().__init__(len)
+
+    def getNativeLayoutType(self):
+        return native_ast.Type.Void()
+
+    def convert_call(self, context, expr, args, kwargs):
+        if len(args) == 1 and not kwargs:
+            return args[0].convert_abs()
+
+        return super().convert_call(context, expr, args, kwargs)

--- a/nativepython/type_wrappers/wrapper.py
+++ b/nativepython/type_wrappers/wrapper.py
@@ -182,6 +182,11 @@ class Wrapper(object):
             generateThrowException(context, TypeError("Can't hash instance of type '%s'" % (str(self),)))
         )
 
+    def convert_abs(self, context, expr):
+        return context.pushTerminal(
+            generateThrowException(context, TypeError("Can't take 'abs' of instance of type '%s'" % (str(self),)))
+        )
+
     def convert_unary_op(self, context, expr, op):
         return context.pushTerminal(
             generateThrowException(context, TypeError("Can't apply unary op %s to type '%s'" % (op, expr.expr_type)))

--- a/nativepython/typed_expression.py
+++ b/nativepython/typed_expression.py
@@ -133,6 +133,9 @@ class TypedExpression(object):
     def convert_hash(self):
         return self.expr_type.convert_hash(self.context, self)
 
+    def convert_abs(self):
+        return self.expr_type.convert_abs(self.context, self)
+
     def convert_reserved(self):
         return self.expr_type.convert_reserved(self.context, self)
 


### PR DESCRIPTION
## Motivation and Context
Goal in testing arithmetic operators is to compare operations on all types between native, interpreted (typed), and compiled calculations.

## Approach
## How Has This Been Tested?

Don't compare interpreted and compiled results if:
* the native result overflows the result type
* the interpreted result is signed and one of the unsigned arguments would overflow if converted to signed
* the native result would be enormous (e.g. >> or **)

Additionally, don't compare native and compiled if:
* one of the args is Float32 and the operation is % or //
* we are comparing Float32 with Float64 with a comparison operator

Also, when doing comparisons:
* treat inf, nan as exceptions
* if ** returns an int, convert to float
* if ** returns a complex number, treat as exception
* when comparing floats, allow an epsilon variation

Binary operators: + - * / % // < > <= >= != & | ^ << >> **
Unary operators: ~ - + abs()
Note that pow ** returns Float64 in all cases

<!-- Provide a general summary of your changes in the Title above -->

<!-- Why is this change required? -->
<!-- What problem does it solve? -->
<!--  If it fixes an open issue, please link to the issue here.-->

<!-- Describe your changes in reasonable detail -->

<!-- Describe in reasonable detail how you tested your changes. -->
<!-- If appropriate, include details of your testing environment, -->
<!-- tests ran to see how your change affects other areas of the code, etc. -->


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.