### PR TITLE
Add missing AST nodes. Ref #159.

### DIFF
--- a/typed_python/python_ast_test.py
+++ b/typed_python/python_ast_test.py
@@ -122,3 +122,79 @@ class TestPythonAst(unittest.TestCase):
             from numpy import float64
             return float(float64(x))
         self.reverseParseAndEvalCheck(f, 10)
+
+    def test_parsing_fstring(self):
+        """
+        This code generates:
+            - ast.JoinedStr
+            - ast.FormattedValue
+        """
+        self.reverseParseCheck(lambda x: f" - {x} - ")
+
+    def test_parsing_assert(self):
+        """This code generates ast.Assert node."""
+        def f(x):
+            assert x == 1
+        self.reverseParseCheck(f)
+
+    def test_parsing_yield_from(self):
+        """This code generates ast.YieldFrom."""
+        def f(x):
+            yield from x
+        self.reverseParseCheck(f)
+
+    def test_parsing_async(self):
+        """This code generates:
+            - ast.AsyncFunctionDef
+            - ast.Await
+            - ast.AsyncWith
+        """
+        import asyncio
+
+        async def f(x, y):
+            print("Compute %s + %s ..." % (x, y))
+            await asyncio.sleep(1.0)
+            async for i in x:
+                print(i)
+            async with y:
+                pass
+            return x + y
+
+        self.reverseParseCheck(f)
+
+    def test_parsing_nonlocal(self):
+        """This code generates: ast.Nonlocal."""
+        def f():
+            x = "local"
+
+            def inner():
+                nonlocal x
+                x = "nonlocal"
+                print("inner:", x)
+
+            inner()
+            print("outer:", x)
+
+        self.reverseParseCheck(f)
+
+    def test_parsing_matmul(self):
+        """This code generates: ast.MatMult."""
+        def f(a, b):
+            a @ b
+            a @= b
+
+        self.reverseParseCheck(f)
+
+    def test_parsing_annotated_assignment(self):
+        """This code generates: ast.AddAssign."""
+        def f():
+            a: int = 2
+            return a
+
+        self.reverseParseCheck(f)
+
+    def test_parsing_bytes(self):
+        def f():
+            return b"aaa"
+
+        self.reverseParseCheck(f)


### PR DESCRIPTION
This PR adds support for all the AST nodes from Python 3.6.

## Motivation and Context
We should support all the AST nodes for from the Python 3.6 documentation. Now we should have all of them, at least for parsing.

## How Has This Been Tested?
There are tests for generating all the new nodes, except for the Constant one.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.