### PR TITLE
Refactoring component render framework

### DIFF
--- a/object_database/web/content/components/AsyncDropdown.js
+++ b/object_database/web/content/components/AsyncDropdown.js
@@ -32,7 +32,7 @@ class AsyncDropdown extends Component {
         this.makeContent = this.makeContent.bind(this);
     }
 
-    render(){
+    build(){
         return (
             h('div', {
                 id: this.props.id,

--- a/object_database/web/content/components/Badge.js
+++ b/object_database/web/content/components/Badge.js
@@ -24,7 +24,7 @@ class Badge extends Component {
         this.makeInner = this.makeInner.bind(this);
     }
 
-    render(){
+    build(){
         return(
             h('span', {
                 class: `cell badge badge-${this.props.extraData.badgeStyle}`,

--- a/object_database/web/content/components/Button.js
+++ b/object_database/web/content/components/Button.js
@@ -27,7 +27,7 @@ class Button extends Component {
         this._getHTMLClasses = this._getHTMLClasses.bind(this);
     }
 
-    render(){
+    build(){
         return(
             h('button', {
                 id: this.props.id,

--- a/object_database/web/content/components/ButtonGroup.js
+++ b/object_database/web/content/components/ButtonGroup.js
@@ -26,7 +26,7 @@ class ButtonGroup extends Component {
         this.makeButtons = this.makeButtons.bind(this);
     }
 
-    render(){
+    build(){
         return(
             h('div', {
                 id: this.props.id,

--- a/object_database/web/content/components/Card.js
+++ b/object_database/web/content/components/Card.js
@@ -30,7 +30,7 @@ class Card extends Component {
         this.makeHeader = this.makeHeader.bind(this);
     }
 
-    render(){
+    build(){
         let bodyClass = "card-body";
         if(this.props.extraData.padding){
             bodyClass = `card-body p-${this.props.extraData.padding}`;

--- a/object_database/web/content/components/CardTitle.js
+++ b/object_database/web/content/components/CardTitle.js
@@ -27,7 +27,7 @@ class CardTitle extends Component {
         this.makeInner = this.makeInner.bind(this);
     }
 
-    render(){
+    build(){
         return(
             h('div', {
                 id: this.props.id,

--- a/object_database/web/content/components/CircleLoader.js
+++ b/object_database/web/content/components/CircleLoader.js
@@ -11,7 +11,7 @@ class CircleLoader extends Component {
         super(props, ...args);
     }
 
-    render(){
+    build(){
         return (
             h('div', {
                 id: this.props.id,

--- a/object_database/web/content/components/Clickable.js
+++ b/object_database/web/content/components/Clickable.js
@@ -28,7 +28,7 @@ class Clickable extends Component {
         this._getEvent = this._getEvent.bind(this);
     }
 
-    render(){
+    build(){
         return(
             h('div', {
                 id: this.props.id,

--- a/object_database/web/content/components/Code.js
+++ b/object_database/web/content/components/Code.js
@@ -26,7 +26,7 @@ class Code extends Component {
         this.makeCode = this.makeCode.bind(this);
     }
 
-    render(){
+    build(){
         return h('pre',
                  {
                      class: "cell code",

--- a/object_database/web/content/components/CodeEditor.js
+++ b/object_database/web/content/components/CodeEditor.js
@@ -61,7 +61,7 @@ class CodeEditor extends Component {
         }
     }
 
-    render(){
+    build(){
         return h('div',
             {
                 class: "cell h-100",

--- a/object_database/web/content/components/CollapsiblePanel.js
+++ b/object_database/web/content/components/CollapsiblePanel.js
@@ -30,7 +30,7 @@ class CollapsiblePanel extends Component {
         this.makeContent = this.makeContent.bind(this);
     }
 
-    render(){
+    build(){
         if(this.props.extraData.isExpanded){
             return(
                 h('div', {

--- a/object_database/web/content/components/Columns.js
+++ b/object_database/web/content/components/Columns.js
@@ -26,7 +26,7 @@ class Columns extends Component {
         this.makeInnerChildren = this.makeInnerChildren.bind(this);
     }
 
-    render(){
+    build(){
         return (
             h('div', {
                 class: "cell container-fluid",

--- a/object_database/web/content/components/Component.js
+++ b/object_database/web/content/components/Component.js
@@ -55,12 +55,25 @@ class Component {
         this._recursivelyMapNamedChildren = this._recursivelyMapNamedChildren.bind(this);
     }
 
-    render(){
+    build(){
         // Objects that extend from
         // me should override this
-        // method in order to generate
+        // method in order to build
         // some content for the vdom
-        throw new Error('You must implement a `render` method on Component objects!');
+        throw new Error('You must implement a `build` method on Component objects!');
+    }
+
+    /**
+     * I first call the component build()
+     * to generate the v-dom/hyperscript element. Then
+     * alter it if necessary and return the hyperscript.
+     * Instead of calling a render() directly on the
+     * subclassed components themselves I provide the option for
+     * global/component-wide changes before the final rendering.
+    */
+    render() {
+        let velement = this.build()
+        return velement;
     }
 
     /**

--- a/object_database/web/content/components/Container.js
+++ b/object_database/web/content/components/Container.js
@@ -26,7 +26,7 @@ class Container extends Component {
         this.makeChild = this.makeChild.bind(this);
     }
 
-    render(){
+    build(){
         let child = this.makeChild();
         let style = "";
         if(!child){

--- a/object_database/web/content/components/ContextualDisplay.js
+++ b/object_database/web/content/components/ContextualDisplay.js
@@ -26,7 +26,7 @@ class ContextualDisplay extends Component {
         this.makeChild = this.makeChild.bind(this);
     }
 
-    render(){
+    build(){
         return h('div',
             {
                 class: "cell contextualDisplay",

--- a/object_database/web/content/components/Dropdown.js
+++ b/object_database/web/content/components/Dropdown.js
@@ -33,7 +33,7 @@ class Dropdown extends Component {
         this.makeItems = this.makeItems.bind(this);
     }
 
-    render(){
+    build(){
         return (
             h('div', {
                 id: this.props.id,
@@ -115,7 +115,7 @@ class DropdownItem extends Component {
         this.clickHandler = this.clickHandler.bind(this);
     }
 
-    render(){
+    build(){
         return (
             h('a', {
                 class: "subcell cell-dropdown-item dropdown-item",

--- a/object_database/web/content/components/Expands.js
+++ b/object_database/web/content/components/Expands.js
@@ -42,7 +42,7 @@ class Expands extends Component {
         this._getEvents = this._getEvent.bind(this);
     }
 
-    render(){
+    build(){
         return(
             h('div', {
                 id: this.props.id,

--- a/object_database/web/content/components/Grid.js
+++ b/object_database/web/content/components/Grid.js
@@ -39,7 +39,7 @@ class Grid extends Component {
         this._makeReplacementRowElements = this._makeReplacementRowElements.bind(this);
     }
 
-    render(){
+    build(){
         let topTableHeader = null;
         if(this.props.extraData.hasTopHeader){
             topTableHeader = h('th');

--- a/object_database/web/content/components/HeaderBar.js
+++ b/object_database/web/content/components/HeaderBar.js
@@ -33,7 +33,7 @@ class HeaderBar extends Component {
         this.makeCenter = this.makeCenter.bind(this);
     }
 
-    render(){
+    build(){
         return (
             h('div', {
                 id: this.props.id,

--- a/object_database/web/content/components/HorizontalSequence.js
+++ b/object_database/web/content/components/HorizontalSequence.js
@@ -29,7 +29,7 @@ class HorizontalSequence extends Component {
         this.makeElements = this.makeElements.bind(this);
     }
 
-    render(){
+    build(){
         return (
             h('div', {
                 id: this.props.id,

--- a/object_database/web/content/components/KeyAction.js
+++ b/object_database/web/content/components/KeyAction.js
@@ -23,7 +23,7 @@ class KeyAction extends Component {
         this.registerKeyAction();
     }
 
-    render(){
+    build(){
         // This is a non-display cell
         // and does not add any elements
         // to the DOM.

--- a/object_database/web/content/components/LargePendingDownloadDisplay.js
+++ b/object_database/web/content/components/LargePendingDownloadDisplay.js
@@ -10,7 +10,7 @@ class LargePendingDownloadDisplay extends Component {
         super(props, ...args);
     }
 
-    render(){
+    build(){
         return (
             h('div', {
                 id: 'object_database_large_pending_download_text',

--- a/object_database/web/content/components/LoadContentsFromUrl.js
+++ b/object_database/web/content/components/LoadContentsFromUrl.js
@@ -10,7 +10,7 @@ class LoadContentsFromUrl extends Component {
         super(props, ...args);
     }
 
-    render(){
+    build(){
         return(
             h('div', {
                 id: this.props.id,

--- a/object_database/web/content/components/Main.js
+++ b/object_database/web/content/components/Main.js
@@ -26,7 +26,7 @@ class Main extends Component {
         this.makeChild = this.makeChild.bind(this);
     }
 
-    render(){
+    build(){
         return (
             h('main', {
                 id: this.props.id,

--- a/object_database/web/content/components/Modal.js
+++ b/object_database/web/content/components/Modal.js
@@ -35,7 +35,7 @@ class Modal extends Component {
         this.makeClasses = this.makeClasses.bind(this);
     }
 
-    render(){
+    build(){
         return (
             h('div', {
                 id: this.props.id,

--- a/object_database/web/content/components/Octicon.js
+++ b/object_database/web/content/components/Octicon.js
@@ -18,7 +18,7 @@ class Octicon extends Component {
         this._getHTMLClasses = this._getHTMLClasses.bind(this);
     }
 
-    render(){
+    build(){
         return(
             h('span', {
                 class: this._getHTMLClasses(),

--- a/object_database/web/content/components/Padding.js
+++ b/object_database/web/content/components/Padding.js
@@ -10,7 +10,7 @@ class Padding extends Component {
         super(props, ...args);
     }
 
-    render(){
+    build(){
         return (
             h('span', {
                 id: this.props.id,

--- a/object_database/web/content/components/PageView.js
+++ b/object_database/web/content/components/PageView.js
@@ -32,7 +32,7 @@ class PageView extends Component {
         this.makeFooter = this.makeFooter.bind(this);
     }
 
-    render(){
+    build(){
         return h('div', {
             id: this.props.id,
             'data-cell-id': this.props.id,

--- a/object_database/web/content/components/Plot.js
+++ b/object_database/web/content/components/Plot.js
@@ -34,7 +34,7 @@ class Plot extends Component {
         this.setupPlot();
     }
 
-    render(){
+    build(){
         return (
             h('div', {
                 id: this.props.id,

--- a/object_database/web/content/components/Popover.js
+++ b/object_database/web/content/components/Popover.js
@@ -31,7 +31,7 @@ class Popover extends Component {
         this.makeDetail = this.makeDetail.bind(this);
     }
 
-    render(){
+    build(){
         return h('div',
             {
                 class: "cell popover-cell",

--- a/object_database/web/content/components/ResizablePanel.js
+++ b/object_database/web/content/components/ResizablePanel.js
@@ -72,7 +72,8 @@ class ResizablePanel extends Component {
         }
         return (
             h('div', {
-                class: 'resizable-panel-item'
+                class: 'resizable-panel-item',
+                'data-resizable-panel-item-id': `panel-item-${this.props.id}`
             }, [inner])
         );
     }
@@ -84,9 +85,12 @@ class ResizablePanel extends Component {
         } else {
             inner = this.renderChildNamed('second');
         }
+        // Our panel items must be uniquely identifiable in order to properly insert
+        // the resize splitter. See the .afterCreate().
         return (
             h('div', {
-                class: 'resizable-panel-item'
+                class: 'resizable-panel-item',
+                'data-resizable-panel-item-id': `panel-item-${this.props.id}`
             }, [inner])
         );
     }
@@ -108,11 +112,9 @@ class ResizablePanel extends Component {
         let reverseDirection = 'horizontal';
         if(this.props.extraData.split == 'horizontal'){
             reverseDirection = 'vertical';
-        } else if(this.props.extraData.split == 'vertical'){
-            reverseDirection = 'horizontal';
         }
-        element._splitter = Split(
-            element.querySelectorAll('.resizable-panel-item'),
+        element._splitter = new Split(
+            element.querySelectorAll(`div[data-resizable-panel-item-id=panel-item-${this.props.id}]`),
             {
                 direction: reverseDirection
             }

--- a/object_database/web/content/components/ResizablePanel.js
+++ b/object_database/web/content/components/ResizablePanel.js
@@ -41,7 +41,7 @@ class ResizablePanel extends Component {
         this.afterDestroyed = this.afterDestroyed.bind(this);
     }
 
-    render(){
+    build(){
         let classString = "";
         if(this.props.extraData.split == 'vertical'){
             classString = " horizontal-panel";

--- a/object_database/web/content/components/RootCell.js
+++ b/object_database/web/content/components/RootCell.js
@@ -26,7 +26,7 @@ class RootCell extends Component {
         this.makeChild = this.makeChild.bind(this);
     }
 
-    render(){
+    build(){
         return (
             h('div', {
                 id: this.props.id,

--- a/object_database/web/content/components/Scrollable.js
+++ b/object_database/web/content/components/Scrollable.js
@@ -27,7 +27,7 @@ class Scrollable extends Component {
         this.makeChild = this.makeChild.bind(this);
     }
 
-    render(){
+    build(){
         let style = "";
         if (this.props.extraData.height){
             style = "height:" + this.props.extraData.height;

--- a/object_database/web/content/components/Sequence.js
+++ b/object_database/web/content/components/Sequence.js
@@ -30,7 +30,7 @@ class Sequence extends Component {
         this.makeElements = this.makeElements.bind(this);
     }
 
-    render(){
+    build(){
         return (
             h('div', {
                 id: this.props.id,

--- a/object_database/web/content/components/Sheet.js
+++ b/object_database/web/content/components/Sheet.js
@@ -54,7 +54,7 @@ class Sheet extends Component {
         }));
     }
 
-    render(){
+    build(){
         console.log(`Rendering sheet ${this.props.id}`);
         return (
             h('div', {

--- a/object_database/web/content/components/SingleLineTextBox.js
+++ b/object_database/web/content/components/SingleLineTextBox.js
@@ -13,7 +13,7 @@ class SingleLineTextBox extends Component {
         this.changeHandler = this.changeHandler.bind(this);
     }
 
-    render(){
+    build(){
         let attrs =
             {
                 class: "cell",

--- a/object_database/web/content/components/Span.js
+++ b/object_database/web/content/components/Span.js
@@ -11,7 +11,7 @@ class Span extends Component {
         super(props, ...args);
     }
 
-    render(){
+    build(){
         return (
             h('span', {
                 id: this.props.id,

--- a/object_database/web/content/components/SplitView.js
+++ b/object_database/web/content/components/SplitView.js
@@ -34,7 +34,7 @@ class SplitView extends Component {
         this.makeChildElements = this.makeChildElements.bind(this);
     }
 
-    render(){
+    build(){
         return (
             h('div', {
                 id: this.props.id,

--- a/object_database/web/content/components/Subscribed.js
+++ b/object_database/web/content/components/Subscribed.js
@@ -26,7 +26,7 @@ class Subscribed extends Component {
         this.makeContent = this.makeContent.bind(this);
     }
 
-    render(){
+    build(){
         return h('div',
             {
                 class: "cell subscribed",

--- a/object_database/web/content/components/SubscribedSequence.js
+++ b/object_database/web/content/components/SubscribedSequence.js
@@ -29,7 +29,7 @@ class SubscribedSequence extends Component {
         this._makeReplacementChildren = this._makeReplacementChildren.bind(this);
     }
 
-    render(){
+    build(){
         return h('div',
             {
                 class: this.makeClass(),

--- a/object_database/web/content/components/Table.js
+++ b/object_database/web/content/components/Table.js
@@ -46,7 +46,7 @@ class Table extends Component {
         this._getRowDisplayElements = this._getRowDisplayElements.bind(this);
     }
 
-    render(){
+    build(){
         return(
             h('table', {
                 id: this.props.id,

--- a/object_database/web/content/components/Tabs.js
+++ b/object_database/web/content/components/Tabs.js
@@ -34,7 +34,7 @@ class Tabs extends Component {
         this.makeDisplay = this.makeDisplay.bind(this);
     }
 
-    render(){
+    build(){
         return (
             h('div', {
                 id: this.props.id,

--- a/object_database/web/content/components/Text.js
+++ b/object_database/web/content/components/Text.js
@@ -12,7 +12,7 @@ class Text extends Component {
         this.style = "color:" + this.props.textColor;
     }
 
-    render(){
+    build(){
         return(
             h('div', {
                 class: "cell",

--- a/object_database/web/content/components/Timestamp.js
+++ b/object_database/web/content/components/Timestamp.js
@@ -32,7 +32,7 @@ class Timestamp extends Component {
         this.getMilliseconds = this.getMilliseconds.bind(this);
     }
 
-    render(){
+    build(){
         return h('span',
             {
                 class: "cell",

--- a/object_database/web/content/components/Traceback.js
+++ b/object_database/web/content/components/Traceback.js
@@ -25,7 +25,7 @@ class  Traceback extends Component {
         this.makeTraceback = this.makeTraceback.bind(this);
     }
 
-    render(){
+    build(){
         return (
             h('div', {
                 id: this.props.id,

--- a/object_database/web/content/components/_NavTab.js
+++ b/object_database/web/content/components/_NavTab.js
@@ -31,7 +31,7 @@ class _NavTab extends Component {
         this.clickHandler = this.clickHandler.bind(this);
     }
 
-    render(){
+    build(){
         let innerClass = "nav-link";
         if(this.props.extraData.isActive){
             innerClass += " active";

--- a/object_database/web/content/components/_PlotUpdater.js
+++ b/object_database/web/content/components/_PlotUpdater.js
@@ -39,7 +39,7 @@ class _PlotUpdater extends Component {
         this.componentDidLoad();
     }
 
-    render(){
+    build(){
         return h('div',
             {
                 class: "cell",

--- a/object_database/web/content/components/tests/component-tests.js
+++ b/object_database/web/content/components/tests/component-tests.js
@@ -14,7 +14,7 @@ class SubComponent extends Component {
         super(props, ...args);
     }
 
-    render(){
+    build(){
         return (
             h('div', {id: this.props.id}, [`Child: ${this.props.id}`])
         );
@@ -88,6 +88,17 @@ describe("Base Component Class", () => {
             assert.equal('SubComponent', instance.name);
         });
     });
+
+    describe('Base Component Rendering', () => {
+        it('#can render basic', () => {
+            let component = new SubComponent({id: 'component'});
+            let result = component.render();
+            assert.exists(result);
+            assert.equal(result.properties.id, 'component');
+        });
+    });
+
+    /*TODO: add test for more advanced rendering when ready*/
 
     describe('Base Component Children Utilities', () => {
         it('#renderedChildren provides hyperscripts for children', () => {


### PR DESCRIPTION
## Motivation and Context
The `render()` method of `Component` subclasses is now available only in the base class itself. This allows us to easily and globally control the way components (parents and children) are styled, which in turn allows us to better model the syntax-implied styling from the server/python side as well as make quicker adjustments. 

## How Has This Been Tested?
Relevant JS tests have been added and pass. 


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Refactoring
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.