### PR TITLE
WIP: Run TravisCI tests on Python 3.6 & 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: xenial
+dist: bitonic  # ubuntu:18.04 LTS
 
 language: python
 
@@ -23,7 +23,7 @@ install:
 
 jobs:
   include:
-    - stage: "Tests"
+    - stage: test
       name: "Lint"
       script:
         - pipenv lock --dev --requirements > dev-reqs.txt
@@ -34,7 +34,8 @@ jobs:
       script:
         - pipenv check || (sleep 60; pipenv check) || (sleep 60; pipenv check)
 
-    - name: "Unit Tests"
+    - name: "Unit Tests (python 3.6)"
+      python: 3.6
       before_script:
         - ulimit -c unlimited -S       # enable core dumps
       script:
@@ -48,6 +49,26 @@ jobs:
         - coverage combine
       after_success:
         - codecov
+      after_failure:
+        - PYTHON_EXECUTABLE=$(python3 -c "import sys; print(sys.executable)")
+        - COREFILE=$(find . -maxdepth 1 -name "core*" | head -n 1) # find core file
+        - if [[ -f "$COREFILE" ]]; then
+              gdb -c "$COREFILE" $PYTHON_EXECUTABLE -ex "thread apply all bt" -ex "set pagination 0" -batch;
+          fi
+
+    - name: "Unit Tests (python 3.7)"
+      python: 3.7
+      before_script:
+        - ulimit -c unlimited -S       # enable core dumps
+      script:
+        - pipenv lock --requirements > reqs.txt
+        - pip install -r reqs.txt
+        - sudo apt-get install -y gdb  # install gdb
+        - make testcert.cert
+        - coverage erase
+        - pytest
+        - ls -la
+        - coverage combine
       after_failure:
         - PYTHON_EXECUTABLE=$(python3 -c "import sys; print(sys.executable)")
         - COREFILE=$(find . -maxdepth 1 -name "core*" | head -n 1) # find core file


### PR DESCRIPTION
## Motivation and Context
Because we rely on internal python implementation choices which could change between minor python versions, we should check against minor versions to be more confident our code works with them.

## Approach
Add a job in the `test` stage that is a replica of the job that runs the tests on Python 3.6, but to run tests on Python 3.7

## How Has This Been Tested?
On TravisCI. It looks like some tests fail on Python 3.7 (Hence the WIP status of the PR)
