### PR TITLE
Some PyPi packaging scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,8 @@ object_database/web/content/dist
 /.coverage*
 /.tox
 /.env
+/pip-wheel-metadata
+/dist/
 
 # don't need the package lock for this sub-pipenv.
 object_database/web/content/package-lock.json

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -1,6 +1,19 @@
 ## Development ##
 There are several methods for building and setting up a development environment.
-  
+
+### Makefile Method (Recommended) ###
+The included Makefile in this repository contains recipes for building, installing,
+and testing.
+
+You can configure your virtual environment and install all the dependencies simply
+by running `make install`.
+
+For the moment, it is explicitly linked to a specific Python interpreter,
+so if you are using, say, an interpreter called `python3.6` (as opposed to `python3`),
+you will need to change the `PYTHON` variable at the top of the Makefile.
+
+You can also customize the name and location of any built virtual environments with the `VIRTUAL_ENV` variable.
+
 ### Manual Method ###
 1. Create a new virtualenv with Python 3.6 (`virtualenv --python=<path-to-py3> venv`) and source it
 2. Install requirements via pip. For the moment there are two options:
@@ -8,26 +21,40 @@ There are several methods for building and setting up a development environment.
    * Install using Pipenv (which reads from the Pipfile)
 3. Build nativepython libraries using `python setup.py build`
 4. Append the root of this repository to your `PYTHONPATH`
-  
+
 ### Pipenv Method ###
 This method is simple, and can take care of virtual environment creation and installation for you.
-1. (Optional) Create a new virtualenv with Python 3.6 (`virtualenv --python=<path-to-py3> venv`) and source it. If you choose to use Pipenv alone, it will create an appropriate virtualenv for you.
+1. (Optional) Create a new virtualenv with Python 3.6
+   (`virtualenv --python=<path-to-py3> venv`) and source it.
+   If you choose to use Pipenv alone, it will create an appropriate virtualenv for you.
 2. Run `pipenv install --dev --deploy`
-  
-### Makefile Method ###
-The included Makefile in this repository contains recipes for building, installing, and testing. For the moment, it is explicitly linked to a specific Python interpreter, so if you are using, say, an interpreter called `python3.6` (as opposed to `python3`), you will need to change the `PYTHON` variable at the top of the Makefile.
-  
-You can also customize the name and location of any built virtual environments with the `VIRTUAL_ENV` variable.
 
 
-## Installation ##
+## Run the Tests ##
+Run `make test`.
+
+If you installed the dependencies using a method other than `Makefile` method,
+look at the test recipe for the commands to run.
+For the python tests, the main command is `pytest` from within any virtualenv
+you configured.
+
+You can select which tests to run with a regular expression using `pytest -k REGEX`
+
+
+## Installation Of system-level Requirements ##
+
+The requirements are python 3.6.x, Redis server, and a C/C++ toolchain.
 
 ### OSX ###
 
 #### Prerequisites ####
 * Python 3.6 (recommended installed with homebrew)
-  * Currently build is tested against `clang`, not `gcc`. For more information about installing `clang` and configuring your environment see [here](https://embeddedartistry.com/blog/2017/2/20/installing-clangllvm-on-osx)
-* It is recommended you use Pipenv ([see this link](https://pipenv.readthedocs.io/en/latest/install/#installing-pipenv)) to manage the application.
+  * Currently build is tested against `clang`, not `gcc`.
+    For more information about installing `clang` and configuring your environment
+    see [here](https://embeddedartistry.com/blog/2017/2/20/installing-clangllvm-on-osx)
+* It is recommended you use Pipenv
+  ([see this link](https://pipenv.readthedocs.io/en/latest/install/#installing-pipenv))
+  to manage the application.
   * You can also use virtualenv.
 * install Redis (`brew install redis`)
 
@@ -51,4 +78,3 @@ Before building the modules in this repository, you will need to make sure that 
   ```
 * Pipenv ([see this link](https://pipenv.readthedocs.io/en/latest/install/#installing-pipenv))
 * Redis Server (`redis-server`)
-

--- a/Makefile
+++ b/Makefile
@@ -124,11 +124,11 @@ unicodeprops: ./unicodeprops.py
 	$(PYTHON) ./unicodeprops.py > $(UNICODEPROPS)
 
 .PHONY: generatetesttypes
-generatetesttypes: $(DT_SRC_PATH)/generate_types.py
+generatetesttypes: $(VIRTUAL_ENV) $(DT_SRC_PATH)/generate_types.py
 	. $(VIRTUAL_ENV)/bin/activate; \
-	python3 $(DT_SRC_PATH)/generate_types.py --testTypes3 $(TESTTYPES)
+	python $(DT_SRC_PATH)/generate_types.py --testTypes3 $(TESTTYPES)
 	. $(VIRTUAL_ENV)/bin/activate; \
-	python3 $(DT_SRC_PATH)/generate_types.py --testTypes2 $(TESTTYPES2)
+	python $(DT_SRC_PATH)/generate_types.py --testTypes2 $(TESTTYPES2)
 
 .PHONY: clean
 clean:
@@ -142,6 +142,19 @@ clean:
 	rm -rf .nodeenv
 	rm -f object_database/web/content/dist/main.bundle.js
 	rm -f .coverage*
+	rm -rf dist/
+
+
+.PHONY: sdist
+sdist: $(VIRTUAL_ENV)
+	. $(VIRTUAL_ENV)/bin/activate; \
+	python setup.py sdist
+
+
+.PHONY: testpypi-upload
+testpypi-upload: $(VIRTUAL_ENV)
+	. $(VIRTUAL_ENV)/bin/activate; \
+	twine upload --repository-url https://test.pypi.org/legacy/  dist/*
 
 
 ##########################################################################

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ can still run in interpreter without compilation if you want.
 Nativepython is generously supported by [A Priori Investments](www.aprioriinvestments.com), a quantitative
 hedge fund in New York.  If you're interested in working with us, drop us a line at info@aprioriinvestments.com.
 
+
 ## Where did this come from?
 
 Every time I (Braxton) find myself writing a lot of  Python code, I eventually
@@ -45,6 +46,7 @@ choose, depending on the context, which style of code I want, from totally
 free-form Python with total type chaos, to statically typed, highly performant
 code, and anything in between.
 
+
 ## How does it work?
 
 We start with `typed_python`, which allows you to express the kinds of
@@ -62,7 +64,9 @@ unexpected value inside of it.
 We can also model the natural variation of types present in
 real python programs: for instance, you can say something like
 
-    ListOf(OneOf(None, str, TupleOf(int)))
+```python
+ListOf(OneOf(None, str, TupleOf(int)))
+```
 
 which is a list whose items must be `None`, strings, or tuples of integers.
 This  allows you to continue to write code in a style that's pythonic, where
@@ -72,12 +76,14 @@ the kinds of constraints you need to catch errors early.
 Separately, the `nativepython` module provides a compiler for functions that
 are expressed in terms of `typed_python` types.  For instance, if you write
 
-    @TypedFunction
-    def sum(l: ListOf(int)):
-        res = 0
-        for x in l:
-            res += x
-        return res
+```python
+@TypedFunction
+def sum(l: ListOf(int)):
+    res = 0
+    for x in l:
+        res += x
+    return res
+```
 
 the compiler can generate far more code efficient than a JIT compiler can, because
 it can _assume_ that the list contains integers. In fact, the internal memory representation
@@ -97,6 +103,7 @@ UndefinedNativepythonOperation Exception. In compiled code, we'll drop the
 bounds check entirely, which in some cases can be a significant performance
 improvement.
 
+
 ## How mature is the project?
 
 As of January 25th, 2019, I use `typed_python` and `object_database` daily in
@@ -105,9 +112,3 @@ is just now getting enough features to be useful.  It produces pretty good code,
 but most functions are still missing, and many optimizations remain.  Portions of the
 `object_database` api are likely to change substantially as we work through the
 best way to use it.
-
-## How do I run tests?
-
-Checkout the project and run `make install` from the root to install the necessary dependencies, then run `make test`.
-The first command will create a python virtualenv and install the necessary dependencies as well as compile the python extensions.
-You can filter tests with a regex using `pytest -k PAT`. from within the created virtualenv (`source .venv/bin/activate` to activate it).

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ extra_compile_args = [
     '-Wno-narrowing'
 ]
 
+
 ext_modules = [
     Extension(
         'object_database._types',
@@ -66,21 +67,27 @@ ext_modules = [
     )
 ]
 
+
 INSTALL_REQUIRES = [line.strip() for line in open('requirements.txt')]
+
+
+with open('README.md', "r") as f:
+    long_description = f.read()
+
 
 setuptools.setup(
     name='nativepython',
-    version='0.0.1',
+    version='0.0.1dev2',
     description='Tools for generating machine code using python.',
+    long_description=long_description,
+    long_description_content_type='text/markdown',
     author='Braxton Mckee',
     author_email='braxton.mckee@gmail.com',
     url='https://github.com/aprioriinvestments/nativepython',
     packages=setuptools.find_packages(),
     cmdclass={'build_ext': NumpyBuildExtension},
     ext_modules=ext_modules,
-    setup_requires=[
-        'numpy'
-    ],
+    setup_requires=['numpy'],
     install_requires=INSTALL_REQUIRES,
 
     # https://pypi.org/classifiers/
@@ -101,5 +108,6 @@ setuptools.setup(
     data_files=[
         ("", ["requirements.txt"]),
     ],
-    zip_safe=False
+    zip_safe=False,
+    python_requires='~=3.6',
 )

--- a/setup.py
+++ b/setup.py
@@ -28,86 +28,74 @@ class NumpyBuildExtension(build_ext):
 
     def run(self):
         self.include_dirs.append(
-            pkg_resources.resource_filename('numpy', 'core/include'))
+            pkg_resources.resource_filename("numpy", "core/include")
+        )
         build_ext.run(self)
 
 
 extra_compile_args = [
-    '-O2',
-    '-fstack-protector-strong',
-    '-Wformat',
-    '-Wdate-time',
-    '-Werror=format-security',
-    '-std=c++14',
-    '-Wno-sign-compare',
-    '-Wno-narrowing'
+    "-O2",
+    "-fstack-protector-strong",
+    "-Wformat",
+    "-Wdate-time",
+    "-Werror=format-security",
+    "-std=c++14",
+    "-Wno-sign-compare",
+    "-Wno-narrowing",
 ]
 
 
 ext_modules = [
     Extension(
-        'object_database._types',
-        sources=[
-            'object_database/all.cpp',
-        ],
-        define_macros=[
-            ("_FORTIFY_SOURCE", 2)
-        ],
-        extra_compile_args=extra_compile_args
+        "object_database._types",
+        sources=["object_database/all.cpp"],
+        define_macros=[("_FORTIFY_SOURCE", 2)],
+        extra_compile_args=extra_compile_args,
     ),
     Extension(
-        'typed_python._types',
-        sources=[
-            'typed_python/all.cpp',
-        ],
-        define_macros=[
-            ("_FORTIFY_SOURCE", 2)
-        ],
-        extra_compile_args=extra_compile_args
-    )
+        "typed_python._types",
+        sources=["typed_python/all.cpp"],
+        define_macros=[("_FORTIFY_SOURCE", 2)],
+        extra_compile_args=extra_compile_args,
+    ),
 ]
 
 
-INSTALL_REQUIRES = [line.strip() for line in open('requirements.txt')]
+INSTALL_REQUIRES = [line.strip() for line in open("requirements.txt")]
 
 
-with open('README.md', "r") as f:
+with open("README.md", "r") as f:
     long_description = f.read()
 
 
 setuptools.setup(
-    name='nativepython',
-    version='0.0.1dev2',
-    description='Tools for generating machine code using python.',
+    name="nativepython",
+    version="0.0.1dev2",
+    description="Tools for generating machine code using python.",
     long_description=long_description,
-    long_description_content_type='text/markdown',
-    author='Braxton Mckee',
-    author_email='braxton.mckee@gmail.com',
-    url='https://github.com/aprioriinvestments/nativepython',
+    long_description_content_type="text/markdown",
+    author="Braxton Mckee",
+    author_email="braxton.mckee@gmail.com",
+    url="https://github.com/aprioriinvestments/nativepython",
     packages=setuptools.find_packages(),
-    cmdclass={'build_ext': NumpyBuildExtension},
+    cmdclass={"build_ext": NumpyBuildExtension},
     ext_modules=ext_modules,
-    setup_requires=['numpy'],
+    setup_requires=["numpy"],
     install_requires=INSTALL_REQUIRES,
-
     # https://pypi.org/classifiers/
     classifiers=[
         "License :: OSI Approved :: Apache Software License",
         "Programming Language :: Python :: 3 :: Only",
     ],
-
     license="Apache Software License v2.0",
     entry_points={
-        'console_scripts': [
-            'object_database_webtest=object_database.frontends.object_database_webtest:main',
-            'object_database_service_manager=object_database.frontends.service_manager:main',
+        "console_scripts": [
+            "object_database_webtest=object_database.frontends.object_database_webtest:main",
+            "object_database_service_manager=object_database.frontends.service_manager:main",
         ]
     },
-
     include_package_data=True,
-    data_files=[
-        ("", ["requirements.txt"]),
-    ],
+    data_files=[("", ["requirements.txt"])],
     zip_safe=False,
-    python_requires='~=3.6',
+    python_requires="~=3.6",
 )


### PR DESCRIPTION
## Motivation and Context
We want to get ready to upload a `nativepython` package to pypi

## Approach
Figure out how to upload packages to `test.pypi` and try to install the package from there and use its functionality. For simplicity, we only provide source packages, which means that the user will have to compile them when `pip install`ing them. Otherwise we will have to provide different wheels for different target architectures.

* `make sdist` will create a distribution according to the version in `setup.py`.
* `make testpypi-upload` uploads the distributions under `/dist` created by the previous step to test.pypi. 

## How Has This Been Tested?
* https://test.pypi.org/project/nativepython/
* In a fresh docker container running ubuntu:18.04, installed python3, python3-pip, python3-virtualenv, created a virtual environment, successfully installed nativepython and manually tested in a REPL that I can import OneOf, create OneOf types, and create objects of those types.

The command used for installing the nativepython package from test.pypi was: 
```pip install --extra-index-url https://test.pypi.org/simple/  nativepython==0.0.1dev2```
