### PR TITLE
Conversions to and from python objects. Refs #167 #202 #185

### DIFF
--- a/nativepython/expression_conversion_context.py
+++ b/nativepython/expression_conversion_context.py
@@ -736,4 +736,4 @@ class ExpressionConversionContext(object):
 
             return out_slot
 
-        raise ConversionException("can't handle python expression type %s" % ast._which)
+        raise ConversionException("can't handle python expression type %s" % ast.Name)

--- a/nativepython/expression_conversion_context.py
+++ b/nativepython/expression_conversion_context.py
@@ -21,6 +21,7 @@ from nativepython.python_object_representation import pythonObjectRepresentation
 from nativepython.typed_expression import TypedExpression
 from nativepython.conversion_exception import ConversionException
 from typed_python import NoneType, Alternative, OneOf, Int32
+from typed_python._types import getTypePointer
 
 
 NoneExprType = NoneWrapper()
@@ -740,3 +741,11 @@ class ExpressionConversionContext(object):
             return out_slot
 
         raise ConversionException("can't handle python expression type %s" % ast.Name)
+
+    def getTypePointer(self, t):
+        """Return a raw type pointer for type t
+
+        Args:
+            t - python representation of Type, e.g. int, UInt64, ListOf(String), ...
+        """
+        return getTypePointer(t)

--- a/nativepython/expression_conversion_context.py
+++ b/nativepython/expression_conversion_context.py
@@ -604,6 +604,9 @@ class ExpressionConversionContext(object):
         if ast.matches.Str:
             return pythonObjectRepresentation(self, ast.s)
 
+        if ast.matches.Bytes:
+            return pythonObjectRepresentation(self, ast.s)
+
         if ast.matches.BoolOp:
             def convertBoolOp(depth=0):
                 with self.subcontext() as sc:

--- a/nativepython/native_ast.py
+++ b/nativepython/native_ast.py
@@ -477,6 +477,12 @@ def const_int_expr(i):
     )
 
 
+def const_uint64_expr(i):
+    return Expression.Constant(
+        val=Constant.Int(bits=64, val=i, signed=False)
+    )
+
+
 def const_int32_expr(i):
     return Expression.Constant(
         val=Constant.Int(bits=32, val=i, signed=True)
@@ -527,10 +533,14 @@ UInt8Ptr = UInt8.pointer()
 Int8Ptr = Type.Pointer(value_type=Type.Int(bits=8, signed=True))
 Float64 = Type.Float(bits=64)
 Float32 = Type.Float(bits=32)
-UInt64 = Type.Int(bits=64, signed=False)
 Int64 = Type.Int(bits=64, signed=True)
-UInt32 = Type.Int(bits=32, signed=False)
 Int32 = Type.Int(bits=32, signed=True)
+Int16 = Type.Int(bits=16, signed=True)
+Int8 = Type.Int(bits=8, signed=True)
+UInt64 = Type.Int(bits=64, signed=False)
+UInt32 = Type.Int(bits=32, signed=False)
+UInt16 = Type.Int(bits=16, signed=False)
+UInt8 = Type.Int(bits=8, signed=False)
 Int32Ptr = Int32.pointer()
 Int64Ptr = Int64.pointer()
 

--- a/nativepython/python_object_representation.py
+++ b/nativepython/python_object_representation.py
@@ -45,6 +45,7 @@ from nativepython.type_wrappers.string_wrapper import StringWrapper
 from nativepython.type_wrappers.bytes_wrapper import BytesWrapper
 from nativepython.type_wrappers.python_object_of_type_wrapper import PythonObjectOfTypeWrapper
 from nativepython.type_wrappers.abs_wrapper import AbsWrapper
+from nativepython.type_wrappers.repr_wrapper import ReprWrapper
 from types import ModuleType
 from typed_python._types import TypeFor, bytecount
 from typed_python import (
@@ -154,6 +155,9 @@ def pythonObjectRepresentation(context, f):
 
     if f is abs:
         return TypedExpression(context, native_ast.nullExpr, AbsWrapper(), False)
+
+    if f is repr:
+        return TypedExpression(context, native_ast.nullExpr, ReprWrapper(), False)
 
     if f is range:
         return TypedExpression(context, native_ast.nullExpr, _RangeWrapper, False)

--- a/nativepython/tests/bytes_compilation_test.py
+++ b/nativepython/tests/bytes_compilation_test.py
@@ -121,3 +121,20 @@ class TestBytesCompilation(unittest.TestCase):
 
         # I get about 200
         self.assertGreater(speedup, 100)
+
+    def test_bytes_literals(self):
+
+        def f(i: int):
+            x = b"abcdefghijklmnopqrstuvwxyz"
+            return x[i]
+
+        def g(i: int):
+            y = bytes(b'01234567890123456789012345')
+            return y[i]
+
+        cf = Compiled(f)
+        cg = Compiled(g)
+
+        for i in range(26):
+            self.assertEqual(f(i), cf(i))
+            self.assertEqual(g(i), cg(i))

--- a/nativepython/tests/class_compilation_test.py
+++ b/nativepython/tests/class_compilation_test.py
@@ -219,7 +219,7 @@ class TestClassCompilationCompilation(unittest.TestCase):
         self.assertEqual(f().x, 123)
         self.assertEqual(f().y, 0)
 
-    def test_compile_class_repr_and_str_and_hash(self):
+    def test_compile_class_repr_and_str(self):
         class ClassWithReprAndStr(Class):
             def __repr__(self):
                 return "repr"

--- a/nativepython/tests/class_compilation_test.py
+++ b/nativepython/tests/class_compilation_test.py
@@ -12,9 +12,9 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-from typed_python import Function, Class, TupleOf, Member
+from typed_python import Function, Class, TupleOf, ListOf, Member
 import typed_python._types as _types
-from nativepython.runtime import Runtime
+from nativepython.runtime import Runtime, SpecializedEntrypoint
 import unittest
 import time
 
@@ -218,3 +218,25 @@ class TestClassCompilationCompilation(unittest.TestCase):
 
         self.assertEqual(f().x, 123)
         self.assertEqual(f().y, 0)
+
+    def test_compile_class_repr_and_str_and_hash(self):
+        class ClassWithReprAndStr(Class):
+            def __repr__(self):
+                return "repr"
+
+            def __str__(self):
+                return "str"
+
+        self.assertEqual(str(ListOf(ClassWithReprAndStr)([ClassWithRepr()])), "[str]")
+        self.assertEqual(repr(ListOf(ClassWithReprAndStr)([ClassWithRepr()])), "[repr]")
+
+        @SpecializedEntrypoint
+        def callRepr(x):
+            return repr(x)
+
+        @SpecializedEntrypoint
+        def callStr(x):
+            return str(x)
+
+        self.assertEqual(callRepr(ClassWithReprAndStr()), "repr")
+        self.assertEqual(callStr(ClassWithReprAndStr()), "str")

--- a/nativepython/tests/class_compilation_test.py
+++ b/nativepython/tests/class_compilation_test.py
@@ -227,8 +227,8 @@ class TestClassCompilationCompilation(unittest.TestCase):
             def __str__(self):
                 return "str"
 
-        self.assertEqual(str(ListOf(ClassWithReprAndStr)([ClassWithRepr()])), "[str]")
-        self.assertEqual(repr(ListOf(ClassWithReprAndStr)([ClassWithRepr()])), "[repr]")
+        self.assertEqual(str(ListOf(ClassWithReprAndStr)([ClassWithReprAndStr()])), "[str]")
+        self.assertEqual(repr(ListOf(ClassWithReprAndStr)([ClassWithReprAndStr()])), "[repr]")
 
         @SpecializedEntrypoint
         def callRepr(x):

--- a/nativepython/tests/python_object_of_type_compilation_test.py
+++ b/nativepython/tests/python_object_of_type_compilation_test.py
@@ -13,7 +13,7 @@
 #   limitations under the License.
 
 from typed_python import (
-    Function, TupleOf, ListOf, String, Dict,
+    Function, TupleOf, ListOf, String, Dict, NamedTuple, OneOf,
     Bool,
     Int8, Int16, Int32, Int64,
     UInt8, UInt16, UInt32, UInt64,
@@ -66,6 +66,8 @@ class TestPythonObjectOfTypeCompilation(unittest.TestCase):
             f(10)
 
     def test_object_conversions(self):
+        NT1 = NamedTuple(a=int, b=float, c=str, d=str)
+        NT2 = NamedTuple(s=String, t=TupleOf(int))
         cases = [
             (Bool, True),
             (Int8, -128),
@@ -90,7 +92,11 @@ class TestPythonObjectOfTypeCompilation(unittest.TestCase):
             (ListOf(str), ["a", "b", "d"]),
             (Float32, 1.2345),
             (Dict(str, int), {'y': 7, 'n': 6}),
-            (TupleOf(int), tuple(range(10000)))
+            (TupleOf(int), tuple(range(10000))),
+            (OneOf(String, Int64), "ab"),
+            (OneOf(String, Int64), 34),
+            (NT1, NT1(a=1, b=2.3, c="c", d="d")),
+            (NT2, NT2(s="xyz", t=tuple(range(10000))))
         ]
 
         for T, v in cases:
@@ -127,4 +133,4 @@ class TestPythonObjectOfTypeCompilation(unittest.TestCase):
                 w = fro_and_to(w)
             finalMem = psutil.Process().memory_info().rss / 1024 ** 2
 
-            self.assertTrue(finalMem < initMem + 5)
+            self.assertTrue(finalMem < initMem + 2)

--- a/nativepython/tests/python_object_of_type_compilation_test.py
+++ b/nativepython/tests/python_object_of_type_compilation_test.py
@@ -12,9 +12,18 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-from typed_python import Function
-from nativepython.runtime import Runtime
+from typed_python import (
+    Function, TupleOf, ListOf, String, Dict,
+    Bool,
+    Int8, Int16, Int32, Int64,
+    UInt8, UInt16, UInt32, UInt64,
+    Float32, Float64,
+)
+
 import unittest
+import psutil
+from nativepython.runtime import Runtime
+from typed_python._types import refcount
 
 
 def Compiled(f):
@@ -55,3 +64,67 @@ class TestPythonObjectOfTypeCompilation(unittest.TestCase):
         self.assertIs(f(HoldsAnA(x)), x)
         with self.assertRaises(Exception):
             f(10)
+
+    def test_object_conversions(self):
+        cases = [
+            (Bool, True),
+            (Int8, -128),
+            (Int16, -32768),
+            (Int32, -2**31),
+            (Int64, -2**63),
+            (UInt8, 127),
+            (UInt16, 65535),
+            (UInt32, 2**32-1),
+            (UInt64, 2**64-1),
+            (Float64, 1.2345),
+            (String, "abcd"),
+            (TupleOf(Int64), (7, 6, 5, 4, 3, 2, -1)),
+            (TupleOf(Int32), (7, 6, 5, 4, 3, 2, -2)),
+            (TupleOf(Int16), (7, 6, 5, 4, 3, 2, -3)),
+            (TupleOf(Int8), (7, 6, 5, 4, 3, 2, -4)),
+            (TupleOf(UInt64), (7, 6, 5, 4, 3, 2, 1)),
+            (TupleOf(UInt32), (7, 6, 5, 4, 3, 2, 2)),
+            (TupleOf(UInt16), (7, 6, 5, 4, 3, 2, 3)),
+            (TupleOf(UInt8), (7, 6, 5, 4, 3, 2, 4)),
+            (TupleOf(str), ("a", "b", "c")),
+            (ListOf(str), ["a", "b", "d"]),
+            (Float32, 1.2345),
+            (Dict(str, int), {'y': 7, 'n': 6}),
+            (TupleOf(int), tuple(range(10000)))
+        ]
+
+        for T, v in cases:
+            @Compiled
+            def to_and_fro(x: T) -> T:
+                return T(object(x))
+
+            @Compiled
+            def fro_and_to(x):
+                return object(T(x))
+
+            if T in [Float32, Float64]:
+                self.assertEqual(to_and_fro(v), T(v))
+            else:
+                self.assertEqual(to_and_fro(v), v)
+            if T in [Float32]:
+                self.assertEqual(fro_and_to(v), T(v))
+            else:
+                self.assertEqual(fro_and_to(v), v)
+
+            x = T(v)
+            if T.__typed_python_category__ in ["ListOf", "TupleOf", "Alternative", "ConcreteAlternative",
+                                               "Class", "Dict", "ConstDict", "Set"]:
+                self.assertEqual(refcount(x), 1)
+                self.assertEqual(to_and_fro(x), x)
+                self.assertEqual(refcount(x), 1)
+                self.assertEqual(fro_and_to(x), x)
+                self.assertEqual(refcount(x), 1)
+
+            initMem = psutil.Process().memory_info().rss / 1024 ** 2
+            w = v
+            for _ in range(10000):
+                v = to_and_fro(v)
+                w = fro_and_to(w)
+            finalMem = psutil.Process().memory_info().rss / 1024 ** 2
+
+            self.assertTrue(finalMem < initMem + 5)

--- a/nativepython/type_wrappers/python_object_of_type_wrapper.py
+++ b/nativepython/type_wrappers/python_object_of_type_wrapper.py
@@ -117,12 +117,10 @@ class PythonObjectOfTypeWrapper(Wrapper):
         tp = context.getTypePointer(t)
         if tp:
             context.pushEffect(
-                targetVal.expr.store(
-                    runtime_functions.pyobj_to_typed.call(
-                        e.nonref_expr.cast(VoidPtr),
-                        targetVal.expr.cast(VoidPtr),
-                        tp).cast(target_type.getNativeLayoutType())
-                )
+                runtime_functions.pyobj_to_typed.call(
+                    e.nonref_expr.cast(VoidPtr),
+                    targetVal.expr.cast(VoidPtr),
+                    tp)
             )
             return context.constant(True)
 
@@ -158,7 +156,7 @@ class PythonObjectOfTypeWrapper(Wrapper):
         if tp:
             context.pushEffect(
                 targetVal.expr.store(
-                    runtime_functions.to_pyobj.call(sourceVal.nonref_expr.cast(VoidPtr), tp)
+                    runtime_functions.to_pyobj.call(sourceVal.expr.cast(VoidPtr), tp)
                 )
             )
             return context.constant(True)

--- a/nativepython/type_wrappers/python_object_of_type_wrapper.py
+++ b/nativepython/type_wrappers/python_object_of_type_wrapper.py
@@ -19,7 +19,6 @@ from nativepython.typed_expression import TypedExpression
 import nativepython.native_ast as native_ast
 from nativepython.native_ast import VoidPtr
 import nativepython.type_wrappers.runtime_functions as runtime_functions
-from typed_python._types import getTypePointer
 
 
 class PythonObjectOfTypeWrapper(Wrapper):
@@ -115,7 +114,7 @@ class PythonObjectOfTypeWrapper(Wrapper):
             )
             return context.constant(True)
 
-        tp = getTypePointer(t)
+        tp = context.getTypePointer(t)
         if tp:
             context.pushEffect(
                 targetVal.expr.store(
@@ -155,7 +154,7 @@ class PythonObjectOfTypeWrapper(Wrapper):
             )
             return context.constant(True)
 
-        tp = getTypePointer(t)
+        tp = context.getTypePointer(t)
         if tp:
             context.pushEffect(
                 targetVal.expr.store(

--- a/nativepython/type_wrappers/repr_wrapper.py
+++ b/nativepython/type_wrappers/repr_wrapper.py
@@ -1,0 +1,34 @@
+#   Coyright 2017-2019 Nativepython Authors
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+from nativepython.type_wrappers.wrapper import Wrapper
+import nativepython.native_ast as native_ast
+
+
+class ReprWrapper(Wrapper):
+    is_pod = True
+    is_empty = False
+    is_pass_by_ref = False
+
+    def __init__(self):
+        super().__init__(len)
+
+    def getNativeLayoutType(self):
+        return native_ast.Type.Void()
+
+    def convert_call(self, context, expr, args, kwargs):
+        if len(args) == 1 and not kwargs:
+            return args[0].convert_repr()
+
+        return super().convert_call(context, expr, args, kwargs)

--- a/nativepython/type_wrappers/runtime_functions.py
+++ b/nativepython/type_wrappers/runtime_functions.py
@@ -14,11 +14,17 @@
 
 import nativepython.native_ast as native_ast
 
+
 Bool = native_ast.Bool
 UInt8Ptr = native_ast.UInt8Ptr
 Int64 = native_ast.Int64
-UInt64 = native_ast.UInt64
 Int32 = native_ast.Int32
+Int16 = native_ast.Int16
+Int8 = native_ast.Int8
+UInt64 = native_ast.UInt64
+UInt32 = native_ast.UInt32
+UInt16 = native_ast.UInt16
+UInt8 = native_ast.UInt8
 Float64 = native_ast.Float64
 Float32 = native_ast.Float32
 Void = native_ast.Void
@@ -147,27 +153,138 @@ getattr_pyobj = externalCallTarget(
     UInt8Ptr
 )
 
-int_to_pyobj = externalCallTarget(
-    "nativepython_runtime_int_to_pyobj",
+pyobj_to_typed = externalCallTarget(
+    "np_runtime_pyobj_to_typed",
     Void.pointer(),
-    Int64
-)
-
-uint_to_pyobj = externalCallTarget(
-    "nativepython_runtime_uint_to_pyobj",
+    Void.pointer(),
     Void.pointer(),
     UInt64
 )
 
-pyobj_to_int = externalCallTarget(
-    "nativepython_runtime_pyobj_to_int",
+to_pyobj = externalCallTarget(
+    "np_runtime_to_pyobj",
+    Void.pointer(),
+    Void.pointer(),
+    UInt64,
+)
+
+int64_to_pyobj = externalCallTarget(
+    "np_runtime_int64_to_pyobj",
+    Void.pointer(),
+    Int64
+)
+
+int32_to_pyobj = externalCallTarget(
+    "np_runtime_int32_to_pyobj",
+    Void.pointer(),
+    Int32
+)
+
+int16_to_pyobj = externalCallTarget(
+    "np_runtime_int16_to_pyobj",
+    Void.pointer(),
+    Int16
+)
+
+int8_to_pyobj = externalCallTarget(
+    "np_runtime_int8_to_pyobj",
+    Void.pointer(),
+    Int8
+)
+
+uint64_to_pyobj = externalCallTarget(
+    "np_runtime_uint64_to_pyobj",
+    Void.pointer(),
+    UInt64
+)
+
+uint32_to_pyobj = externalCallTarget(
+    "np_runtime_uint32_to_pyobj",
+    Void.pointer(),
+    UInt32
+)
+
+uint16_to_pyobj = externalCallTarget(
+    "np_runtime_uint16_to_pyobj",
+    Void.pointer(),
+    UInt16
+)
+
+uint8_to_pyobj = externalCallTarget(
+    "np_runtime_uint8_to_pyobj",
+    Void.pointer(),
+    UInt8
+)
+
+float64_to_pyobj = externalCallTarget(
+    "np_runtime_float64_to_pyobj",
+    Void.pointer(),
+    Float64
+)
+
+float32_to_pyobj = externalCallTarget(
+    "np_runtime_float32_to_pyobj",
+    Void.pointer(),
+    Float32
+)
+
+pyobj_to_int64 = externalCallTarget(
+    "np_runtime_pyobj_to_int64",
     Int64,
     Void.pointer()
 )
 
-pyobj_to_uint = externalCallTarget(
-    "nativepython_runtime_pyobj_to_uint",
+pyobj_to_int32 = externalCallTarget(
+    "np_runtime_pyobj_to_int32",
+    Int32,
+    Void.pointer()
+)
+
+pyobj_to_int16 = externalCallTarget(
+    "np_runtime_pyobj_to_int16",
+    Int16,
+    Void.pointer()
+)
+
+pyobj_to_int8 = externalCallTarget(
+    "np_runtime_pyobj_to_int8",
+    Int8,
+    Void.pointer()
+)
+
+pyobj_to_uint64 = externalCallTarget(
+    "np_runtime_pyobj_to_uint64",
     UInt64,
+    Void.pointer()
+)
+
+pyobj_to_uint32 = externalCallTarget(
+    "np_runtime_pyobj_to_uint32",
+    UInt32,
+    Void.pointer()
+)
+
+pyobj_to_uint16 = externalCallTarget(
+    "np_runtime_pyobj_to_uint16",
+    UInt16,
+    Void.pointer()
+)
+
+pyobj_to_uint8 = externalCallTarget(
+    "np_runtime_pyobj_to_uint8",
+    UInt8,
+    Void.pointer()
+)
+
+pyobj_to_float64 = externalCallTarget(
+    "np_runtime_pyobj_to_float64",
+    Float64,
+    Void.pointer()
+)
+
+pyobj_to_float32 = externalCallTarget(
+    "np_runtime_pyobj_to_float32",
+    Float32,
     Void.pointer()
 )
 

--- a/nativepython/type_wrappers/runtime_functions.py
+++ b/nativepython/type_wrappers/runtime_functions.py
@@ -146,6 +146,19 @@ decref_pyobj = externalCallTarget(
     Void.pointer()
 )
 
+np_repr = externalCallTarget(
+    "nativepython_runtime_repr",
+    Void.pointer(),
+    Void.pointer(),
+    UInt64
+)
+
+np_str = externalCallTarget(
+    "nativepython_runtime_str",
+    Void.pointer(),
+    Void.pointer(),
+    UInt64
+)
 getattr_pyobj = externalCallTarget(
     "nativepython_runtime_getattr_pyobj",
     Void.pointer(),

--- a/nativepython/type_wrappers/runtime_functions.py
+++ b/nativepython/type_wrappers/runtime_functions.py
@@ -168,7 +168,7 @@ getattr_pyobj = externalCallTarget(
 
 pyobj_to_typed = externalCallTarget(
     "np_runtime_pyobj_to_typed",
-    Void.pointer(),
+    Void,
     Void.pointer(),
     Void.pointer(),
     UInt64

--- a/nativepython/type_wrappers/string_wrapper.py
+++ b/nativepython/type_wrappers/string_wrapper.py
@@ -312,3 +312,19 @@ class StringWrapper(RefcountedWrapper):
                 )
 
         return super().convert_method_call(context, instance, methodname, args, kwargs)
+
+    def convert_to_self_with_target(self, context, targetVal, sourceVal, explicit):
+        if not explicit:
+            return super().convert_to_self_with_target(context, targetVal, sourceVal, explicit)
+
+        t = sourceVal.expr_type.typeRepresentation
+        tp = context.getTypePointer(t)
+        if tp:
+            context.pushEffect(
+                targetVal.expr.store(
+                    runtime_functions.np_str.call(sourceVal.nonref_expr.cast(VoidPtr), tp).cast(self.getNativeLayoutType())
+                )
+            )
+            return context.constant(True)
+
+        return super().convert_to_self_with_target(context, targetVal, sourceVal, explicit)

--- a/nativepython/type_wrappers/string_wrapper.py
+++ b/nativepython/type_wrappers/string_wrapper.py
@@ -322,7 +322,7 @@ class StringWrapper(RefcountedWrapper):
         if tp:
             context.pushEffect(
                 targetVal.expr.store(
-                    runtime_functions.np_str.call(sourceVal.nonref_expr.cast(VoidPtr), tp).cast(self.getNativeLayoutType())
+                    runtime_functions.np_str.call(sourceVal.expr.cast(VoidPtr), tp).cast(self.getNativeLayoutType())
                 )
             )
             return context.constant(True)

--- a/nativepython/type_wrappers/wrapper.py
+++ b/nativepython/type_wrappers/wrapper.py
@@ -205,7 +205,7 @@ class Wrapper(object):
             return context.push(
                 str,
                 lambda r: r.expr.store(
-                    runtime_functions.np_repr.call(expr.nonref_expr.cast(VoidPtr), tp).cast(typeWrapper(str).layoutType)
+                    runtime_functions.np_repr.call(expr.expr.cast(VoidPtr), tp).cast(typeWrapper(str).layoutType)
                 )
             )
         return context.pushTerminal(

--- a/nativepython/typed_expression.py
+++ b/nativepython/typed_expression.py
@@ -136,6 +136,9 @@ class TypedExpression(object):
     def convert_abs(self):
         return self.expr_type.convert_abs(self.context, self)
 
+    def convert_repr(self):
+        return self.expr_type.convert_repr(self.context, self)
+
     def convert_reserved(self):
         return self.expr_type.convert_reserved(self.context, self)
 

--- a/typed_python/_runtime.cpp
+++ b/typed_python/_runtime.cpp
@@ -340,18 +340,14 @@ extern "C" {
         return floorresult;
     }
 
-    // returns layout*
-    uint8_t *np_runtime_pyobj_to_typed(PyObject *obj, uint8_t* tgt, Type* tp) {
-        // tgt is a layout pointer
+    void np_runtime_pyobj_to_typed(PyObject *obj, instance_ptr tgt, Type* tp) {
         PyEnsureGilAcquired acquireTheGil;
-        PyInstance::copyConstructFromPythonInstance((Type *)tp, (instance_ptr)&tgt, obj, true);
-        // returns modified layout pointer
-        return tgt;
+        PyInstance::copyConstructFromPythonInstance(tp, tgt, obj, true);
     }
 
-    PyObject* np_runtime_to_pyobj(PyObject *obj, uint64_t tp) {
+    PyObject* np_runtime_to_pyobj(instance_ptr obj, Type* tp) {
         PyEnsureGilAcquired acquireTheGil;
-        return PyInstance::extractPythonObject((instance_ptr)&obj, (Type*)tp);
+        return PyInstance::extractPythonObject(obj, tp);
     }
 
     PyObject* np_runtime_int64_to_pyobj(int64_t i) {

--- a/typed_python/_runtime.cpp
+++ b/typed_python/_runtime.cpp
@@ -6,6 +6,7 @@
 #include "StringType.hpp"
 #include "BytesType.hpp"
 #include "hash_table_layout.hpp"
+#include "PyInstance.hpp"
 
 thread_local const char* nativepython_cur_exception_value = nullptr;
 
@@ -303,20 +304,139 @@ extern "C" {
         return floorresult;
     }
 
-    PyObject* nativepython_runtime_int_to_pyobj(int64_t i) {
+    // returns layout*
+    void *np_runtime_pyobj_to_typed(PyObject *obj, void* tgt, uint64_t tp) {
+        // tgt is a layout pointer
+        PyEnsureGilAcquired acquireTheGil;
+        PyInstance::copyConstructFromPythonInstance((Type *)tp, (instance_ptr)&tgt, obj, true);
+        // returns modified layout pointer
+        return tgt;
+    }
+
+    PyObject* np_runtime_to_pyobj(PyObject *obj, uint64_t tp) {
+        PyEnsureGilAcquired acquireTheGil;
+        return PyInstance::extractPythonObject((instance_ptr)&obj, (Type*)tp);
+    }
+
+    PyObject* np_runtime_int64_to_pyobj(int64_t i) {
+        return PyLong_FromLongLong(i);
+    }
+
+    PyObject* np_runtime_int32_to_pyobj(int32_t i) {
         return PyLong_FromLong(i);
     }
 
-    PyObject* nativepython_runtime_uint_to_pyobj(uint64_t u) {
+    PyObject* np_runtime_int16_to_pyobj(int16_t i) {
+        return PyLong_FromLong(i);
+    }
+
+    PyObject* np_runtime_int8_to_pyobj(int8_t i) {
+        return PyLong_FromLong(i);
+    }
+
+    PyObject* np_runtime_uint64_to_pyobj(uint64_t u) {
+        return PyLong_FromUnsignedLongLong(u);
+    }
+
+    PyObject* np_runtime_uint32_to_pyobj(uint32_t u) {
         return PyLong_FromUnsignedLong(u);
     }
 
-    int64_t nativepython_runtime_pyobj_to_int(PyObject* i) {
+    PyObject* np_runtime_uint16_to_pyobj(uint16_t u) {
+        return PyLong_FromUnsignedLong(u);
+    }
+
+    PyObject* np_runtime_uint8_to_pyobj(uint8_t u) {
+        return PyLong_FromUnsignedLong(u);
+    }
+
+    PyObject* np_runtime_float64_to_pyobj(double f) {
+        return PyFloat_FromDouble(f);
+    }
+
+    PyObject* np_runtime_float32_to_pyobj(float f) {
+        return PyFloat_FromDouble((double)f);
+    }
+
+    // C identifiers can ignore character 32 and onward, so shorten prefix to just "np_"
+    int64_t np_runtime_pyobj_to_int64(PyObject* i) {
         if (PyLong_Check(i)) {
-            return PyLong_AsLongLong(i);
+            return PyLong_AsLong(i);
         }
 
-        throw std::runtime_error("Couldn't convert to an int64.");
+        throw std::runtime_error("Couldn't convert to int64.");
+    }
+
+    int32_t np_runtime_pyobj_to_int32(PyObject* i) {
+        if (PyLong_Check(i)) {
+            return PyLong_AsLong(i);
+        }
+
+        throw std::runtime_error("Couldn't convert to int32.");
+    }
+
+    int16_t np_runtime_pyobj_to_int16(PyObject* i) {
+        if (PyLong_Check(i)) {
+            return PyLong_AsLong(i);
+        }
+
+        throw std::runtime_error("Couldn't convert to int16.");
+    }
+
+    int8_t np_runtime_pyobj_to_int8(PyObject* i) {
+        if (PyLong_Check(i)) {
+            return PyLong_AsLong(i);
+        }
+
+        throw std::runtime_error("Couldn't convert to int8.");
+    }
+
+    uint64_t np_runtime_pyobj_to_uint64(PyObject* i) {
+        if (PyLong_Check(i)) {
+            return PyLong_AsUnsignedLong(i);
+        }
+
+        throw std::runtime_error("Couldn't convert to uint64.");
+    }
+
+    uint32_t np_runtime_pyobj_to_uint32(PyObject* i) {
+        if (PyLong_Check(i)) {
+            return PyLong_AsUnsignedLong(i);
+        }
+
+        throw std::runtime_error("Couldn't convert to uint32.");
+    }
+
+    uint16_t np_runtime_pyobj_to_uint16(PyObject* i) {
+        if (PyLong_Check(i)) {
+            return PyLong_AsUnsignedLong(i);
+        }
+
+        throw std::runtime_error("Couldn't convert to uint16.");
+    }
+
+    uint8_t np_runtime_pyobj_to_uint8(PyObject* i) {
+        if (PyLong_Check(i)) {
+            return PyLong_AsUnsignedLong(i);
+        }
+
+        throw std::runtime_error("Couldn't convert to uint8.");
+    }
+
+    double np_runtime_pyobj_to_float64(PyObject* o) {
+        if (PyFloat_Check(o)) {
+            return PyFloat_AsDouble(o);
+        }
+
+        throw std::runtime_error("Couldn't convert to float64.");
+    }
+
+    float np_runtime_pyobj_to_float32(PyObject* o) {
+        if (PyFloat_Check(o)) {
+            return (float)PyFloat_AsDouble(o);
+        }
+
+        throw std::runtime_error("Couldn't convert to float32.");
     }
 
     void nativepython_print_string(StringType::layout* layout) {

--- a/typed_python/_runtime.cpp
+++ b/typed_python/_runtime.cpp
@@ -305,7 +305,7 @@ extern "C" {
     }
 
     // returns layout*
-    void *np_runtime_pyobj_to_typed(PyObject *obj, void* tgt, uint64_t tp) {
+    void *np_runtime_pyobj_to_typed(PyObject *obj, uint8_t* tgt, Type* tp) {
         // tgt is a layout pointer
         PyEnsureGilAcquired acquireTheGil;
         PyInstance::copyConstructFromPythonInstance((Type *)tp, (instance_ptr)&tgt, obj, true);

--- a/typed_python/_runtime.cpp
+++ b/typed_python/_runtime.cpp
@@ -140,10 +140,10 @@ extern "C" {
         return Py_None;
     }
 
-    StringType::layout* nativepython_runtime_repr(PyObject* inst, Type* tp) {
+    StringType::layout* nativepython_runtime_repr(instance_ptr inst, Type* tp) {
         PyEnsureGilAcquired getTheGil;
 
-        PyObject* o = PyInstance::extractPythonObject((instance_ptr)&inst, (Type*)tp);
+        PyObject* o = PyInstance::extractPythonObject(inst, tp);
         if (!o) {
             PyErr_PrintEx(0);
             throw std::runtime_error("failed to extract python object");
@@ -158,10 +158,10 @@ extern "C" {
         return StringType::createFromUtf8(c, s);
     }
 
-    StringType::layout* nativepython_runtime_str(PyObject* inst, Type* tp) {
+    StringType::layout* nativepython_runtime_str(instance_ptr inst, Type* tp) {
         PyEnsureGilAcquired getTheGil;
 
-        PyObject* o = PyInstance::extractPythonObject((instance_ptr)&inst, (Type*)tp);
+        PyObject* o = PyInstance::extractPythonObject(inst, tp);
         if (!o) {
             PyErr_PrintEx(0);
             throw std::runtime_error("failed to extract python object");

--- a/typed_python/_runtime.cpp
+++ b/typed_python/_runtime.cpp
@@ -140,6 +140,42 @@ extern "C" {
         return Py_None;
     }
 
+    StringType::layout* nativepython_runtime_repr(PyObject* inst, Type* tp) {
+        PyEnsureGilAcquired getTheGil;
+
+        PyObject* o = PyInstance::extractPythonObject((instance_ptr)&inst, (Type*)tp);
+        if (!o) {
+            PyErr_PrintEx(0);
+            throw std::runtime_error("failed to extract python object");
+        }
+        PyObject *r = PyObject_Repr(o);
+        if (!r) {
+            PyErr_PrintEx(0);
+            throw std::runtime_error("PyObject_Repr returned 0");
+        }
+        Py_ssize_t s;
+        const char* c = PyUnicode_AsUTF8AndSize(r, &s);
+        return StringType::createFromUtf8(c, s);
+    }
+
+    StringType::layout* nativepython_runtime_str(PyObject* inst, Type* tp) {
+        PyEnsureGilAcquired getTheGil;
+
+        PyObject* o = PyInstance::extractPythonObject((instance_ptr)&inst, (Type*)tp);
+        if (!o) {
+            PyErr_PrintEx(0);
+            throw std::runtime_error("failed to extract python object");
+        }
+        PyObject *r = PyObject_Str(o);
+        if (!r) {
+            PyErr_PrintEx(0);
+            throw std::runtime_error("PyObject_Str returned 0");
+        }
+        Py_ssize_t s;
+        const char* c = PyUnicode_AsUTF8AndSize(r, &s);
+        return StringType::createFromUtf8(c, s);
+    }
+
     PyObject* nativepython_runtime_getattr_pyobj(PyObject* p, const char* a) {
         PyEnsureGilAcquired getTheGil;
 
@@ -305,7 +341,7 @@ extern "C" {
     }
 
     // returns layout*
-    void *np_runtime_pyobj_to_typed(PyObject *obj, uint8_t* tgt, Type* tp) {
+    uint8_t *np_runtime_pyobj_to_typed(PyObject *obj, uint8_t* tgt, Type* tp) {
         // tgt is a layout pointer
         PyEnsureGilAcquired acquireTheGil;
         PyInstance::copyConstructFromPythonInstance((Type *)tp, (instance_ptr)&tgt, obj, true);

--- a/typed_python/_types.cpp
+++ b/typed_python/_types.cpp
@@ -1452,6 +1452,17 @@ PyObject *MakeAlternativeType(PyObject* nullValue, PyObject* args, PyObject* kwa
         ));
 }
 
+PyObject *getTypePointer(PyObject* nullValue, PyObject* args) {
+    if (PyTuple_Size(args) != 1 || !PyInstance::unwrapTypeArgToTypePtr(PyTuple_GetItem(args,0))) {
+        PyErr_SetString(PyExc_TypeError, "getTypePointer takes 1 positional argument (a type)");
+        return NULL;
+    }
+
+    Type* type = PyInstance::unwrapTypeArgToTypePtr(PyTuple_GetItem(args,0));
+
+    return PyLong_FromLong((uint64_t)type);
+}
+
 static PyMethodDef module_methods[] = {
     {"NoneType", (PyCFunction)MakeNoneType, METH_VARARGS, NULL},
     {"Bool", (PyCFunction)MakeBoolType, METH_VARARGS, NULL},
@@ -1505,6 +1516,7 @@ static PyMethodDef module_methods[] = {
     {"refcount", (PyCFunction)refcount, METH_VARARGS, NULL},
     {"cpp_tests", (PyCFunction)cpp_tests, METH_VARARGS, NULL},
     {"getOrSetTypeResolver", (PyCFunction)getOrSetTypeResolver, METH_VARARGS, NULL},
+    {"getTypePointer", (PyCFunction)getTypePointer, METH_VARARGS, NULL},
     {NULL, NULL}
 };
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Motivation and Context
Improve scope of compilation with ability to convert typed-python types to object.
Allow bytes literals.
Allow repr() and str() on typed python Classes.

## Approach
This uses the approach of passing a raw type pointer (Type*) to identify the type. (Not the getOrSetTypeResolver as mentioned in #167.)

## How Has This Been Tested?
Back and forth conversions produce same value.
Bytes literals are used in compiled functions.
repr() and str() work on typed python Classes with custom __repr__ or __str__.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.