### PR TITLE
Add string::join. Ref: #191

### DIFF
--- a/nativepython/type_wrappers/runtime_functions.py
+++ b/nativepython/type_wrappers/runtime_functions.py
@@ -225,6 +225,12 @@ string_find_3 = externalCallTarget(
     Void.pointer(), Void.pointer(), Int64
 )
 
+string_join = externalCallTarget(
+    "nativepython_runtime_string_join",
+    Void,
+    Void.pointer(), Void.pointer(), Void.pointer()
+)
+
 string_split = externalCallTarget(
     "nativepython_runtime_string_split",
     Void,

--- a/typed_python/StringType.hpp
+++ b/typed_python/StringType.hpp
@@ -68,6 +68,11 @@ public:
     static void split(ListOfType::layout *outList, layout* l, layout* sep, int64_t max);
     static void split_3(ListOfType::layout *outList, layout* l, int64_t max);
 
+    /**
+     * It should behave like outString = separator.join(toJoin).
+     */
+    static void join(StringType::layout **outString, StringType::layout *separator, ListOfType::layout *toJoin);
+
     static bool isalpha(layout *l);
     static bool isalnum(layout *l);
     static bool isdecimal(layout *l);

--- a/typed_python/_runtime.cpp
+++ b/typed_python/_runtime.cpp
@@ -43,6 +43,10 @@ extern "C" {
         return StringType::find(l, sub, start, l ? l->pointcount : 0);
     }
 
+    void nativepython_runtime_string_join(StringType::layout** outString, StringType::layout* separator, ListOfType::layout* toJoin) {
+        StringType::join(outString, separator, toJoin);
+    }
+
     void nativepython_runtime_string_split(ListOfType::layout* outList, StringType::layout* l, StringType::layout* sep, int64_t max) {
         StringType::split(outList, l, sep, max);
     }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!-- Why is this change required? -->
<!-- What problem does it solve? -->
<!--  If it fixes an open issue, please link to the issue here.-->
Adds string.join method to the compiler. It supports calling as:

```
separator.join(items)
```

where:

* separator is a string
* items is either ListOf(str) or TupleOf(str)

## Approach
<!-- Describe your changes in reasonable detail -->

## How Has This Been Tested?
<!-- Describe in reasonable detail how you tested your changes. -->
<!-- If appropriate, include details of your testing environment, -->
<!-- tests ran to see how your change affects other areas of the code, etc. -->
There are new tests.

## Screenshots or console output (if appropriate)
<!-- if not appropriate, remove this section -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.