### PR TITLE
Provide conversions to bool for many types. Refs #210, #209, #212.

### DIFF
--- a/nativepython/expression_conversion_context.py
+++ b/nativepython/expression_conversion_context.py
@@ -787,7 +787,7 @@ class ExpressionConversionContext(object):
 
             return pythonObjectRepresentation(self, "").convert_method_call("join", (items_to_join,), {})
 
-        raise ConversionException("can't handle python expression type %s" % ast._which)
+        raise ConversionException("can't handle python expression type %s" % ast.Name)
 
     def getTypePointer(self, t):
         """Return a raw type pointer for type t

--- a/nativepython/python_object_representation.py
+++ b/nativepython/python_object_representation.py
@@ -108,7 +108,6 @@ def _typedPythonTypeToTypeWrapper(t):
         return DictWrapper(t)
 
     if t.__typed_python_category__ == "ConcreteAlternative":
-        print(t, type(t))
         return makeAlternativeWrapper(t)
 
     if t.__typed_python_category__ == "NamedTuple":

--- a/nativepython/tests/alternative_compilation_test.py
+++ b/nativepython/tests/alternative_compilation_test.py
@@ -158,3 +158,56 @@ class TestAlternativeCompilation(unittest.TestCase):
         self.assertEqual(sum, sumCompiled)
         speedup = (t1-t0)/(t2-t1)
         self.assertGreater(speedup, 20)  # I get about 50
+
+    def test_compile_alternative_magic_methods(self):
+        A = Alternative("A", a={'a': int}, b={'b': str},
+                        extramethod=lambda self: self.Name,
+                        __bool__=lambda self: False,
+                        __str__=lambda self: "my str",
+                        __repr__=lambda self: "my repr",
+                        __call__=lambda self: "my call",
+                        __len__=lambda self: 42,
+                        __contains__=lambda self, item: not not item,
+
+                        __add__=lambda lhs, rhs: A.b("add"),
+                        __sub__=lambda lhs, rhs: A.b("sub"),
+                        __mul__=lambda lhs, rhs: A.b("mul"),
+                        __matmul__=lambda lhs, rhs: A.b("matmul"),
+                        __truediv__=lambda lhs, rhs: A.b("truediv"),
+                        __floordiv__=lambda lhs, rhs: A.b("floordiv"),
+                        __mod__=lambda lhs, rhs: A.b("mod"),
+                        __divmod=lambda lhs, rhs: A.b("divmod"),
+                        __pow__=lambda lhs, rhs: A.b("pow"),
+                        __lshift__=lambda lhs, rhs: A.b("lshift"),
+                        __rshift__=lambda lhs, rhs: A.b("rshift"),
+                        __and__=lambda lhs, rhs: A.b("and"),
+                        )
+
+        def f_bool(x: A):
+            return bool(x)
+
+        def f_str(x: A):
+            return str(x)
+
+        def f_repr(x: A):
+            return repr(x)
+
+        def f_call(x: A):
+            return x()
+
+        def f_in(x: A):
+            return 1 in x
+
+        def f_len(x: A):
+            return len(x)
+
+        def f_add(x: A):
+            return x + A.a()
+
+        test_cases = [f_bool, f_str, f_repr]
+        # failing_test_cases = [f_call, f_in, f_len, f_add]
+        for f in test_cases:
+            compiled_f = Compiled(f)
+            r1 = f(A.a())
+            r2 = compiled_f(A.a())
+            self.assertEqual(r1, r2)

--- a/nativepython/tests/conversion_test.py
+++ b/nativepython/tests/conversion_test.py
@@ -89,8 +89,11 @@ class TestCompilationStructures(unittest.TestCase):
             return x and y and z
 
         self.assertEqual(f(0, 1, "s"), False)
-        with self.assertRaises(TypeError):
-            f(1, 1, "s")
+        # former behavior was to error on the conversion of "s" to bool
+        # with self.assertRaises(TypeError):
+        #    f(1, 1, "s")
+        # but this is treated as an explicit conversion, so "s" converts to True
+        self.assertEqual(f(1, 1, "s"), True)
 
     def test_object_to_int_conversion(self):
         @Compiled

--- a/nativepython/tests/string_compilation_test.py
+++ b/nativepython/tests/string_compilation_test.py
@@ -12,10 +12,13 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-from typed_python import Function, ListOf, _types, TupleOf, Dict, ConstDict
+from typed_python import _types, Function, ListOf, TupleOf, NamedTuple, Dict, ConstDict, OneOf, \
+    Int64, Int32, Int16, Int8, UInt64, UInt32, UInt16, UInt8, Bool, Float64, Float32, \
+    String, Bytes, Alternative, Set
 from typed_python.test_util import currentMemUsageMb
 from nativepython.runtime import Runtime
 import unittest
+import pytest
 
 
 def Compiled(f):
@@ -578,3 +581,85 @@ class TestStringCompilation(unittest.TestCase):
 
         with self.assertRaisesRegex(Exception, "not_valid"):
             f()
+
+    @pytest.mark.skip(reason="not implemented yet")
+    @unittest.skip
+    def test_string_from_various_types(self):
+        NT1 = NamedTuple(a=int, b=float, c=str, d=str)
+        NT2 = NamedTuple(s=String, t=TupleOf(int))
+        Alt1 = Alternative("Alt1", X={'a': int}, Y={'b': str})
+        cases = [
+            (Bool, True),
+            (Float64, 1.0/7.0),  # verify number of digits in string representation
+            (Float64, 8.0/7.0),  # verify number of digits in string representation
+            (Float64, 71.0/7.0),  # verify number of digits in string representation
+            (Float64, 0.123456789),
+            (Float64, 1.23456789),
+            (Float64, 12.3456789),
+            (Float64, 1.0),  # verify trailing zeros in string representation of float
+            (Float64, 2**32),  # verify trailing zeros in string representation of float
+            (Float64, 2**64),  # verify trailing zeros in string representation of float
+            (Float64, 1.8e19),  # verify trailing zeros in string representation of float
+            (Float64, 1e16),  # verify exp transition in string representation of float
+            (Float64, 1e16-2),  # verify exp transition in string representation of float
+            (Float64, 1e16+2),  # verify exp transition in string representation of float
+            (Float64, -1.0/7.0),  # verify number of digits in string representation
+            (Float64, -8.0/7.0),  # verify number of digits in string representation
+            (Float64, -71.0/7.0),  # verify number of digits in string representation
+            (Float64, -0.123456789),
+            (Float64, -1.23456789),
+            (Float64, -12.3456789),
+            (Float64, -1.0),  # verify trailing zeros in string representation of float
+            (Float64, -2**32),  # verify trailing zeros in string representation of float
+            (Float64, -2**64),  # verify trailing zeros in string representation of float
+            (Float64, -1.8e19),  # verify trailing zeros in string representation of float
+            (Float64, -1e16),  # verify exp transition in string representation of float
+            (Float64, -1e16-2),  # verify exp transition in string representation of float
+            (Float64, -1e16+2),  # verify exp transition in string representation of float
+            (Alt1, Alt1.X(a=-1)),
+            (Alt1, Alt1.Y(b='yes')),
+            (Float32, 1.234),
+            (int, 3),
+            (int, -2**63),
+            (Bool, True),
+            (Int8, -128),
+            (Int16, -32768),
+            (Int32, -2**31),
+            (UInt8, 127),
+            (UInt16, 65535),
+            (UInt32, 2**32-1),
+            (UInt64, 2**64-1),
+            (Float32, 1.234567),
+            (Float32, 1.234),
+            (String, "abcd"),
+            (Bytes, b"\01\00\02\03"),
+            (Set(int), [1, 3, 5, 7]),
+            (TupleOf(Int64), (7, 6, 5, 4, 3, 2, -1)),
+            (TupleOf(Int32), (7, 6, 5, 4, 3, 2, -2)),
+            (TupleOf(Int16), (7, 6, 5, 4, 3, 2, -3)),
+            (TupleOf(Int8), (7, 6, 5, 4, 3, 2, -4)),
+            (TupleOf(UInt64), (7, 6, 5, 4, 3, 2, 1)),
+            (TupleOf(UInt32), (7, 6, 5, 4, 3, 2, 2)),
+            (TupleOf(UInt16), (7, 6, 5, 4, 3, 2, 3)),
+            (TupleOf(UInt8), (7, 6, 5, 4, 3, 2, 4)),
+            (TupleOf(str), ("a", "b", "c")),
+            (ListOf(str), ["a", "b", "d"]),
+            (Dict(str, int), {'y': 7, 'n': 6}),
+            (ConstDict(str, int), {'y': 2, 'n': 4}),
+            (TupleOf(int), tuple(range(10000))),
+            (OneOf(String, Int64), "ab"),
+            (OneOf(String, Int64), 34),
+            (NT1, NT1(a=1, b=2.3, c="c", d="d")),
+            (NT2, NT2(s="xyz", t=tuple(range(10000))))
+        ]
+
+        for T, v in cases:
+            @Compiled
+            def toString(f: T):
+                return str(f)
+
+            a1 = toString(v)
+            a2 = str(T(v))
+            if a1 != a2:
+                print("mismatch")
+            # self.assertEqual(toString(v), str(T(v)))

--- a/nativepython/type_wrappers/arithmetic_wrapper.py
+++ b/nativepython/type_wrappers/arithmetic_wrapper.py
@@ -175,9 +175,15 @@ class IntWrapper(ArithmeticTypeWrapper):
                         runtime_functions.int64_to_string.call(e.nonref_expr).cast(strRef.expr_type.layoutType)
                     )
                 )
+            elif self.typeRepresentation == UInt64:
+                strForm = context.push(
+                    str,
+                    lambda strRef: strRef.expr.store(
+                        runtime_functions.uint64_to_string.call(e.nonref_expr).cast(strRef.expr_type.layoutType)
+                    )
+                )
             else:
                 suffix = {
-                    UInt64: 'u64',
                     Int32: 'i32',
                     UInt32: 'u32',
                     Int16: 'i16',
@@ -186,7 +192,7 @@ class IntWrapper(ArithmeticTypeWrapper):
                     UInt8: 'u8'
                 }[self.typeRepresentation]
 
-                strForm = e.convert_to_type(int).convert_to_type(str) + context.constant(suffix)
+                strForm = e.convert_to_type(Int64).convert_to_type(str) + context.constant(suffix)
 
             targetVal.convert_copy_initialize(strForm)
             return context.constant(True)
@@ -395,6 +401,32 @@ class BoolWrapper(ArithmeticTypeWrapper):
                 )
             )
             return context.constant(True)
+
+        # elif target_type.typeRepresentation == String:
+        #     #if not e.isReference:
+        #     #    e = context.push(e.expr_type, lambda x: x.convert_copy_initialize(e))
+        #     strForm = context.pushPod(
+        #         String,
+        #         lambda strRef: strRef.expr.store(
+        #             runtime_functions.int64_to_string.call(e.nonref_expr).cast(strRef.expr_type.layoutType)
+        #         )
+        #     )
+        #     targetVal.convert_copy_initialize(strForm)
+        #     #targetVal.convert_copy_initialize(context.constant('TRUE'))
+        #     # context.pushEffect(
+        #         # native_ast.Expression.Branch(
+        #         #     cond=e.nonref_expr,
+        #         #     true=targetVal.expr.store(context.constant('TRUE').nonref_expr),
+        #         #     false=targetVal.expr.store(context.constant('FALSE').nonref_expr)
+        #         # targetVal.expr.store(
+        #         #     native_ast.Expression.Branch(
+        #         #         cond=e.nonref_expr,
+        #         #         true=context.constant('TRUE').nonref_expr),
+        #         #         false=context.constant('FALSE').nonref_expr
+        #         #     )
+        #     #     targetVal.expr.store(context.constant('TRUE').nonref_expr)
+        #     # )
+        #     return context.constant(True)
 
         return super().convert_to_type_with_target(context, e, targetVal, explicit)
 

--- a/nativepython/type_wrappers/bound_compiled_method_wrapper.py
+++ b/nativepython/type_wrappers/bound_compiled_method_wrapper.py
@@ -15,6 +15,7 @@
 from nativepython.type_wrappers.wrapper import Wrapper
 
 import nativepython
+from typed_python import Bool
 
 typeWrapper = lambda x: nativepython.python_object_representation.typedPythonTypeToTypeWrapper(x)
 
@@ -53,3 +54,19 @@ class BoundCompiledMethodWrapper(Wrapper):
             args,
             kwargs
         )
+
+    def convert_to_type_with_target(self, context, e, targetVal, explicit):
+        if not explicit:
+            return super().convert_to_type_with_target(context, e, targetVal, explicit)
+
+        target_type = targetVal.expr_type
+
+        if target_type.typeRepresentation == Bool:
+            context.pushEffect(
+                targetVal.expr.store(
+                    context.constant(True)
+                )
+            )
+            return context.constant(True)
+
+        return super().convert_to_type_with_target(context, e, targetVal, explicit)

--- a/nativepython/type_wrappers/bound_method_wrapper.py
+++ b/nativepython/type_wrappers/bound_method_wrapper.py
@@ -16,6 +16,7 @@ from nativepython.type_wrappers.wrapper import Wrapper
 
 import nativepython.native_ast as native_ast
 import nativepython
+from typed_python import Bool
 
 typeWrapper = lambda x: nativepython.python_object_representation.typedPythonTypeToTypeWrapper(x)
 
@@ -59,3 +60,19 @@ class BoundMethodWrapper(Wrapper):
             (left.changeType(clsType),) + tuple(args),
             kwargs
         )
+
+    def convert_to_type_with_target(self, context, e, targetVal, explicit):
+        if not explicit:
+            return super().convert_to_type_with_target(context, e, targetVal, explicit)
+
+        target_type = targetVal.expr_type
+
+        if target_type.typeRepresentation == Bool:
+            context.pushEffect(
+                targetVal.expr.store(
+                    context.constant(True)
+                )
+            )
+            return context.constant(True)
+
+        return super().convert_to_type_with_target(context, e, targetVal, explicit)

--- a/nativepython/type_wrappers/bytes_wrapper.py
+++ b/nativepython/type_wrappers/bytes_wrapper.py
@@ -15,7 +15,7 @@
 from nativepython.type_wrappers.refcounted_wrapper import RefcountedWrapper
 import nativepython.type_wrappers.runtime_functions as runtime_functions
 
-from typed_python import Bytes, Int32
+from typed_python import Bytes, Int32, Bool
 
 import nativepython.native_ast as native_ast
 import nativepython
@@ -146,3 +146,19 @@ class BytesWrapper(RefcountedWrapper):
                 ).cast(self.layoutType)
             )
         )
+
+    def convert_to_type_with_target(self, context, e, targetVal, explicit):
+        if not explicit:
+            return super().convert_to_type_with_target(context, e, targetVal, explicit)
+
+        target_type = targetVal.expr_type
+
+        if target_type.typeRepresentation == Bool:
+            context.pushEffect(
+                targetVal.expr.store(
+                    self.convert_len_native(e.nonref_expr).neq(0)
+                )
+            )
+            return context.constant(True)
+
+        return super().convert_to_type_with_target(context, e, targetVal, explicit)

--- a/nativepython/type_wrappers/dict_wrapper.py
+++ b/nativepython/type_wrappers/dict_wrapper.py
@@ -18,7 +18,7 @@ import nativepython.type_wrappers.runtime_functions as runtime_functions
 from nativepython.type_wrappers.bound_compiled_method_wrapper import BoundCompiledMethodWrapper
 from nativepython.type_wrappers.wrapper import Wrapper
 from nativepython.type_wrappers.compilable_builtin import CompilableBuiltin
-from typed_python import NoneType, Tuple, PointerTo, Int32, Int64, UInt8
+from typed_python import NoneType, Tuple, PointerTo, Int32, Int64, UInt8, Bool
 
 import nativepython.native_ast as native_ast
 import nativepython
@@ -585,6 +585,22 @@ class DictWrapper(DictWrapperBase):
             runtime_functions.free.call(inst.nonref_expr.ElementPtrIntegers(0, 6).load().cast(native_ast.UInt8Ptr)) >>
             runtime_functions.free.call(inst.nonref_expr.cast(native_ast.UInt8Ptr))
         )
+
+    def convert_to_type_with_target(self, context, e, targetVal, explicit):
+        if not explicit:
+            return super().convert_to_type_with_target(context, e, targetVal, explicit)
+
+        target_type = targetVal.expr_type
+
+        if target_type.typeRepresentation == Bool:
+            context.pushEffect(
+                targetVal.expr.store(
+                    self.convert_len_native(e.nonref_expr).neq(0)
+                )
+            )
+            return context.constant(True)
+
+        return super().convert_to_type_with_target(context, e, targetVal, explicit)
 
 
 class DictMakeIteratorWrapper(DictWrapperBase):

--- a/nativepython/type_wrappers/none_wrapper.py
+++ b/nativepython/type_wrappers/none_wrapper.py
@@ -13,7 +13,7 @@
 #   limitations under the License.
 
 from nativepython.type_wrappers.wrapper import Wrapper
-from typed_python import NoneType, Int32
+from typed_python import NoneType, Int32, Bool
 import nativepython.native_ast as native_ast
 
 
@@ -59,3 +59,19 @@ class NoneWrapper(Wrapper):
                 return context.constant(False)
 
         return super().convert_bin_op(context, left, op, right)
+
+    def convert_to_type_with_target(self, context, e, targetVal, explicit):
+        if not explicit:
+            return super().convert_to_type_with_target(context, e, targetVal, explicit)
+
+        target_type = targetVal.expr_type
+
+        if target_type.typeRepresentation == Bool:
+            context.pushEffect(
+                targetVal.expr.store(
+                    context.constant(False)
+                )
+            )
+            return context.constant(True)
+
+        return super().convert_to_type_with_target(context, e, targetVal, explicit)

--- a/nativepython/type_wrappers/python_object_of_type_wrapper.py
+++ b/nativepython/type_wrappers/python_object_of_type_wrapper.py
@@ -13,7 +13,7 @@
 #   limitations under the License.
 
 from nativepython.type_wrappers.wrapper import Wrapper
-from typed_python import Int64, Int32, Int16, Int8, UInt64, UInt32, UInt16, UInt8, Float32, Float64
+from typed_python import Int64, Int32, Int16, Int8, UInt64, UInt32, UInt16, UInt8, Float32, Float64, Bool
 from nativepython.typed_expression import TypedExpression
 
 import nativepython.native_ast as native_ast
@@ -99,7 +99,8 @@ class PythonObjectOfTypeWrapper(Wrapper):
             UInt16: runtime_functions.pyobj_to_uint16,
             UInt8: runtime_functions.pyobj_to_uint8,
             Float64: runtime_functions.pyobj_to_float64,
-            Float32: runtime_functions.pyobj_to_float32
+            Float32: runtime_functions.pyobj_to_float32,
+            Bool: runtime_functions.pyobj_to_bool
         }
 
         t = target_type.typeRepresentation

--- a/nativepython/type_wrappers/runtime_functions.py
+++ b/nativepython/type_wrappers/runtime_functions.py
@@ -174,6 +174,13 @@ pyobj_to_typed = externalCallTarget(
     UInt64
 )
 
+instance_to_bool = externalCallTarget(
+    "np_runtime_instance_to_bool",
+    Bool,
+    Void.pointer(),
+    UInt64,
+)
+
 to_pyobj = externalCallTarget(
     "np_runtime_to_pyobj",
     Void.pointer(),
@@ -298,6 +305,12 @@ pyobj_to_float64 = externalCallTarget(
 pyobj_to_float32 = externalCallTarget(
     "np_runtime_pyobj_to_float32",
     Float32,
+    Void.pointer()
+)
+
+pyobj_to_bool = externalCallTarget(
+    "np_runtime_pyobj_to_bool",
+    Bool,
     Void.pointer()
 )
 
@@ -477,6 +490,12 @@ print_string = externalCallTarget(
 
 int64_to_string = externalCallTarget(
     "nativepython_int64_to_string",
+    Void.pointer(),
+    Int64
+)
+
+uint64_to_string = externalCallTarget(
+    "nativepython_uint64_to_string",
     Void.pointer(),
     Int64
 )

--- a/nativepython/type_wrappers/set_wrapper.py
+++ b/nativepython/type_wrappers/set_wrapper.py
@@ -15,7 +15,7 @@
 from nativepython.type_wrappers.refcounted_wrapper import RefcountedWrapper
 from nativepython.typed_expression import TypedExpression
 import nativepython.type_wrappers.runtime_functions as runtime_functions
-from typed_python import NoneType
+from typed_python import NoneType, Bool
 
 import nativepython.native_ast as native_ast
 import nativepython
@@ -115,3 +115,19 @@ class SetWrapper(SetWrapperBase):
             runtime_functions.free.call(inst.nonref_expr.ElementPtrIntegers(0, 6).load().cast(native_ast.UInt8Ptr)) >>
             runtime_functions.free.call(inst.nonref_expr.cast(native_ast.UInt8Ptr))
         )
+
+    def convert_to_type_with_target(self, context, e, targetVal, explicit):
+        if not explicit:
+            return super().convert_to_type_with_target(context, e, targetVal, explicit)
+
+        target_type = targetVal.expr_type
+
+        if target_type.typeRepresentation == Bool:
+            context.pushEffect(
+                targetVal.expr.store(
+                    self.convert_len_native(e.nonref_expr).neq(0)
+                )
+            )
+            return context.constant(True)
+
+        return super().convert_to_type_with_target(context, e, targetVal, explicit)

--- a/nativepython/type_wrappers/string_wrapper.py
+++ b/nativepython/type_wrappers/string_wrapper.py
@@ -336,3 +336,19 @@ class StringWrapper(RefcountedWrapper):
             return context.constant(True)
 
         return super().convert_to_self_with_target(context, targetVal, sourceVal, explicit)
+
+    def convert_to_type_with_target(self, context, e, targetVal, explicit):
+        if not explicit:
+            return super().convert_to_type_with_target(context, e, targetVal, explicit)
+
+        target_type = targetVal.expr_type
+
+        if target_type.typeRepresentation == Bool:
+            context.pushEffect(
+                targetVal.expr.store(
+                    self.convert_len_native(e.nonref_expr).neq(0)
+                )
+            )
+            return context.constant(True)
+
+        return super().convert_to_type_with_target(context, e, targetVal, explicit)

--- a/nativepython/type_wrappers/tuple_of_wrapper.py
+++ b/nativepython/type_wrappers/tuple_of_wrapper.py
@@ -16,8 +16,9 @@ from nativepython.type_wrappers.refcounted_wrapper import RefcountedWrapper
 from nativepython.type_wrappers.wrapper import Wrapper
 from nativepython.type_wrappers.exceptions import generateThrowException
 import nativepython.type_wrappers.runtime_functions as runtime_functions
+from nativepython.typed_expression import TypedExpression
 
-from typed_python import NoneType, Int32
+from typed_python import NoneType, Int32, Bool
 from nativepython.type_wrappers.util import min
 
 import nativepython.native_ast as native_ast
@@ -269,6 +270,8 @@ class TupleOrListOfWrapper(RefcountedWrapper):
         )
 
     def convert_len_native(self, expr):
+        if isinstance(expr, TypedExpression):
+            expr = expr.nonref_expr
         return native_ast.Expression.Branch(
             cond=expr,
             false=native_ast.const_int_expr(0),
@@ -294,6 +297,22 @@ class TupleOrListOfWrapper(RefcountedWrapper):
             return res
 
         return super().convert_method_call(context, instance, methodname, args, kwargs)
+
+    def convert_to_type_with_target(self, context, e, targetVal, explicit):
+        if not explicit:
+            return super().convert_to_type_with_target(context, e, targetVal, explicit)
+
+        target_type = targetVal.expr_type
+
+        if target_type.typeRepresentation == Bool:
+            context.pushEffect(
+                targetVal.expr.store(
+                    self.convert_len_native(e).neq(0)
+                )
+            )
+            return context.constant(True)
+
+        return super().convert_to_type_with_target(context, e, targetVal, explicit)
 
 
 class TupleOrListOfIteratorWrapper(Wrapper):

--- a/nativepython/type_wrappers/tuple_wrapper.py
+++ b/nativepython/type_wrappers/tuple_wrapper.py
@@ -14,7 +14,7 @@
 
 from nativepython.type_wrappers.wrapper import Wrapper
 
-from typed_python import _types, Int32, OneOf
+from typed_python import _types, Int32, OneOf, Bool
 
 from nativepython.type_wrappers.bound_compiled_method_wrapper import BoundCompiledMethodWrapper
 import nativepython.native_ast as native_ast
@@ -141,6 +141,22 @@ class TupleWrapper(Wrapper):
 
     def get_iteration_expressions(self, context, expr):
         return [self.refAs(context, expr, i) for i in range(len(self.subTypeWrappers))]
+
+    def convert_to_type_with_target(self, context, e, targetVal, explicit):
+        if not explicit:
+            return super().convert_to_type_with_target(context, e, targetVal, explicit)
+
+        target_type = targetVal.expr_type
+
+        if target_type.typeRepresentation == Bool:
+            context.pushEffect(
+                targetVal.expr.store(
+                    context.constant(len(self.subTypeWrappers) != 0)
+                )
+            )
+            return context.constant(True)
+
+        return super().convert_to_type_with_target(context, e, targetVal, explicit)
 
 
 class NamedTupleWrapper(TupleWrapper):

--- a/nativepython/type_wrappers/wrapper.py
+++ b/nativepython/type_wrappers/wrapper.py
@@ -201,6 +201,8 @@ class Wrapper(object):
     def convert_repr(self, context, expr):
         tp = context.getTypePointer(expr.expr_type.typeRepresentation)
         if tp:
+            if not expr.isReference:
+                expr = context.push(expr.expr_type, lambda x: x.convert_copy_initialize(expr))
             return context.push(
                 str,
                 lambda r: r.expr.store(

--- a/object_database/server.py
+++ b/object_database/server.py
@@ -262,7 +262,7 @@ class Server:
     def dropConnection(self, channel):
         with self._lock:
             if channel not in self._clientChannels:
-                self._logger.warn('Tried to drop a nonexistant channel %s', channel)
+                self._logger.warning('Tried to drop a nonexistent channel %s', channel)
                 return
 
             connectedChannel = self._clientChannels[channel]

--- a/typed_python/PyAlternativeInstance.cpp
+++ b/typed_python/PyAlternativeInstance.cpp
@@ -417,3 +417,22 @@ int PyConcreteAlternativeInstance::pyInquiryConcrete(const char* op, const char*
     }
     return PyObject_IsTrue(p.second);
 }
+
+int PyConcreteAlternativeInstance::sq_contains_concrete(PyObject* item) {
+    std::pair<bool, PyObject*> p = callMethod("__contains__", item, nullptr);
+    if (!p.first) {
+        return 0;
+    }
+    return PyObject_IsTrue(p.second);
+}
+
+Py_ssize_t PyConcreteAlternativeInstance::mp_and_sq_length_concrete() {
+    std::pair<bool, PyObject*> p = callMethod("__len__", nullptr, nullptr);
+    if (!p.first) {
+        return 0;
+    }
+    if (!PyLong_Check(p.second)) {
+        return 0;
+    }
+    return PyLong_AsLong(p.second);
+}

--- a/typed_python/PyAlternativeInstance.hpp
+++ b/typed_python/PyAlternativeInstance.hpp
@@ -72,6 +72,10 @@ public:
 
     PyObject* tp_call_concrete(PyObject* args, PyObject* kwargs);
 
+    int sq_contains_concrete(PyObject* item);
+
+    Py_ssize_t mp_and_sq_length_concrete();
+
     static bool pyValCouldBeOfTypeConcrete(modeled_type* type, PyObject* pyRepresentation, bool isExplicit) {
         return extractTypeFrom(pyRepresentation->ob_type) == type;
     }

--- a/typed_python/PyAlternativeInstance.hpp
+++ b/typed_python/PyAlternativeInstance.hpp
@@ -62,6 +62,10 @@ public:
 
     PyObject* pyUnaryOperatorConcrete(const char* op, const char* opErr);
 
+    std::pair<bool, PyObject*> callMethod(const char* name, PyObject* arg0=nullptr, PyObject* arg1=nullptr);
+
+    int pyInquiryConcrete(const char* op, const char* opErrRep);
+
     PyObject* tp_getattr_concrete(PyObject* pyAttrName, const char* attrName);
 
     int tp_setattr_concrete(PyObject* attrName, PyObject* attrVal);

--- a/typed_python/PyBoundMethodInstance.cpp
+++ b/typed_python/PyBoundMethodInstance.cpp
@@ -59,3 +59,7 @@ void PyBoundMethodInstance::mirrorTypeInformationIntoPyTypeConcrete(BoundMethod*
 }
 
 
+int PyBoundMethodInstance::pyInquiryConcrete(const char* op, const char* opErrRep) {
+    // op == '__bool__'
+    return 1;
+}

--- a/typed_python/PyBoundMethodInstance.hpp
+++ b/typed_python/PyBoundMethodInstance.hpp
@@ -26,6 +26,8 @@ public:
 
     PyObject* tp_call_concrete(PyObject* args, PyObject* kwargs);
 
+    int pyInquiryConcrete(const char* op, const char* opErrRep);
+
     static void mirrorTypeInformationIntoPyTypeConcrete(BoundMethod* methodT, PyTypeObject* pyType);
 
     static bool pyValCouldBeOfTypeConcrete(modeled_type* type, PyObject* pyRepresentation, bool isExplicit) {

--- a/typed_python/PyClassInstance.cpp
+++ b/typed_python/PyClassInstance.cpp
@@ -155,6 +155,18 @@ PyObject* PyClassInstance::pyTernaryUnaryOperatorConcrete(PyObject* rhs, PyObjec
     return res.second;
 }
 
+int PyClassInstance::pyInquiryConcrete(const char* op, const char* opErrRep) {
+    // op == '__bool__'
+    std::pair<bool, PyObject*> p = callMemberFunction("__bool__", nullptr, nullptr);
+    if (!p.first) {
+        p = callMemberFunction("__len__", nullptr, nullptr);
+        // if neither __bool__ nor __len__ is available, return True
+        if (!p.first)
+            return 1;
+    }
+    return PyObject_IsTrue(p.second);
+}
+
 std::pair<bool, PyObject*> PyClassInstance::callMemberFunction(const char* name, PyObject* arg0, PyObject* arg1) {
     auto it = type()->getMemberFunctions().find(name);
 

--- a/typed_python/PyClassInstance.hpp
+++ b/typed_python/PyClassInstance.hpp
@@ -52,6 +52,8 @@ public:
 
     PyObject* pyTernaryUnaryOperatorConcrete(PyObject* rhs, PyObject* ternaryArg, const char* op, const char* opErr);
 
+    int pyInquiryConcrete(const char* op, const char* opErrRep);
+
     static void mirrorTypeInformationIntoPyTypeConcrete(Class* classT, PyTypeObject* pyType);
 
     int tp_setattr_concrete(PyObject* attrName, PyObject* attrVal);

--- a/typed_python/PyCompositeTypeInstance.cpp
+++ b/typed_python/PyCompositeTypeInstance.cpp
@@ -75,6 +75,11 @@ Py_ssize_t PyCompositeTypeInstance::mp_and_sq_length_concrete() {
     return type()->getTypes().size();
 }
 
+int PyCompositeTypeInstance::pyInquiryConcrete(const char* op, const char* opErrRep) {
+    // op == '__bool__'
+    return type()->getTypes().size() != 0;
+}
+
 void PyNamedTupleInstance::copyConstructFromPythonInstanceConcrete(NamedTuple* namedTupleT, instance_ptr tgt, PyObject* pyRepresentation, bool isExplicit) {
     if (PyDict_Check(pyRepresentation)) {
         if (namedTupleT->getTypes().size() < PyDict_Size(pyRepresentation)) {

--- a/typed_python/PyCompositeTypeInstance.hpp
+++ b/typed_python/PyCompositeTypeInstance.hpp
@@ -92,6 +92,8 @@ public:
     static bool pyValCouldBeOfTypeConcrete(modeled_type* type, PyObject* pyRepresentation, bool isExplicit) {
         return PyTuple_Check(pyRepresentation) || PyList_Check(pyRepresentation) || PyDict_Check(pyRepresentation);
     }
+
+    int pyInquiryConcrete(const char* op, const char* opErrRep);
 };
 
 class PyTupleInstance : public PyCompositeTypeInstance {

--- a/typed_python/PyConstDictInstance.cpp
+++ b/typed_python/PyConstDictInstance.cpp
@@ -372,5 +372,7 @@ bool PyConstDictInstance::compare_to_python_concrete(ConstDictType* dictType, in
     return true;
 }
 
-
-
+int PyConstDictInstance::pyInquiryConcrete(const char* op, const char* opErrRep) {
+    // op == '__bool__'
+    return type()->size(dataPtr()) != 0;
+}

--- a/typed_python/PyConstDictInstance.hpp
+++ b/typed_python/PyConstDictInstance.hpp
@@ -34,6 +34,8 @@ public:
 
     PyObject* pyOperatorConcrete(PyObject* rhs, const char* op, const char* opErr);
 
+    int pyInquiryConcrete(const char* op, const char* opErrRep);
+
     PyObject* mp_subscript_concrete(PyObject* item);
 
     static PyObject* constDictItems(PyObject *o);

--- a/typed_python/PyDictInstance.cpp
+++ b/typed_python/PyDictInstance.cpp
@@ -457,3 +457,8 @@ PyObject* PyDictInstance::setDefault(PyObject* o, PyObject* args) {
 
     });
 }
+
+int PyDictInstance::pyInquiryConcrete(const char* op, const char* opErrRep) {
+    // op == '__bool__'
+    return type()->size(dataPtr()) != 0;
+}

--- a/typed_python/PyDictInstance.hpp
+++ b/typed_python/PyDictInstance.hpp
@@ -34,6 +34,8 @@ public:
 
     PyObject* pyOperatorConcrete(PyObject* rhs, const char* op, const char* opErr);
 
+    int pyInquiryConcrete(const char* op, const char* opErrRep);
+
     PyObject* mp_subscript_concrete(PyObject* item);
 
     int mp_ass_subscript_concrete(PyObject* item, PyObject* value);
@@ -74,6 +76,3 @@ public:
      */
     static PyObject* setDefault(PyObject* o, PyObject* args);
 };
-
-
-

--- a/typed_python/PyFunctionInstance.cpp
+++ b/typed_python/PyFunctionInstance.cpp
@@ -401,3 +401,8 @@ void PyFunctionInstance::mirrorTypeInformationIntoPyTypeConcrete(Function* inTyp
             overloads
             );
 }
+
+int PyFunctionInstance::pyInquiryConcrete(const char* op, const char* opErrRep) {
+    // op == '__bool__'
+    return 1;
+}

--- a/typed_python/PyFunctionInstance.hpp
+++ b/typed_python/PyFunctionInstance.hpp
@@ -55,4 +55,6 @@ public:
     static std::string argTupleTypeDescription(PyObject* args, PyObject* kwargs);
 
     static void mirrorTypeInformationIntoPyTypeConcrete(Function* inType, PyTypeObject* pyType);
+
+    int pyInquiryConcrete(const char* op, const char* opErrRep);
 };

--- a/typed_python/PyInstance.hpp
+++ b/typed_python/PyInstance.hpp
@@ -359,6 +359,8 @@ public:
 
     static PyObject* pyTernaryOperator(PyObject* lhs, PyObject* rhs, PyObject* ternary, const char* op, const char* opErrRep);
 
+    static int pyInquiry(PyObject* lhs, const char* op, const char* opErrRep);
+
     PyObject* pyUnaryOperatorConcrete(const char* op, const char* opErrRep);
 
     PyObject* pyOperatorConcrete(PyObject* rhs, const char* op, const char* opErrRep);
@@ -366,6 +368,8 @@ public:
     PyObject* pyOperatorConcreteReverse(PyObject* lhs, const char* op, const char* opErrRep);
 
     PyObject* pyTernaryOperatorConcrete(PyObject* rhs, PyObject* third, const char* op, const char* opErrRep);
+
+    int pyInquiryConcrete(const char* op, const char* opErrRep);
 
     static PyObject* nb_inplace_add(PyObject* lhs, PyObject* rhs);
 
@@ -410,6 +414,8 @@ public:
     static PyObject* nb_int(PyObject* lhs);
 
     static PyObject* nb_float(PyObject* lhs);
+
+    static int nb_bool(PyObject* lhs);
 
     static PyObject* nb_index(PyObject* lhs);
 

--- a/typed_python/PyPythonSubclassInstance.hpp
+++ b/typed_python/PyPythonSubclassInstance.hpp
@@ -66,8 +66,11 @@ public:
         return specializeForTypeReturningSizeT((PyObject*)this, [&](auto& subtype) {
             return subtype.mp_and_sq_length_concrete();
         }, type()->getBaseType());
-
     }
 
+    int pyInquiryConcrete(const char* op, const char* opErrRep) {
+        // op == '__bool__'
+        return 1;
+    }
 };
 

--- a/typed_python/PyRegisterTypeInstance.hpp
+++ b/typed_python/PyRegisterTypeInstance.hpp
@@ -616,6 +616,11 @@ public:
         return NULL;
     }
 
+    int pyInquiryConcrete(const char* op, const char* opErrRep) {
+        // op == '__bool__'
+        return (*(T*)dataPtr() != 0);
+    }
+
     PyObject* pyUnaryOperatorConcrete(const char* op, const char* opErr) {
         if (strcmp(op, "__float__") == 0) {
             return PyFloat_FromDouble(*(T*)dataPtr());

--- a/typed_python/PySetInstance.cpp
+++ b/typed_python/PySetInstance.cpp
@@ -549,3 +549,8 @@ void PySetInstance::copyConstructFromPythonInstanceConcrete(SetType* setType, in
 
     PyInstance::copyConstructFromPythonInstanceConcrete(setType, tgt, pyRepresentation, isExplicit);
 }
+
+int PySetInstance::pyInquiryConcrete(const char* op, const char* opErrRep) {
+    // op == '__bool__'
+    return type()->size(dataPtr()) != 0;
+}

--- a/typed_python/PySetInstance.hpp
+++ b/typed_python/PySetInstance.hpp
@@ -46,6 +46,7 @@ class PySetInstance : public PyInstance {
                                            bool isExplicit) {
         return true;
     }
+    int pyInquiryConcrete(const char* op, const char* opErrRep);
 
   private:
     static int try_insert_key(PySetInstance* self, PyObject* pyKey, instance_ptr key);

--- a/typed_python/PyTupleOrListOfInstance.cpp
+++ b/typed_python/PyTupleOrListOfInstance.cpp
@@ -886,3 +886,7 @@ void PyTupleOrListOfInstance::mirrorTypeInformationIntoPyTypeConcrete(TupleOrLis
         );
 }
 
+int PyTupleOrListOfInstance::pyInquiryConcrete(const char* op, const char* opErrRep) {
+    // op == '__bool__'
+    return type()->count(dataPtr()) != 0;
+}

--- a/typed_python/PyTupleOrListOfInstance.hpp
+++ b/typed_python/PyTupleOrListOfInstance.hpp
@@ -34,6 +34,8 @@ public:
 
     PyObject* pyOperatorConcrete(PyObject* rhs, const char* op, const char* opErr);
 
+    int pyInquiryConcrete(const char* op, const char* opErrRep);
+
     PyObject* pyOperatorAdd(PyObject* rhs, const char* op, const char* opErr, bool reversed);
 
     PyObject* pyOperatorConcreteReverse(PyObject* lhs, const char* op, const char* opErrRep);

--- a/typed_python/RegisterTypes.hpp
+++ b/typed_python/RegisterTypes.hpp
@@ -15,6 +15,7 @@
 ******************************************************************************/
 
 #pragma once
+#include <iomanip>
 
 #include "Type.hpp"
 
@@ -230,7 +231,7 @@ public:
     }
 
     void repr(instance_ptr self, ReprAccumulator& stream) {
-        stream << *(float*)self << "f32";
+        stream << std::fixed << std::setprecision(5) << *(float*)self << "f32";
     }
 
     static Float32* Make() { static Float32* res = new Float32(); return res; }
@@ -244,7 +245,8 @@ public:
     }
 
     void repr(instance_ptr self, ReprAccumulator& stream) {
-        stream << *(double*)self;
+        // this is never actually called
+        stream << std::fixed << std::setprecision(16) << *(double*)self;
     }
 
     static Float64* Make() { static Float64* res = new Float64(); return res; }

--- a/typed_python/types_test.py
+++ b/typed_python/types_test.py
@@ -945,6 +945,52 @@ class NativeTypesTests(unittest.TestCase):
         self.assertEqual(alt.x_0().f(), 1)
         self.assertEqual(str(alt.x_0()), "not_your_usual_str")
 
+    def test_alternative_magic_methods(self):
+        A = Alternative("A", a={'a': int}, b={'b': str},
+                        __bool__=lambda self: False,
+                        __str__=lambda self: "str",
+                        __repr__=lambda self: "repr",
+                        __call__=lambda self: "call",
+                        __len__=lambda self: 42,
+                        __contains__=lambda self, item: not not item,
+
+                        __add__=lambda lhs, rhs: A.b("add"),
+                        __sub__=lambda lhs, rhs: A.b("sub"),
+                        __mul__=lambda lhs, rhs: A.b("mul"),
+                        __matmul__=lambda lhs, rhs: A.b("matmul"),
+                        __truediv__=lambda lhs, rhs: A.b("truediv"),
+                        __floordiv__=lambda lhs, rhs: A.b("floordiv"),
+                        __mod__=lambda lhs, rhs: A.b("mod"),
+                        __divmod=lambda lhs, rhs: A.b("divmod"),
+                        __pow__=lambda lhs, rhs: A.b("pow"),
+                        __lshift__=lambda lhs, rhs: A.b("lshift"),
+                        __rshift__=lambda lhs, rhs: A.b("rshift"),
+                        __and__=lambda lhs, rhs: A.b("and"),
+                        )
+        self.assertEqual(A.a().__bool__(), False)
+        self.assertEqual(bool(A.a()), False)
+        self.assertEqual(A.a().__str__(), "str")
+        self.assertEqual(str(A.a()), "str")
+        self.assertEqual(A.a().__repr__(), "repr")
+        self.assertEqual(repr(A.a()), "repr")
+        self.assertEqual(A.a().__call__(), "call")
+        self.assertEqual(A.a()(), "call")
+        self.assertEqual(A.a().__contains__(0), False)
+        self.assertEqual(A.a().__contains__(1), True)
+        self.assertEqual(0 in A.a(), False)
+        self.assertEqual(1 in A.a(), True)
+        self.assertEqual(A.a().__len__(), 42)
+        self.assertEqual(len(A.a()), 42)
+
+        self.assertEqual(A.a().__add__(A.a()).Name, "b")
+        self.assertEqual(A.a().__add__(A.a()).b, "add")
+        self.assertEqual((A.a() + A.a()).Name, "b")
+        self.assertEqual((A.a() + A.a()).b, "add")
+        self.assertEqual(A.a().__sub__(A.a()).Name, "b")
+        self.assertEqual(A.a().__sub__(A.a()).b, "sub")
+        self.assertEqual((A.a() - A.a()).Name, "b")
+        self.assertEqual((A.a() - A.a()).b, "sub")
+
     def test_named_tuple_subclass_magic_methods(self):
         class X(NamedTuple(x=int, y=int)):
             def __str__(self):


### PR DESCRIPTION
## Motivation and Context
* Provide bool conversion functionality.

## Approach
* Conversions to bool for most types, interpreted and compiled.
    * including Classes with __bool__ or __len__ methods
    * including Alternatives with __bool__ or __len__ methods
* Conversions to bool for any object.
* When compiling, consistently check that expression is a reference before treating it as an instance pointer.
* Also fix some string conversions:
    * Avoid buffer overflow in nativepython_int64_to_string.
    * Provide suitable uint64 conversion to string.
* and some cosmetic changes

<!-- Provide a general summary of your changes in the Title above -->


<!-- Why is this change required? -->
<!-- What problem does it solve? -->
<!--  If it fixes an open issue, please link to the issue here.-->

<!-- Describe your changes in reasonable detail -->

## How Has This Been Tested?
* Compare direct bool() with compiled bool and SpecializedEntrypoint
* Note there is a failing case (outer_specialized_bool) in python_obect_of_type_compilation_test.py that warrants further investigation.


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.