### PR TITLE
Add Dict::setdefault function

### DIFF
--- a/nativepython/tests/dict_compilation_test.py
+++ b/nativepython/tests/dict_compilation_test.py
@@ -110,6 +110,40 @@ class TestDictCompilation(unittest.TestCase):
 
         self.assertEqual(x, {i: i*i for i in range(1000)})
 
+    def test_dict_setdefault(self):
+        @SpecializedEntrypoint
+        def dict_setdefault(d, k, v):
+            return d.setdefault(k, v)
+
+        x = Dict(int, str)()
+        x[1] = "a"
+
+        # This should not change the dictionary, and return "a"
+        v1 = dict_setdefault(x, 1, "b")
+        self.assertEqual(v1, "a")
+        self.assertEqual(x, {1: "a"})
+
+        # This should set x[2]="b" and return "b"
+        v2 = dict_setdefault(x, 2, "b")
+        self.assertEqual(v2, "b")
+        self.assertEqual(x, {1: "a", 2: "b"})
+
+    def test_dict_with_different_types(self):
+        """Check if the dictionary with different types
+        supports proper key and type conversion.
+        """
+        @SpecializedEntrypoint
+        def dict_setvalue(d, k, v):
+            d[k] = v
+
+        x = Dict(int, str)()
+        x[1] = "a"
+        self.assertEqual(x, {1: "a"})
+
+        x = Dict(str, int)()
+        x["a"] = 1
+        self.assertEqual(x, {"a": 1})
+
     def test_dict_del(self):
         @SpecializedEntrypoint
         def dict_delitem(d, k):

--- a/typed_python/PyDictInstance.hpp
+++ b/typed_python/PyDictInstance.hpp
@@ -61,6 +61,18 @@ public:
     static void copyConstructFromPythonInstanceConcrete(DictType* dictType, instance_ptr tgt, PyObject* pyRepresentation, bool isExplicit);
 
     static bool compare_to_python_concrete(DictType* listT, instance_ptr self, PyObject* other, bool exact, int pyComparisonOp);
+
+    /**
+     * Function implementing python's dict::setdefault.
+     * 
+     * https://docs.python.org/3/library/stdtypes.html#dict.setdefault
+     * 
+     * setdefault(key[, default])
+     *      If key is in the dictionary, return its value. 
+     *      If not, insert key with a value of default and return default. default defaults to None.
+     * 
+     */
+    static PyObject* setDefault(PyObject* o, PyObject* args);
 };
 
 

--- a/typed_python/types_test.py
+++ b/typed_python/types_test.py
@@ -1908,6 +1908,57 @@ class NativeTypesTests(unittest.TestCase):
         with self.assertRaises(TypeError):
             self.assertEqual(d.get("1000"), None)
 
+    def test_mutable_dict_setdefault_bad_arguments(self):
+        d = Dict(int, str)()
+
+        with self.assertRaises(TypeError):
+            d.setdefault()
+
+        with self.assertRaises(TypeError):
+            d.setdefault(1, 2, 3)
+
+    def test_mutable_dict_setdefault(self):
+        d = Dict(int, str)()
+        d[1] = "a"
+
+        # check if this call doesn't change the dict
+        # and returns already existing value
+        v1 = d.setdefault(1, "b")
+        self.assertEqual(v1, "a")
+        self.assertEqual(d[1], "a")
+
+        # check if this call sets the d[2]="b"
+        # # and returns "b"
+        v2 = d.setdefault(2, "b")
+        self.assertEqual(v2, "b")
+        self.assertEqual(d[2], "b")
+
+        # it's not possible to convert None to String,
+        # so this should throw an exception
+        with self.assertRaisesRegex(TypeError, "Can't initialize a StringType from an instance of NoneType"):
+            v3 = d.setdefault(3)
+
+        with self.assertRaisesRegex(TypeError, "Can't initialize a StringType from an instance of NoneType"):
+            v3 = d.setdefault(3, None)
+
+    def test_mutable_dict_setdefault_refcount(self):
+        d = Dict(int, ListOf(int))()
+        aList = ListOf(int)([1, 2, 3])
+
+        self.assertEquals(_types.refcount(aList), 1)
+        d[1] = aList
+        self.assertEquals(_types.refcount(aList), 2)
+        d.setdefault(2, aList)
+        self.assertEquals(_types.refcount(aList), 3)
+        a = d.setdefault(2, aList)
+        self.assertEquals(_types.refcount(aList), 4)
+        a = None
+        self.assertEquals(_types.refcount(aList), 3)
+        d.setdefault(3, ListOf(int)([1]))
+        self.assertEquals(_types.refcount(aList), 3)
+        d.setdefault(3, aList)
+        self.assertEquals(_types.refcount(aList), 3)
+
     def test_mutable_dict_iteration_order(self):
         d = Dict(int, int)()
 

--- a/typed_python/types_test.py
+++ b/typed_python/types_test.py
@@ -1936,10 +1936,10 @@ class NativeTypesTests(unittest.TestCase):
         # it's not possible to convert None to String,
         # so this should throw an exception
         with self.assertRaisesRegex(TypeError, "Can't initialize a StringType from an instance of NoneType"):
-            v3 = d.setdefault(3)
+            d.setdefault(3)
 
         with self.assertRaisesRegex(TypeError, "Can't initialize a StringType from an instance of NoneType"):
-            v3 = d.setdefault(3, None)
+            d.setdefault(3, None)
 
     def test_mutable_dict_setdefault_refcount(self):
         d = Dict(int, ListOf(int))()
@@ -1952,6 +1952,7 @@ class NativeTypesTests(unittest.TestCase):
         self.assertEquals(_types.refcount(aList), 3)
         a = d.setdefault(2, aList)
         self.assertEquals(_types.refcount(aList), 4)
+        self.assertEquals(a, aList)
         a = None
         self.assertEquals(_types.refcount(aList), 3)
         d.setdefault(3, ListOf(int)([1]))


### PR DESCRIPTION
The setdefault function should work exactly the same as it does in python's dictionary.

Also, there is a fix to a dictionary bug: when storing a value in a dictionary, it was converted to the key type. If the conversion was not doable, there was an exception.

## Motivation and Context
<!-- Why is this change required? -->
<!-- What problem does it solve? -->
<!--  If it fixes an open issue, please link to the issue here.-->
Fixes the issue: #149

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.