### PR TITLE
Initial Cell Styling Removal / Cleanup

### DIFF
--- a/object_database/web/ActiveWebService.py
+++ b/object_database/web/ActiveWebService.py
@@ -30,7 +30,8 @@ from object_database import ServiceBase, service_schema
 from object_database.web.AuthPlugin import AuthPluginBase, LdapAuthPlugin
 from object_database.web.LoginPlugin import LoginIpPlugin
 from object_database.web.ActiveWebService_util import (
-    Configuration, LoginPlugin, mainBar,
+    Configuration, LoginPlugin,
+    makeMainView,
     displayAndHeadersForPathAndQueryArgs,
     writeJsonMessage,
     readThread
@@ -281,8 +282,8 @@ class ActiveWebService(ServiceBase):
 
     def displayForPathAndQueryArgs(self, path, queryArgs):
         display, toggles = displayAndHeadersForPathAndQueryArgs(path, queryArgs)
-        return mainBar(display, toggles, current_user.username,
-                       self.authorized_groups_text)
+        return makeMainView(display, toggles, current_user.username,
+                            self.authorized_groups_text)
 
     @login_required
     def mainSocket(self, ws, path):

--- a/object_database/web/ActiveWebService_util.py
+++ b/object_database/web/ActiveWebService_util.py
@@ -20,7 +20,7 @@ from object_database.web.ActiveWebServiceSchema import active_webservice_schema
 from object_database.web.cells import (
     Main, Subscribed, Sequence, Traceback, Span, Button, Octicon,
     Padding, Tabs, Table, Clickable, Dropdown, Popover, HeaderBar,
-    LargePendingDownloadDisplay
+    LargePendingDownloadDisplay, PageView
 )
 
 from object_database.web.AuthPlugin import AuthPluginBase
@@ -56,20 +56,20 @@ def view():
     buttons = Sequence([
         Padding(),
         Button(
-            Sequence([Octicon('shield').color('green'), Span('Lock ALL')]),
+            Sequence([Octicon('shield', color='green'), Span('Lock ALL')]),
             lambda: [s.lock() for s in service_schema.Service.lookupAll()]),
         Button(
-            Sequence([Octicon('shield').color('orange'), Span('Prepare ALL')]),
+            Sequence([Octicon('shield', color='orange'), Span('Prepare ALL')]),
             lambda: [s.prepare() for s in service_schema.Service.lookupAll()]),
         Button(
-            Sequence([Octicon('stop').color('red'), Span('Unlock ALL')]),
+            Sequence([Octicon('stop', color='red'), Span('Unlock ALL')]),
             lambda: [s.unlock() for s in service_schema.Service.lookupAll()]),
-    ])
+    ], split="vertical")
     tabs = Tabs(
         Services=servicesTable(),
         Hosts=hostsTable()
     )
-    return Sequence([buttons, tabs])
+    return Sequence([buttons, tabs], split="horizontal")
 
 
 def hostsTable():
@@ -163,19 +163,22 @@ def servicesTableDataPrep(s, field, serviceCounts):
         data = (
             Clickable(
                 Sequence(
-                    [Octicon('stop').color('red'), Span('Unlocked')]
+                    [Octicon('stop', color='red'), Span('Unlocked')],
+                    split="vertical"
                 ),
                 lambda: s.lock()
             ) if s.isUnlocked else
             Clickable(
                 Sequence(
-                    [Octicon('shield').color('green'), Span('Locked')]
+                    [Octicon('shield', color='green'), Span('Locked')],
+                    split="vertical"
                 ),
                 lambda: s.prepare()
             ) if s.isLocked else
             Clickable(
                 Sequence(
-                    [Octicon('shield').color('orange'), Span('Prepared')]
+                    [Octicon('shield', color='orange'), Span('Prepared')],
+                    split="vertical"
                 ), lambda: s.unlock()
             )
         )
@@ -215,38 +218,81 @@ def servicesTableDataPrep(s, field, serviceCounts):
     return data
 
 
-def mainBar(display, toggles, current_username, authorized_groups_text):
-    """Main header bar.
+def makeServiceDropdown(services):
+    """Creates a dropdown menu of available
+    services.
 
-    Parameters:
-    -----------
-    display: serviceDisplay object
-    togges: list of servicesToggles
-    current_username : text
-    authorized_groups_text: text
+    Parameters
+    ----------
+    services ServiceSchema - A collection of services
+
+    Returns
+    -------
+    A Subscribed Cell whose lambda returns
+    a dropdown of service items
     """
+    return [
+        Subscribed(
+            lambda: Dropdown(
+                "Service",
+                [("All", "/services")] +
+                [(s.name, "/services/" + s.name)
+                 for s in sorted(services.Service.lookupAll(),
+                                 key=lambda s:s.name)]
+            ),
+        )
+    ]
 
-    return (
-        HeaderBar(
-            [
-                Subscribed(
-                    lambda: Dropdown(
-                        "Service",
-                        [("All", "/services")] +
-                        [(s.name, "/services/" + s.name)
-                         for s in sorted(service_schema.Service.lookupAll(),
-                                         key=lambda s:s.name)]
-                    ),
-                )
-            ],
-            toggles,
-            [
-                LargePendingDownloadDisplay(),
-                Octicon('person') + Span(current_username),
-                Span('Authorized Groups: {}'.format(authorized_groups_text)),
-                Button(Octicon('sign-out'), '/logout')
-            ]) +
-        Main(display)
+
+def makeMainHeader(toggles, current_username, authorized_groups_text):
+    """Creates the main view's header
+
+    Parameters
+    ----------
+    toggles - A list of serviceToggles
+    current_username str - The name of the current
+              user for display
+    authorized_groups_text str - Text to display
+              about the user's authorized groups
+
+    Returns
+    -------
+    A HeaderBar Cell configured as the main view's header
+    """
+    serviceDropdown = makeServiceDropdown(service_schema)
+    return HeaderBar(
+        serviceDropdown,
+        toggles,
+        [
+            LargePendingDownloadDisplay(),
+            Octicon('person') + Span(current_username),
+            Span('Authorized Groups: {}'.format(authorized_groups_text)),
+            Button(Octicon('sign-out'), '/logout')
+        ]
+    )
+
+
+def makeMainView(display, toggles, current_username, authorized_groups_text):
+    """Creates a PageView configured as the
+    application's primary view with header etc.
+
+    Parameters
+    ----------
+    display Cell - The content Cell that will be displayed in the
+            Main display area of the view
+    toggles list - A list of serviceToggles
+    current_username str - The current user's name
+    authorized_groups_text str - Text about auth groups for user
+
+    Returns
+    -------
+    A configured PageView Cell for use as the application's
+    primary view container, with configured header
+    """
+    header = makeMainHeader(toggles, current_username, authorized_groups_text)
+    return PageView(
+        Main(display),
+        header=header
     )
 
 

--- a/object_database/web/CellsTestService.py
+++ b/object_database/web/CellsTestService.py
@@ -103,7 +103,7 @@ class CellsTestService(ServiceBase):
         else:
             page = None
             description = ""
-            ed = cells.Card("pick something").height(inputAreaHeight)
+            ed = cells.Card("pick something").height("100%")
 
             def actualDisplay():
                 return cells.Text("nothing to display")
@@ -118,7 +118,7 @@ class CellsTestService(ServiceBase):
 
         inputArea = cells.Card(
             cells.SplitView(
-                [(selectionPanel(page, inputAreaHeight), 1), (ed, 6)]
+                [(selectionPanel(page, inputAreaHeight), 1), (ed, 8)]
             ), padding=2
         ).height(inputAreaHeight)
 
@@ -147,7 +147,8 @@ def selectionPanel(page, height):
                 dict(category=x.category(), name=x.name())),
             makeBold=x is page)
             for perCategory in getPages().values()
-            for x in perCategory.values()]
+            for x in perCategory.values()],
+        split="horizontal"
     )
     return cells.Card(
         cells.SplitView([

--- a/object_database/web/cells/__init__.py
+++ b/object_database/web/cells/__init__.py
@@ -62,6 +62,8 @@ from object_database.web.cells.cells import (
 
 from object_database.web.cells.views.split_view import SplitView
 
+from object_database.web.cells.views.page_view import PageView
+
 from .non_display.key_action import KeyAction
 
 from object_database.web.cells.CellsTestMixin import CellsTestMixin

--- a/object_database/web/cells/cells.py
+++ b/object_database/web/cells/cells.py
@@ -903,7 +903,6 @@ class Card(Cell):
             self.children['____header__'] = headerCell
             self.namedChildren['header'] = headerCell
 
-        self.exportData['divStyle'] = self._divStyle()
         self.exportData['padding'] = self.padding
 
     def sortsAs(self):
@@ -959,9 +958,10 @@ class Modal(Cell):
 
 
 class Octicon(Cell):
-    def __init__(self, which):
+    def __init__(self, which, color='black'):
         super().__init__()
         self.whichOcticon = which
+        self.color = color
 
     def sortsAs(self):
         return self.whichOcticon
@@ -969,7 +969,7 @@ class Octicon(Cell):
     def recalculate(self):
         octiconClasses = ['octicon', ('octicon-%s' % self.whichOcticon)]
         self.exportData['octiconClasses'] = octiconClasses
-        self.exportData['divStyle'] = self._divStyle()
+        self.exportData['color'] = self.color
 
 
 class Badge(Cell):
@@ -1000,7 +1000,6 @@ class CollapsiblePanel(Cell):
     def recalculate(self):
         expanded = self.evaluateWithDependencies(self.isExpanded)
         self.exportData['isExpanded'] = expanded
-        self.exportData['divStyle'] = self._divStyle()
         self.children = {
             '____content__': self.content
         }
@@ -1011,10 +1010,11 @@ class CollapsiblePanel(Cell):
 
 
 class Text(Cell):
-    def __init__(self, text, sortAs=None):
+    def __init__(self, text, text_color='black', sortAs=None):
         super().__init__()
         self.text = text
         self._sortAs = sortAs if sortAs is not None else text
+        self.text_color = text_color
 
     def sortsAs(self):
         return self._sortAs
@@ -1023,7 +1023,7 @@ class Text(Cell):
         escapedText = cgi.escape(str(self.text)) if self.text else " "
         self.exportData['escapedText'] = escapedText
         self.exportData['rawText'] = self.text
-        self.exportData['divStyle'] = self._divStyle()
+        self.exportData['text_color'] = self.text_color
 
 
 class Padding(Cell):
@@ -1044,7 +1044,19 @@ class Span(Cell):
 
 
 class Sequence(Cell):
-    def __init__(self, elements):
+    def __init__(self, elements, split="horizontal", overflow=True):
+        """
+        Parameters:
+        -----------
+        elements: list of cells
+        split: str
+            The split axis of the  view. Can
+            be either 'horizontal' or 'vertical'. Defaults
+            to 'vertical'.
+        overflow: bool
+            Sets overflow-auto on the div.
+
+        """
         super().__init__()
         elements = [Cell.makeCell(x) for x in elements]
 
@@ -1052,6 +1064,8 @@ class Sequence(Cell):
         self.namedChildren['elements'] = elements
         self.children = {"____c_%s__" %
                          i: elements[i] for i in range(len(elements))}
+        self.split = split
+        self.overflow = overflow
 
     def __add__(self, other):
         other = Cell.makeCell(other)
@@ -1062,7 +1076,8 @@ class Sequence(Cell):
 
     def recalculate(self):
         self.namedChildren['elements'] = self.elements
-        self.exportData['divStyle'] = self._divStyle()
+        self.exportData['split'] = self.split
+        self.exportData['overflow'] = self.overflow
 
     def sortsAs(self):
         if self.elements:
@@ -1074,7 +1089,6 @@ class Columns(Cell):
     def __init__(self, *elements):
         super().__init__()
         elements = [Cell.makeCell(x) for x in elements]
-        self.exportData['divStyle'] = self._divStyle()
 
         self.elements = elements
         self.children = {"____c_%s__" %
@@ -1534,9 +1548,6 @@ class Subscribed(Cell):
 
             self._resetSubscriptionsToViewReads(v)
 
-            # temporary js WS refactoring data
-            self.exportData['divStyle'] = self._divStyle()
-
 
 class SubscribedSequence(Cell):
     # TODO: Get a better idea of what is actually happening
@@ -1609,9 +1620,6 @@ class SubscribedSequence(Cell):
         for i in list(self.existingItems):
             if i not in spineAsSet:
                 del self.existingItems[i]
-
-        # temporary js WS refactoring data
-        self.exportData['divStyle'] = self._divStyle()
         self.exportData['asColumns'] = self.asColumns
         self.exportData['numSpineChildren'] = len(self.spine)
 
@@ -1639,7 +1647,6 @@ class Popover(Cell):
         }
 
     def recalculate(self):
-        self.exportData['divStyle'] = self._divStyle()
         self.exportData['width'] = self.width
 
     def sortsAs(self):
@@ -2063,7 +2070,7 @@ class Table(Cell):
             self.namedChildren['page'] = pageCell
         if self.curPage.get() == "1":
             leftCell = Octicon(
-                "triangle-left").nowrap().color("lightgray")
+                "triangle-left", color="lightgray").nowrap()
             self.children['____left__'] = leftCell
             self.namedChildren['left'] = leftCell
         else:
@@ -2077,7 +2084,7 @@ class Table(Cell):
             self.namedChildren['left'] = leftCell
         if self.curPage.get() == str(totalPages):
             rightCell = Octicon(
-                "triangle-right").nowrap().color("lightgray")
+                "triangle-right", color="lightgray").nowrap()
             self.children['____right__'] = rightCell
             self.namedChildren['right'] = rightCell
         else:
@@ -2240,8 +2247,6 @@ class Expands(Cell):
             'icon': self.openedIcon if self.isExpanded else self.closedIcon
         }
 
-        self.exportData['divStyle'] = self._divStyle()
-
         # TODO: Refactor this. We shouldn't need to send
         # an inline script!
         self.exportData['events'] = {"onclick": inlineScript}
@@ -2313,7 +2318,6 @@ class CodeEditor(Cell):
         self.children = {}  # Is there ever any children for this Cell type?
 
         # temporary js WS refactoring data
-        self.exportData['divStyle'] = self._divStyle()
         self.exportData['initialText'] = self.initialText
         self.exportData['autocomplete'] = self.autocomplete
         self.exportData['noScroll'] = self.noScroll
@@ -2414,7 +2418,6 @@ class Sheet(Cell):
         # Should now be implemented completely
         # in the JS side component.
 
-        self.exportData['divStyle'] = self._divStyle()
         self.exportData['columnNames'] = [x for x in self.columnNames]
         self.exportData['rowCount'] = self.rowCount
         self.exportData['columnWidth'] = self.colWidth
@@ -2473,7 +2476,6 @@ class Plot(Cell):
         self.namedDataSubscriptions = namedDataSubscriptions
         self.curXYRanges = xySlot or Slot(None)
         self.error = Slot(None)
-        self.exportData['divStyle'] = self._divStyle()
 
     def recalculate(self):
         chartUpdaterCell = Subscribed(lambda: _PlotUpdater(self))

--- a/object_database/web/cells/views/page_view.py
+++ b/object_database/web/cells/views/page_view.py
@@ -1,0 +1,39 @@
+#   Copyright 2017-2019 Nativepython Authors
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+"""PageView Cell
+
+This cell is a view that fills the entire page with optional
+header and footer areas and a responsive middle main content
+area.
+"""
+from ..cells import Cell
+
+
+class PageView(Cell):
+    def __init__(self, main, header=None, footer=None):
+        super().__init__()
+        self.main = main
+        self.header = header
+        self.footer = footer
+        self.updateChildren()
+
+    def updateChildren(self):
+        self.children['____main__'] = self.main
+        self.namedChildren['main'] = self.main
+        if self.header:
+            self.children['____header__'] = self.header
+            self.namedChildren['header'] = self.header
+        if self.footer:
+            self.children['____footer__'] = self.footer
+            self.namedChildren['footer'] = self.footer

--- a/object_database/web/cells_demo/octicon.py
+++ b/object_database/web/cells_demo/octicon.py
@@ -1,0 +1,36 @@
+#   Coyright 2017-2019 Nativepython Authors
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+from object_database.web import cells as cells
+from object_database.web.CellsTestPage import CellsTestPage
+
+
+class BasicOcticon(CellsTestPage):
+    def cell(self):
+        return cells.Octicon('shield', color='green')
+
+    def text(self):
+        return "You should see a single octicon."
+
+
+class MultiOcticon(CellsTestPage):
+    def cell(self):
+        return cells.Sequence([
+            cells.Octicon('shield', color='green'),
+            cells.Octicon('stop', color='red'),
+            cells.Octicon('alert', color='yellow')
+        ], split="vertical")
+
+    def text(self):
+        return "You should see a single octicon."

--- a/object_database/web/cells_demo/sequence.py
+++ b/object_database/web/cells_demo/sequence.py
@@ -1,0 +1,39 @@
+#   Coyright 2017-2019 Nativepython Authors
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+from object_database.web import cells as cells
+from object_database.web.CellsTestPage import CellsTestPage
+
+
+class VerticalSplitSequence(CellsTestPage):
+    def cell(self):
+        return cells.Sequence(
+            [cells.Text("item 1", text_color="red"),
+             cells.Text("item 2", text_color="blue")]
+        )
+
+    def text(self):
+        return "You should see a vertically split sequence of text."
+
+
+class HorizontalSplitSequence(CellsTestPage):
+    def cell(self):
+        return cells.Sequence(
+            [cells.Text("item 1", text_color="red"),
+             cells.Text("item 2", text_color="blue")],
+            split="horizontal"
+        )
+
+    def text(self):
+        return "You should see a horizontally split sequence of text."

--- a/object_database/web/cells_demo/text.py
+++ b/object_database/web/cells_demo/text.py
@@ -1,0 +1,33 @@
+#   Coyright 2017-2019 Nativepython Authors
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+from object_database.web import cells as cells
+from object_database.web.CellsTestPage import CellsTestPage
+
+
+class BasicText(CellsTestPage):
+    def cell(self):
+        return cells.Text("This is some text")
+
+    def text(self):
+        return "You should see some text."
+
+
+class EmbeddedColoredText(CellsTestPage):
+    def cell(self):
+        return cells.Card(cells.Text("This is some text", text_color="blue"),
+                          padding=0)
+
+    def text(self):
+        return "You should see some colored text in a Card."

--- a/object_database/web/content/CellHandler.js
+++ b/object_database/web/content/CellHandler.js
@@ -261,7 +261,7 @@ class CellHandler {
         this.cells[message.id] = velement;
 
         // Now wire in replacements
-        this._installReplacements(replacements);
+        this._installReplacements(replacements, message);
 
         if(message.postscript !== undefined){
             this.postscripts.push(message.postscript);
@@ -290,7 +290,7 @@ class CellHandler {
     /**
      * Helper function that install all the replacements into the DOM
      */
-    _installReplacements(replacements) {
+    _installReplacements(replacements, message) {
         Object.keys(replacements).forEach((replacementKey, idx) => {
             let target = document.getElementById(replacementKey);
             let source = null;

--- a/object_database/web/content/ComponentRegistry.js
+++ b/object_database/web/content/ComponentRegistry.js
@@ -49,6 +49,7 @@ import {Plot} from './components/Plot';
 import {_PlotUpdater} from './components/_PlotUpdater';
 import {Timestamp} from './components/Timestamp';
 import {SplitView} from './components/SplitView';
+import {PageView} from './components/PageView';
 
 const ComponentRegistry = {
     AsyncDropdown,
@@ -76,6 +77,7 @@ const ComponentRegistry = {
     Modal,
     Octicon,
     Padding,
+    PageView,
     Popover,
     ResizablePanel,
     RootCell,

--- a/object_database/web/content/app.css
+++ b/object_database/web/content/app.css
@@ -97,4 +97,23 @@
     background-color: rgba(50, 50, 50, 0.5);
     transition: background-color 0.2s linear;
     z-index: 1050;
+
+/* PageView
+ *================================================================*/
+.page-view {
+    display: flex;
+    flex-direction: column;
+    min-height: 100vh;
+    width: 100%;
+}
+
+.page-view > main {
+    flex-grow: 1
+}
+
+.page-view-header {
+
+}
+
+.page-view-footer {
 }

--- a/object_database/web/content/components/Card.js
+++ b/object_database/web/content/components/Card.js
@@ -46,7 +46,6 @@ class Card extends Component {
         return h('div',
             {
                 class: "cell card",
-                style: this.props.divStyle,
                 id: this.props.id,
                 "data-cell-id": this.props.id,
                 "data-cell-type": "Card"
@@ -77,10 +76,6 @@ Card.propTypes = {
     padding: {
         description: "Padding weight as defined by Boostrap css classes.",
         type: PropTypes.oneOf([PropTypes.number, PropTypes.string])
-    },
-    divStyle: {
-        description: "HTML style attribute string.",
-        type: PropTypes.oneOf([PropTypes.string])
     }
 };
 

--- a/object_database/web/content/components/CodeEditor.js
+++ b/object_database/web/content/components/CodeEditor.js
@@ -11,7 +11,7 @@ class CodeEditor extends Component {
         this.editor = null;
         // used to schedule regular server updates
         this.SERVER_UPDATE_DELAY_MS = 1;
-        this.editorStyle = 'width:100%;height:100%;margin:auto;border:1px solid lightgray;';
+        this.editorStyle = 'width:100%;min-height:100%;margin:auto;border:1px solid lightgray;';
 
         this.setupEditor = this.setupEditor.bind(this);
         this.setupKeybindings = this.setupKeybindings.bind(this);
@@ -65,11 +65,10 @@ class CodeEditor extends Component {
     render(){
         return h('div',
             {
-                class: "cell",
-                style: this.props.extraData.divStyle,
+                class: "cell h-100",
                 id: this.props.id,
                 "data-cell-id": this.props.id,
-                "data-cell-type": "CodeEditor"
+                "data-cell-type": "CodeEditor",
             },
             [h('div', { id: "editor" + this.props.id, style: this.editorStyle }, [])
         ]);

--- a/object_database/web/content/components/CollapsiblePanel.js
+++ b/object_database/web/content/components/CollapsiblePanel.js
@@ -34,18 +34,17 @@ class CollapsiblePanel extends Component {
         if(this.props.extraData.isExpanded){
             return(
                 h('div', {
-                    class: "cell container-fluid",
+                    class: "cell d-flex",
                     "data-cell-id": this.props.id,
                     "data-cell-type": "CollapsiblePanel",
                     "data-expanded": true,
                     id: this.props.id,
-                    style: this.props.extraData.divStyle
                 }, [
                     h('div', {class: "row flex-nowrap no-gutters"}, [
-                        h('div', {class: "col-md-auto"},[
+                        h('div', {class: "col-md-auto", style: "flex-grow:1"},[
                             this.makePanel()
                         ]),
-                        h('div', {class: "col-sm"}, [
+                        h('div', {class: "col-sm", style: "flex-grow:5"}, [
                             this.makeContent()
                         ])
                     ])
@@ -59,7 +58,6 @@ class CollapsiblePanel extends Component {
                     "data-cell-type": "CollapsiblePanel",
                     "data-expanded": false,
                     id: this.props.id,
-                    style: this.props.extraData.divStyle
                 }, [this.makeContent()])
             );
         }

--- a/object_database/web/content/components/Columns.js
+++ b/object_database/web/content/components/Columns.js
@@ -33,7 +33,6 @@ class Columns extends Component {
                 id: this.props.id,
                 "data-cell-id": this.props.id,
                 "data-cell-type": "Columns",
-                style: this.props.extraData.divStyle
             }, [
                 h('div', {class: "row flex-nowrap"}, this.makeInnerChildren())
             ])

--- a/object_database/web/content/components/Expands.js
+++ b/object_database/web/content/components/Expands.js
@@ -48,7 +48,6 @@ class Expands extends Component {
                 id: this.props.id,
                 "data-cell-id": this.props.id,
                 "data-cell-type": "Expands",
-                style: this.props.extraData.divStyle
             },
                 [
                     h('div', {

--- a/object_database/web/content/components/Octicon.js
+++ b/object_database/web/content/components/Octicon.js
@@ -3,11 +3,16 @@
  */
 
 import {Component} from './Component';
+import {PropTypes} from './util/PropertyValidator';
 import {h} from 'maquette';
 
 class Octicon extends Component {
     constructor(props, ...args){
         super(props, ...args);
+        this.style = ""
+        if (this.props.color !== null) {
+            this.style = "color:" + this.props.color
+        }
 
         // Bind context to methods
         this._getHTMLClasses = this._getHTMLClasses.bind(this);
@@ -21,18 +26,30 @@ class Octicon extends Component {
                 "data-cell-id": this.props.id,
                 "data-cell-type": "Octicon",
                 "aria-hidden": true,
-                style: this.props.extraData.divStyle
+                style: this.style
             })
         );
     }
 
     _getHTMLClasses(){
         let classes = ["cell", "octicon"];
-        this.props.extraData.octiconClasses.forEach(name => {
+        this.props.octiconClasses.forEach(name => {
             classes.push(name);
         });
         return classes.join(" ");
     }
 }
+
+Octicon.propTypes = {
+    octiconClasses: {
+        description: "Octicon css classes, such as 'shield,' 'alert' etc.",
+        type: PropTypes.oneOf([PropTypes.object])
+    },
+    color: {
+        description: "Color of the Octicon",
+        type: PropTypes.oneOf([PropTypes.string])
+    }
+};
+
 
 export {Octicon, Octicon as default};

--- a/object_database/web/content/components/PageView.js
+++ b/object_database/web/content/components/PageView.js
@@ -1,0 +1,93 @@
+/**
+ * PageView Cell Component
+ * Used for dividing up main views,
+ * with optional header and footer.
+ */
+import {Component} from './Component';
+import {h} from 'maquette';
+
+/**
+ * About Replacements
+ * ------------------
+ * This component has three regular
+ * replacements:
+ * * `header`
+ * * `main`
+ * * `footer`
+ */
+
+/**
+ * About Named Children
+ * `header` - An optional header cell
+ * `main` - A required main content cell
+ * `footer` - An optional footer cell
+ */
+class PageView extends Component {
+    constructor(props, ...args){
+        super(props, ...args);
+
+        // Bind component methods
+        this.makeHeader = this.makeHeader.bind(this);
+        this.makeMain = this.makeMain.bind(this);
+        this.makeFooter = this.makeFooter.bind(this);
+    }
+
+    render(){
+        return h('div', {
+            id: this.props.id,
+            'data-cell-id': this.props.id,
+            'data-cell-type': "PageView",
+            class: 'cell page-view'
+        }, [
+            this.makeHeader(),
+            this.makeMain(),
+            this.makeFooter()
+        ]);
+    }
+
+    makeHeader(){
+        let headerContent = null;
+        if(this.usesReplacements){
+            headerContent = this.getReplacementElementFor('header');
+        } else {
+            headerContent = this.renderChildNamed('header');
+        }
+        if(headerContent){
+            return h('header', {
+                class: 'page-view-header'
+            }, [headerContent]);
+        } else {
+            return null;
+        }
+    }
+
+    makeMain(){
+        let mainContent;
+        if(this.usesReplacements){
+            mainContent = this.getReplacementElementFor('main');
+        } else {
+            mainContent = this.renderChildNamed('main');
+        }
+        return h('main', {
+            class: 'page-view-main'
+        }, [mainContent]);
+    }
+
+    makeFooter(){
+        let footerContent = null;
+        if(this.usesReplacements){
+            footerContent = this.getReplacementElementFor('footer');
+        } else {
+            footerContent = this.renderChildNamed('footer');
+        }
+        if(footerContent){
+            return h('footer', {
+                class: 'page-view-footer'
+            }, [footerContent]);
+        } else {
+            return null;
+        }
+    }
+}
+
+export {PageView, PageView as default};

--- a/object_database/web/content/components/Plot.js
+++ b/object_database/web/content/components/Plot.js
@@ -42,7 +42,7 @@ class Plot extends Component {
                 "data-cell-type": "Plot",
                 class: "cell"
             }, [
-                h('div', {id: `plot${this.props.id}`, style: this.props.extraData.divStyle}),
+                h('div', {id: `plot${this.props.id}`}),
                 this.makeChartUpdater(),
                 this.makeError()
             ])

--- a/object_database/web/content/components/Popover.js
+++ b/object_database/web/content/components/Popover.js
@@ -35,7 +35,6 @@ class Popover extends Component {
         return h('div',
             {
                 class: "cell popover-cell",
-                style: this.props.extraData.divStyle,
                 id: this.props.id,
                 "data-cell-id": this.props.id,
                 "data-cell-type": "Popover"

--- a/object_database/web/content/components/Sequence.js
+++ b/object_database/web/content/components/Sequence.js
@@ -3,6 +3,7 @@
  */
 
 import {Component} from './Component';
+import {PropTypes} from './util/PropertyValidator';
 import {h} from 'maquette';
 
 /**
@@ -24,6 +25,7 @@ class Sequence extends Component {
         super(props, ...args);
 
         // Bind component methods
+        this.makeStyle = this.makeStyle.bind(this);
         this.makeElements = this.makeElements.bind(this);
     }
 
@@ -34,7 +36,7 @@ class Sequence extends Component {
                 class: "cell",
                 "data-cell-id": this.props.id,
                 "data-cell-type": "Sequence",
-                style: this.props.extraData.divStyle
+                style: this.makeStyle()
             }, this.makeElements())
         );
     }
@@ -46,6 +48,30 @@ class Sequence extends Component {
             return this.renderChildrenNamed('elements');
         }
     }
+
+    makeStyle(){
+        // Note: the server side uses "split" (axis) to denote the direction
+        let direction = "row";
+        if (this.props.split == "horizontal"){
+            direction = "column";
+        }
+        let overflow = ""
+        if (this.props.overflow) {
+            overflow = "overflow:auto"
+        }
+        return `width:100%;height:100%;display:inline-flex;flex-direction:${direction};${overflow}`;
+    }
 }
+
+Sequence.propTypes = {
+    split: {
+        description: "Horizontal/vertical layout of the children.",
+        type: PropTypes.oneOf([PropTypes.string])
+    },
+    overflow: {
+        description: "Overflow-auto.",
+        type: PropTypes.oneOf([PropTypes.boolean])
+    }
+};
 
 export {Sequence, Sequence as default};

--- a/object_database/web/content/components/Sheet.js
+++ b/object_database/web/content/components/Sheet.js
@@ -65,7 +65,6 @@ class Sheet extends Component {
             }, [
                 h('div', {
                     id: `sheet${this.props.id}`,
-                    style: this.props.extraData.divStyle,
                     class: "handsontable"
                 }, [this.makeError()])
             ])

--- a/object_database/web/content/components/Subscribed.js
+++ b/object_database/web/content/components/Subscribed.js
@@ -30,7 +30,6 @@ class Subscribed extends Component {
         return h('div',
             {
                 class: "cell subscribed",
-                style: this.props.extraData.divStyle,
                 id: this.props.id,
                 "data-cell-id": this.props.id,
                 "data-cell-type": "Subscribed"

--- a/object_database/web/content/components/SubscribedSequence.js
+++ b/object_database/web/content/components/SubscribedSequence.js
@@ -33,7 +33,6 @@ class SubscribedSequence extends Component {
         return h('div',
             {
                 class: this.makeClass(),
-                style: this.props.extraData.divStyle,
                 id: this.props.id,
                 "data-cell-id": this.props.id,
                 "data-cell-type": "SubscribedSequence"

--- a/object_database/web/content/components/Text.js
+++ b/object_database/web/content/components/Text.js
@@ -3,11 +3,14 @@
  */
 
 import {Component} from './Component';
+import {PropTypes} from './util/PropertyValidator';
 import {h} from 'maquette';
 
 class Text extends Component {
     constructor(props, ...args){
         super(props, ...args);
+
+        this.style = "color:" + this.props.text_color
     }
 
     render(){
@@ -15,12 +18,27 @@ class Text extends Component {
             h('div', {
                 class: "cell",
                 id: this.props.id,
-                style: this.props.extraData.divStyle,
+                style: this.style,
                 "data-cell-id": this.props.id,
                 "data-cell-type": "Text"
-            }, [this.props.extraData.rawText])
+            }, [this.props.rawText])
         );
     }
 }
+
+Text.propTypes = {
+    text_color: {
+        description: "Text color.",
+        type: PropTypes.oneOf([PropTypes.string])
+    },
+    rawText: {
+        description: "Basic display text.",
+        type: PropTypes.oneOf([PropTypes.string])
+    },
+    escapedText: {
+        description: "Escaped Text.", //TODO!
+        type: PropTypes.oneOf([PropTypes.string])
+    },
+};
 
 export {Text, Text as default};


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
The PR is a first pass at moving most styling from the Python side to the frontend side. We have also added new Cell/Components and extra styling adjustments as needed.

## Motivation and Context
<!-- Why is this change required? -->
Previously, Cells had internal methods to set their own custom inline CSS styling on the resulting DOM elements (things like `width()` and `_divStyle()`). Our goal is to eventually have a simple vocabulary on a cell by cell basis for what visual properties a cell should have, rather than to set all kinds of styling in Python where it cannot be tracked or managed easily.
  
Another goal is to have most styling in CSS file(s) with classnames and cascades that make sense for the front end.
<!-- What problem does it solve? -->
<!--  If it fixes an open issue, please link to the issue here.-->

## Approach
<!-- Describe your changes in reasonable detail -->
We have removed all Cell calls to the `_divStyle()` method. Whatever styles were required for each Cell, we have moved into the Component for that Cell as an inline style (the next phase will involve moving these things to the stylesheet/CSS classes).
  
In the process of doing this we also refactored some Cell/Components and created a couple of new ones.
  
### `Sequence` ###
The `Sequence` Cell is used all over the place. Its expected behavior is to display some collection of Cells stacked inline vertically. It can also use the `+` operator on any Cell to wrap that Cell in a `Sequence`.
  
One issue is that the UIs were using `Sequence`, but the resulting elements were displayed in a horizontal row. This had to do with the custom `divStyle()` etc methods that were being called in those circumstances. They were likely a simple hack to get things to display in a row.
  
`Sequence` will now result in exclusively *vertical* displays. Anything that was previously using Sequence but intended for horizontal display will need to be adjusted.
  
### `HorizontalSequence` ###
We introduce the `HorizontalSequence` Cell type which is more or less polymorphic with `Sequence` except for two key factors:
1. The resulting objects will be displayed in a *horizontal* element (rather than vertical)
2. You can use the `>>` operator on any two Cells to automatically wrap them in a `HorizontalSequence`.
  
We have adjusted to UI in places where we saw that Sequence was being used for horizontal things. There might be others that we have missed or do not know about.
  
### `PageView` ###
We have also created a new view level Cell/Component combination called `PageView` which knows how to make the `ActiveWebService` page views -- ie, a menubar at the top and a body taking up the rest of the space. This is now the default in `ActiveWebService`
  
### `ActiveWebService` Refactoring` ###
We have decomposed some of the more complex declarative Cell structures for pages into smaller functions and Cell combinations (in addition to the new `PageView`).
  
### **Heads Up** ###
Because we do not have access to all UIs currently used in production, these changes will likely result in odd looking results in some cases, most likely where Sequences have been used. These will need to be reported to us and probably shared as a playground example.

## How Has This Been Tested?
We have tested this by examining the test frontend.
  
We have also added many new examples to the Playground to ensure that individual Cells are rendering as expected.
<!-- Describe in reasonable detail how you tested your changes. -->
<!-- If appropriate, include details of your testing environment, -->
<!-- tests ran to see how your change affects other areas of the code, etc. -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.