### PR TITLE
[set] add support for difference, copy, union, intersection, minor bug fixes

### DIFF
--- a/typed_python/PySetInstance.cpp
+++ b/typed_python/PySetInstance.cpp
@@ -17,17 +17,22 @@
 #include "PySetInstance.hpp"
 
 PyMethodDef* PySetInstance::typeMethodsConcrete(Type* t) {
-    return new PyMethodDef[6]{{"add", (PyCFunction)PySetInstance::setAdd, METH_VARARGS, NULL},
+    return new PyMethodDef[9]{{"add", (PyCFunction)PySetInstance::setAdd, METH_VARARGS, NULL},
                               {"discard", (PyCFunction)PySetInstance::setDiscard, METH_VARARGS,
                                NULL},
                               {"remove", (PyCFunction)PySetInstance::setRemove, METH_VARARGS, NULL},
                               {"clear", (PyCFunction)PySetInstance::setClear, METH_VARARGS, NULL},
+                              {"copy", (PyCFunction)PySetInstance::setCopy, METH_VARARGS, NULL},
+                              {"union", (PyCFunction)PySetInstance::setUnion, METH_VARARGS, NULL},
+                              {"intersection", (PyCFunction)PySetInstance::setIntersection,
+                               METH_VARARGS, NULL},
+                              {"difference", (PyCFunction)PySetInstance::setDifference,
+                               METH_VARARGS, NULL},
                               {NULL, NULL}};
 }
 
-PyObject* PySetInstance::try_remove(PyObject* o, PyObject* args, bool assertKeyError) {
+PyObject* PySetInstance::try_remove(PyObject* o, PyObject* item, bool assertKeyError) {
     PySetInstance* self_w = (PySetInstance*)o;
-    PyObjectHolder item(PyTuple_GetItem(args, 0));
     Type* item_type = extractTypeFrom(item->ob_type);
     Type* self_type = extractTypeFrom(o->ob_type);
 
@@ -71,7 +76,8 @@ PyObject* PySetInstance::setRemove(PyObject* o, PyObject* args) {
         return NULL;
     }
 
-    return try_remove(o, args, true);
+    PyObjectHolder item(PyTuple_GetItem(args, 0));
+    return try_remove(o, item, true);
 }
 
 PyObject* PySetInstance::setDiscard(PyObject* o, PyObject* args) {
@@ -80,17 +86,300 @@ PyObject* PySetInstance::setDiscard(PyObject* o, PyObject* args) {
         return NULL;
     }
 
-    return try_remove(o, args, false);
+    PyObjectHolder item(PyTuple_GetItem(args, 0));
+    return try_remove(o, item, false);
 }
 
 PyObject* PySetInstance::setClear(PyObject* o, PyObject* args) {
-    if (PyTuple_Size(args) != 0) {
+    if (args && PyTuple_Size(args) != 0) {
         PyErr_SetString(PyExc_TypeError, "Set.clear takes no arguments");
         return NULL;
     }
     PySetInstance* self_w = (PySetInstance*)o;
     self_w->type()->clear(self_w->dataPtr());
     Py_RETURN_NONE;
+}
+
+void PySetInstance::copy_elements(PyObject* dst, PyObject* src) {
+    PySetInstance* dst_w = (PySetInstance*)dst;
+
+    PyObjectStealer iterator(PyObject_GetIter(src));
+    if (!iterator) {
+        throw PythonExceptionSet();
+    }
+
+    PyObject* item;
+    while ((item = PyObjectStealer(PyIter_Next(iterator)))) {
+
+        if (!item) {
+            if (PyErr_Occurred()) {
+                throw PythonExceptionSet();
+            } else {
+                // no more values to iterate over
+                break;
+            }
+        }
+
+        Instance key(dst_w->type()->keyType(), [&](instance_ptr data) {
+            PyInstance::copyConstructFromPythonInstance(dst_w->type()->keyType(), data, item, true);
+        });
+
+        if (try_insert_key(dst_w, item, key.data()) != 0) {
+            throw PythonExceptionSet();
+        }
+    }
+}
+
+PyObject* PySetInstance::setCopy(PyObject* o, PyObject* args) {
+    if (args && PyTuple_Size(args) != 0) {
+        PyErr_SetString(PyExc_TypeError, "Set.copy takes no arguments");
+        return NULL;
+    }
+
+    PySetInstance* new_inst = (PySetInstance*)PyInstance::tp_new(Py_TYPE(o), NULL, NULL);
+    if (!new_inst) {
+        return NULL;
+    }
+    new_inst->mIteratorOffset = 0;
+    new_inst->mIteratorFlag = 0;
+    new_inst->mIsMatcher = false;
+
+    try {
+        copy_elements((PyObject*)new_inst, (PyObject*)(PySetInstance*)o);
+    } catch (PythonExceptionSet& e) {
+        decref((PyObject*)new_inst);
+        return NULL;
+    } catch (std::exception& e) {
+        decref((PyObject*)new_inst);
+        PyErr_SetString(PyExc_TypeError, e.what());
+        return NULL;
+    }
+    return (PyObject*)new_inst;
+}
+
+PyObject* PySetInstance::set_intersection(PyObject* o, PyObject* other) {
+    PySetInstance* new_inst = (PySetInstance*)PyInstance::tp_new(Py_TYPE(o), NULL, NULL);
+    if (!new_inst) {
+        return NULL;
+    }
+    new_inst->mIteratorOffset = 0;
+    new_inst->mIteratorFlag = 0;
+    new_inst->mIsMatcher = false;
+
+    PyObjectStealer iterator(PyObject_GetIter(other));
+    if (!iterator) {
+        decref((PyObject*)new_inst);
+        return NULL;
+    }
+
+    PySetInstance* self_w = (PySetInstance*)o;
+    PyObject* item;
+    while ((item = PyObjectStealer(PyIter_Next(iterator))) != NULL) {
+
+        Instance key(self_w->type()->keyType(), [&](instance_ptr data) {
+            PyInstance::copyConstructFromPythonInstance(self_w->type()->keyType(), data, item,
+                                                        true);
+        });
+
+        instance_ptr existingLoc = self_w->type()->lookupKey(self_w->dataPtr(), key.data());
+        if (!existingLoc) {
+            continue;
+        }
+        if (existingLoc && try_insert_key(new_inst, item, key.data()) != 0) {
+            decref((PyObject*)new_inst);
+            return NULL;
+        }
+    }
+    if (PyErr_Occurred()) {
+        decref((PyObject*)new_inst);
+        return NULL;
+    }
+    return (PyObject*)new_inst;
+}
+
+PyObject* PySetInstance::set_difference(PyObject* o, PyObject* other) {
+    if (!PySet_Check(other)) {
+        PyObject* new_inst = setCopy(o, NULL);
+        if (!new_inst) {
+            return NULL;
+        }
+        if (set_difference_update(new_inst, other) < 0) {
+            decref(new_inst);
+            return NULL;
+        }
+        return new_inst;
+    }
+
+    PySetInstance* new_inst = (PySetInstance*)PyInstance::tp_new(Py_TYPE(o), NULL, NULL);
+    if (!new_inst) {
+        return NULL;
+    }
+    new_inst->mIteratorOffset = 0;
+    new_inst->mIteratorFlag = 0;
+    new_inst->mIsMatcher = false;
+
+    PyObjectStealer iterator(PyObject_GetIter(o));
+    if (!iterator) {
+        decref((PyObject*)new_inst);
+        return NULL;
+    }
+
+    PySetInstance* other_w = (PySetInstance*)other;
+    PyObject* item;
+    while ((item = PyObjectStealer(PyIter_Next(iterator))) != NULL) {
+
+        Instance key(other_w->type()->keyType(), [&](instance_ptr data) {
+            PyInstance::copyConstructFromPythonInstance(other_w->type()->keyType(), data, item,
+                                                        true);
+        });
+
+        instance_ptr existingLoc = other_w->type()->lookupKey(other_w->dataPtr(), key.data());
+        if (!existingLoc && try_insert_key(new_inst, item, key.data()) != 0) {
+            decref((PyObject*)new_inst);
+            return NULL;
+        }
+    }
+    if (PyErr_Occurred()) {
+        decref((PyObject*)new_inst);
+        return NULL;
+    }
+    return (PyObject*)new_inst;
+}
+
+int PySetInstance::set_difference_update(PyObject* o, PyObject* other) {
+    if (o == other) {
+        setClear(o, NULL);
+        return 0;
+    }
+
+    PyObjectStealer iterator(PyObject_GetIter(other));
+    if (!iterator) {
+        return -1;
+    }
+
+    PySetInstance* self_w = (PySetInstance*)o;
+    PyObject* item;
+    while ((item = PyObjectStealer(PyIter_Next(iterator))) != NULL) {
+        if (!try_remove(o, item)) {
+            return -1;
+        }
+    }
+    if (PyErr_Occurred()) {
+        return -1;
+    }
+    return 0;
+}
+
+PyObject* PySetInstance::setDifference(PyObject* o, PyObject* args) {
+    if (PyTuple_Size(args) == 0) {
+        return setCopy(o, NULL);
+    }
+
+    PyObject* result;
+    PyObjectHolder other(PyTuple_GetItem(args, 0));
+    result = set_difference(o, other);
+    if (!result) {
+        return NULL;
+    }
+
+    for (Py_ssize_t i = 1; i < PyTuple_Size(args); ++i) {
+        PyObjectHolder other(PyTuple_GetItem(args, i));
+        if (set_difference_update(result, other) < 0) {
+            decref(result);
+            return NULL;
+        }
+    }
+
+    return result;
+}
+
+PyObject* PySetInstance::setIntersection(PyObject* o, PyObject* args) {
+    if (PyTuple_Size(args) == 0) {
+        return setCopy(o, NULL);
+    }
+
+    for (size_t k = 0; k < PyTuple_Size(args); ++k) {
+        PyObjectHolder item(PyTuple_GetItem(args, k));
+        if (!PyIter_Check(item) && !PyList_Check(item) && !PySet_Check(item)
+            && !PyTuple_Check(item)) {
+            PyErr_SetString(PyExc_TypeError, "Set.intersection one of args has wrong type");
+            return NULL;
+        }
+    }
+
+    PyObject* self_w = o;
+    incref(o);
+    try {
+        for (size_t k = 0; k < PyTuple_Size(args); ++k) {
+            PyObjectHolder item(PyTuple_GetItem(args, k));
+            PyObject* set_result = set_intersection(self_w, item);
+            if (!set_result) {
+                decref(self_w);
+                return NULL;
+            }
+            decref(self_w);
+            self_w = set_result;
+        }
+    } catch (PythonExceptionSet& e) {
+        decref(self_w);
+        return NULL;
+    } catch (std::exception& e) {
+        decref(self_w);
+        PyErr_SetString(PyExc_TypeError, e.what());
+        return NULL;
+    }
+    return self_w;
+}
+
+PyObject* PySetInstance::setUnion(PyObject* o, PyObject* args) {
+    if (PyTuple_Size(args) < 1) {
+        PyErr_SetString(PyExc_TypeError, "Set.union takes at least one argument");
+        return NULL;
+    }
+
+    for (size_t k = 0; k < PyTuple_Size(args); ++k) {
+        PyObjectHolder item(PyTuple_GetItem(args, k));
+        if (!PyIter_Check(item) && !PyList_Check(item) && !PyAnySet_Check(item)
+            && !PyTuple_Check(item)) {
+            PyErr_SetString(PyExc_TypeError, "Set.union one of args has wrong type");
+            return NULL;
+        }
+    }
+
+    PySetInstance* self_w = (PySetInstance*)o;
+    PySetInstance* new_inst = (PySetInstance*)PyInstance::tp_new(Py_TYPE(o), NULL, NULL);
+    if (!new_inst) {
+        return NULL;
+    }
+    new_inst->mIteratorOffset = 0;
+    new_inst->mIteratorFlag = 0;
+    new_inst->mIsMatcher = false;
+
+    try {
+        // copy lhs to new set
+        copy_elements((PyObject*)new_inst, (PyObject*)self_w);
+
+        // copy rhs arg items to new set
+        for (size_t k = 0; k < PyTuple_Size(args); ++k) {
+            PyObjectHolder arg_item(PyTuple_GetItem(args, k));
+            Type* item_type = extractTypeFrom(Py_TYPE((PyObject*)arg_item));
+            if (item_type == self_w->type()->keyType()) {
+                continue;
+            }
+
+            copy_elements((PyObject*)new_inst, (PyObject*)arg_item);
+        }
+
+    } catch (PythonExceptionSet& e) {
+        decref((PyObject*)new_inst);
+        return NULL;
+    } catch (std::exception& e) {
+        decref((PyObject*)new_inst);
+        PyErr_SetString(PyExc_TypeError, e.what());
+        return NULL;
+    }
+
+    return (PyObject*)new_inst;
 }
 
 int PySetInstance::sq_contains_concrete(PyObject* item) {
@@ -199,6 +488,7 @@ SetType* PySetInstance::type() {
 void PySetInstance::copyConstructFromPythonInstanceConcrete(SetType* setType, instance_ptr tgt,
                                                             PyObject* pyRepresentation,
                                                             bool isExplicit) {
+
     setType->constructor(tgt);
     try {
         if ((PyList_Check(pyRepresentation) || PySet_Check(pyRepresentation)
@@ -213,6 +503,8 @@ void PySetInstance::copyConstructFromPythonInstanceConcrete(SetType* setType, in
                 if (!item) {
                     if (PyErr_Occurred()) {
                         throw PythonExceptionSet();
+                    } else {
+                        break;
                     }
                 }
 
@@ -236,11 +528,33 @@ void PySetInstance::copyConstructFromPythonInstanceConcrete(SetType* setType, in
                 setType->insertKey(tgt, key.data());
             }
             return;
+        } else if (PyUnicode_Check(pyRepresentation)) {
+            if (PyUnicode_READY(pyRepresentation) < 0) {
+                if (PyErr_Occurred()) {
+                    throw PythonExceptionSet();
+                }
+            }
+
+            Py_ssize_t str_size = PyUnicode_GetLength(pyRepresentation);
+            for (size_t i = 0; i < str_size; ++i) {
+                Py_UCS4 c = PyUnicode_ReadChar(pyRepresentation, i);
+                Instance key(setType->keyType(), [&](instance_ptr data) {
+                    copyConstructFromPythonInstance(setType->keyType(), data,
+                                                    PyUnicode_FromFormat("%c", c));
+                });
+
+                instance_ptr found = setType->lookupKey(tgt, key.data());
+                if (!found) {
+                    setType->insertKey(tgt, key.data());
+                }
+            }
+            return;
         }
 
     } catch (...) {
         setType->destroy(tgt);
         throw;
     }
+
     PyInstance::copyConstructFromPythonInstanceConcrete(setType, tgt, pyRepresentation, isExplicit);
 }

--- a/typed_python/PySetInstance.hpp
+++ b/typed_python/PySetInstance.hpp
@@ -29,6 +29,10 @@ class PySetInstance : public PyInstance {
     static PyObject* setDiscard(PyObject* o, PyObject* args);
     static PyObject* setRemove(PyObject* o, PyObject* args);
     static PyObject* setClear(PyObject* o, PyObject* args);
+    static PyObject* setCopy(PyObject* o, PyObject* args);
+    static PyObject* setUnion(PyObject* o, PyObject* args);
+    static PyObject* setIntersection(PyObject* o, PyObject* args);
+    static PyObject* setDifference(PyObject* o, PyObject* args);
     Py_ssize_t mp_and_sq_length_concrete();
     int sq_contains_concrete(PyObject* item);
     PyObject* tp_iter_concrete();
@@ -44,7 +48,11 @@ class PySetInstance : public PyInstance {
 
   private:
     static int try_insert_key(PySetInstance* self, PyObject* pyKey, instance_ptr key);
-    static PyObject* try_remove(PyObject* o, PyObject* args, bool assertKeyError = false);
+    static PyObject* try_remove(PyObject* o, PyObject* item, bool assertKeyError = false);
+    static void copy_elements(PyObject* dst, PyObject* src);
+    static PyObject* set_intersection(PyObject* o, PyObject* other);
+    static PyObject* set_difference(PyObject* o, PyObject* other);
+    static int set_difference_update(PyObject* o, PyObject* other);
     SetType* type();
 };
 

--- a/typed_python/PySetInstance.hpp
+++ b/typed_python/PySetInstance.hpp
@@ -15,8 +15,8 @@
 ******************************************************************************/
 
 #pragma once
-
 #include "PyInstance.hpp"
+#include <functional>
 
 class PySetInstance : public PyInstance {
   public:
@@ -42,7 +42,8 @@ class PySetInstance : public PyInstance {
                                                         PyObject* pyRepresentation,
                                                         bool isExplicit);
     static void mirrorTypeInformationIntoPyTypeConcrete(SetType* setType, PyTypeObject* pyType);
-    static bool pyValCouldBeOfTypeConcrete(modeled_type* type, PyObject* pyRepresentation, bool isExplicit) {
+    static bool pyValCouldBeOfTypeConcrete(modeled_type* type, PyObject* pyRepresentation,
+                                           bool isExplicit) {
         return true;
     }
 
@@ -54,5 +55,8 @@ class PySetInstance : public PyInstance {
     static PyObject* set_difference(PyObject* o, PyObject* other);
     static int set_difference_update(PyObject* o, PyObject* other);
     SetType* type();
+    static void getDataFromNative(PySetInstance* src, std::function<void(instance_ptr)> func);
+    static void getDataFromNative(PyTupleOrListOfInstance* src,
+                                  std::function<void(instance_ptr)> func);
 };
 

--- a/typed_python/SetType.cpp
+++ b/typed_python/SetType.cpp
@@ -1,6 +1,6 @@
 #include "AllTypes.hpp"
 #include "hash_table_layout.hpp"
-#include <iostream>
+
 #include <map>
 
 SetType* SetType::Make(Type* eltype) {
@@ -108,6 +108,13 @@ void SetType::destroy(instance_ptr self) {
 void SetType::copy_constructor(instance_ptr self, instance_ptr other) {
     (*(hash_table_layout**)self) = (*(hash_table_layout**)other);
     (*(hash_table_layout**)self)->refcount++;
+}
+
+void SetType::assign(instance_ptr self, instance_ptr other) {
+    hash_table_layout* old = (*(hash_table_layout**)self);
+    (*(hash_table_layout**)self) = (*(hash_table_layout**)other);
+    (*(hash_table_layout**)self)->refcount++;
+    destroy((instance_ptr)&old);
 }
 
 bool SetType::cmp(instance_ptr left, instance_ptr right, int pyComparisonOp,

--- a/typed_python/SetType.hpp
+++ b/typed_python/SetType.hpp
@@ -28,6 +28,7 @@ class SetType : public Type {
     int64_t size(instance_ptr self) const;
     bool cmp(instance_ptr left, instance_ptr right, int pyComparisonOp,
              bool suppressExceptions = false);
+    void assign(instance_ptr self, instance_ptr other);
     Type* keyType() const { return m_key_type; }
 
     // hash_table_layout accessors

--- a/typed_python/types_test.py
+++ b/typed_python/types_test.py
@@ -2459,7 +2459,7 @@ class NativeTypesTests(unittest.TestCase):
             self.assertEqual(Set(str)('abcba').intersection(C('cbcf'), C('bag')), Set(str)('b'))
 
         # difference
-        for C in list, tuple, ListOf(str), TupleOf(str), Set(str):
+        for C in set, list, tuple, ListOf(str), TupleOf(str), Set(str):
             self.assertEqual(Set(str)('abcba').difference(C('cdc')), Set(str)('ab'))
             self.assertEqual(Set(str)('abcba').difference(C('efgfe')), Set(str)('abc'))
             self.assertEqual(Set(str)('abcba').difference(C('ccb')), Set(str)('a'))


### PR DESCRIPTION
The PR enriches the `Set(T)` API with additional commonplace functionality that is expected when working with sets; namely the API was extended to include `difference(), union(), intersection(), and copy()` functions. The functions, where args are appropriate, are not limited to working with only other sets, but can be used with various other iterable container objects from both python and typed_python to increase the general application of the container.

## Motivation and Context
The `Set(T)` type function needs additional api enrichments to mimic the behavior one would expect from using a native python set(). Having an ability to express a difference, intersection, or union, between elements is, at a fundamental level, what makes a set useful. 

## Approach
1 - `Set(T)` now supports `difference(args...), union(args...), intersection(args...),  copy()`, where `args...` is any combination of potentially the following objects `set, list, tuple, ListOf(T), TupleOf(T), Set(T)` 
2 -`Set(T)` also now supports construction from unicode strings e.g. , it is possible to express the following `Set(str)("helloworld")` which will initialize a set of unique characters.

## How Has This Been Tested?
There are a number of additional tests added to `typed_python/types_test.py` to cover the extended API functionality.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.