### PR TITLE
Flexible Sequences

### DIFF
--- a/object_database/web/CellsTestService.py
+++ b/object_database/web/CellsTestService.py
@@ -127,7 +127,7 @@ def reload():
     import os
     os._exit(0)
 
-
+"""
 def selectionPanel(page):
     availableCells = cells.Scrollable(
         cells.Card(
@@ -150,3 +150,18 @@ def selectionPanel(page):
         (reloadInput, 1),
         (availableCells, 6)
     ], split="horizontal")
+"""
+
+def selectionPanel(page):
+    availableCells = []
+    for category in getPages().values():
+        for item in category.values():
+            displayName = "{}.{}".format(item.category(), item.name())
+            url = "CellsTestService?{}".format(
+                urllib.parse.urlencode(
+                    dict(category=item.category(), name=item.name())))
+            clickable = cells.Clickable(displayName, url, makeBold=item is page)
+            availableCells.append(clickable)
+    reloadInput = cells.Button(cells.Octicon("sync"), reload)
+
+    return cells.Sequence([reloadInput, cells.Flex(cells.Sequence(availableCells))])

--- a/object_database/web/cells/__init__.py
+++ b/object_database/web/cells/__init__.py
@@ -71,6 +71,8 @@ from object_database.web.cells.CellsTestMixin import CellsTestMixin
 
 from object_database.web.cells.util import waitForCellsCondition
 
+from object_database.web.cells.util import Flex, ShrinkWrap
+
 from object_database.web.cells.views.resizable_panel import ResizablePanel
 
 MAX_FPS = 10

--- a/object_database/web/cells/cells.py
+++ b/object_database/web/cells/cells.py
@@ -1126,12 +1126,19 @@ class Sequence(Cell):
         self.exportData['margin'] = self.margin
 
     def updateChildren(self):
+        newElements = []
+        for childCell in self.elements:
+            if childCell.isFlex:
+                self.isFlexParent = True
+                newElements.append(childCell)
+            elif isinstance(childCell, Sequence):
+                newElements += childCell.elements
+            else:
+                newElements.append(childCell)
+        self.elements = newElements
         self.children = {"____c_%s__" %
                          i: self.elements[i] for i in range(len(self.elements))}
         self.namedChildren['elements'] = self.elements
-        for childCell in self.elements:
-            if childCell.isFlex or childCell.isShrinkWrapped:
-                self.isFlexParent = True
 
     def sortsAs(self):
         if self.elements:

--- a/object_database/web/cells/cells.py
+++ b/object_database/web/cells/cells.py
@@ -1146,7 +1146,7 @@ class Sequence(Cell):
 
 
 class HorizontalSequence(Cell):
-    def __init__(self, elements, overflow=True, margin=None):
+    def __init__(self, elements, overflow=True, margin=None, wrap=True):
         """
         Lays out (children) elements in a horizontal sequence.
 
@@ -1165,6 +1165,7 @@ class HorizontalSequence(Cell):
         self.elements = elements
         self.overflow = overflow
         self.margin = margin
+        self.wrap = wrap
         self.isFlexParent = False
         self.updateChildren()
 
@@ -1181,6 +1182,7 @@ class HorizontalSequence(Cell):
             self.exportData['flexParent'] = True
         self.exportData['overflow'] = self.overflow
         self.exportData['margin'] = self.margin
+        self.exportData['wrap'] = self.wrap
 
     def updateChildren(self):
         newElements = []

--- a/object_database/web/cells/cells.py
+++ b/object_database/web/cells/cells.py
@@ -1183,13 +1183,20 @@ class HorizontalSequence(Cell):
         self.exportData['margin'] = self.margin
 
     def updateChildren(self):
+        newElements = []
+        for childCell in self.elements:
+            if childCell.isFlex:
+                self.isFlexParent = True
+                newElements.append(childCell)
+            elif isinstance(childCell, HorizontalSequence):
+                newElements += childCell.elements
+            else:
+                newElements.append(childCell)
+        self.elements = newElements
         self.namedChildren['elements'] = self.elements
         self.children = {}
         for i in range(len(self.elements)):
             self.children["____c_{}__".format(i)] = self.elements[i]
-        for element in self.elements:
-            if element.isFlex or element.isShrinkWrapped:
-                self.isFlexParent = True
 
     def sortAs(self):
         if self.elements:

--- a/object_database/web/cells/cells.py
+++ b/object_database/web/cells/cells.py
@@ -1122,7 +1122,6 @@ class Sequence(Cell):
         if self.isFlexParent:
             self.exportData['flexParent'] = True
         self.namedChildren['elements'] = self.elements
-        self.exportData['overflow'] = self.overflow
         self.exportData['margin'] = self.margin
 
     def updateChildren(self):

--- a/object_database/web/cells/cells_test.py
+++ b/object_database/web/cells/cells_test.py
@@ -643,6 +643,11 @@ class CellsSequenceHandlingTests(unittest.TestCase):
         self.assertIn(first_child_seq.elements[0], parent_seq.elements)
         self.assertIn(first_child_seq.elements[1], parent_seq.elements)
 
+    def test_basic_plus_composition(self):
+        result = Text("Hello") + Text("There") + Text("This Is A") + Button("Button", lambda: None)
+        self.assertTrue(isinstance(result, Sequence))
+        self.assertEqual(len(result.elements), 4)
+
 
 class CellsHorizSequenceHandlingTests(unittest.TestCase):
     @classmethod

--- a/object_database/web/cells/cells_test.py
+++ b/object_database/web/cells/cells_test.py
@@ -16,6 +16,7 @@ from object_database.web.cells import (
     AsyncDropdown,
     Cell,
     Cells,
+    Button,
     Subscribed,
     Card,
     Container,
@@ -704,6 +705,12 @@ class CellsHorizSequenceHandlingTests(unittest.TestCase):
         self.assertIn(second_child_seq, parent_seq.elements)
         self.assertIn(first_child_seq.elements[0], parent_seq.elements)
         self.assertIn(first_child_seq.elements[1], parent_seq.elements)
+
+    def test_basic_rshift_composition(self):
+        result = (Text("Hi") >> Text("Bye") >> Text("Go Away") >> Button("Away", lambda: None))
+        self.assertTrue(isinstance(result, HorizontalSequence))
+        self.assertEqual(len(result.elements), 4)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/object_database/web/cells/cells_test.py
+++ b/object_database/web/cells/cells_test.py
@@ -25,7 +25,8 @@ from object_database.web.cells import (
     Text,
     Slot,
     ensureSubscribedType,
-    registerDisplay
+    registerDisplay,
+    Flex
 )
 
 from object_database import InMemServer, Schema, Indexed, connect
@@ -35,7 +36,7 @@ from object_database.test_util import (
     currentMemUsageMb,
     log_cells_stats
 )
-from .Messenger import getStructure
+from object_database.web.cells.Messenger import getStructure
 
 import logging
 import unittest
@@ -576,6 +577,69 @@ class CellsStructureTests(unittest.TestCase):
         self.cells._recalculateCells()
         struct = c.getCurrentStructure()
         self.assertIsInstance(struct, dict)
+
+
+class CellsSequenceHandlingTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        configureLogging(
+            preamble="cells_test",
+            level=logging.INFO
+        )
+        cls._logger = logging.getLogger(__name__)
+
+    def setUp(self):
+        self.token = genToken()
+        self.server = InMemServer(auth_token=self.token)
+        self.server.start()
+
+        self.db = self.server.connect(self.token)
+        self.db.subscribeToSchema(test_schema)
+        self.cells = Cells(self.db)
+
+    def tearDown(self):
+        self.server.stop()
+
+    def test_seq_elements_length(self):
+        child_elements = [Text('One'), Text('Two'), Text('Three')]
+        child_seq = Sequence(child_elements)
+        parent_seq = Sequence([Text('First'), child_seq, Text('Third')])
+        self.cells.withRoot(parent_seq)
+        self.cells._recalculateCells()
+        self.assertEqual(len(child_seq.elements), len(child_elements))
+
+    def test_seq_element_presence(self):
+        child_elements = [Text('One'), Text('Two'), Text('Three')]
+        child_seq = Sequence(child_elements)
+        parent_seq = Sequence([Text('First'), child_seq, Text('Third')])
+        self.cells.withRoot(parent_seq)
+
+        self.assertIn(child_elements[0], child_seq.elements)
+
+    def test_seq_not_flex_parent(self):
+        child_seq = Sequence([Text('One'), Text('Two'), Text('Three')])
+        parent_seq = Sequence([Text('First'), child_seq, Text('Last')])
+        parent_seq.recalculate()
+        self.assertFalse(parent_seq.isFlexParent)
+        self.assertFalse(parent_seq.isFlex)
+
+    def test_seq_becomes_flex_parent(self):
+        child_seq = Sequence([Text('One'), Text('Two'), Text('Three')])
+        parent_seq = Sequence([Flex(Text('First')), child_seq, Text('Last')])
+        parent_seq.recalculate()
+        self.assertTrue(parent_seq.isFlexParent)
+
+    def test_seq_flattens_non_flex(self):
+        first_child_seq = Sequence([Text('One'), Text('Two')])
+        second_child_seq = Sequence([Text('Five'), Text('Six')])
+        parent_seq = Sequence([Text('Outer'), first_child_seq, Flex(second_child_seq), Text('Last')])
+        self.cells.withRoot(parent_seq)
+        self.cells._recalculateCells()
+
+        self.assertNotIn(first_child_seq, parent_seq.elements)
+        self.assertIn(second_child_seq, parent_seq.elements)
+        self.assertIn(first_child_seq.elements[0], parent_seq.elements)
+        self.assertIn(first_child_seq.elements[1], parent_seq.elements)
 
 
 if __name__ == '__main__':

--- a/object_database/web/cells/util.py
+++ b/object_database/web/cells/util.py
@@ -35,3 +35,15 @@ def waitForCellsCondition(cells: Cells, condition, timeout=10.0):
         raise Exception("\n\n".join([e.childByIndex(0).contents for e in exceptions]))
 
     return None
+
+
+def ShrinkWrap(aCell):
+    aCell.isShrinkWrapped = True
+    aCell.exportData['shrinkwrap'] = True
+    return aCell
+
+
+def Flex(aCell):
+    aCell.isFlex = True
+    aCell.exportData['flexChild'] = True
+    return aCell

--- a/object_database/web/cells_demo/flex_and_shrinkwrap.py
+++ b/object_database/web/cells_demo/flex_and_shrinkwrap.py
@@ -53,3 +53,26 @@ class VertSequenceWithoutFlex(CellsTestPage):
 
     def text(self):
         return "The vertical sequence should not be a flex container and should display all of its contents using as much space as it needs"
+
+
+class HorizSequenceWithFlex(CellsTestPage):
+    def cell(self):
+        textItems = [cells.Button("Inner Button %s" % i, lambda: None) for i in range(50)]
+        middleArea = cells.HorizontalSequence(textItems)
+        firstButton = cells.Button("First Button", lambda: None)
+        secondButton = cells.Button("Another Button", lambda: None)
+        return (firstButton >> Flex(middleArea) >> secondButton)
+
+    def text(self):
+        return "The vertical sequence should display two shrinkwrapped buttons sandwiching a flexed-out sequence containing a scrollable list of inner buttons"
+
+
+class HorizSequenceWithoutFlex(CellsTestPage):
+    def cell(self):
+        buttonItems = [cells.Button("Inner Button %s" % i, lambda: None) for i in range(50)]
+        firstButton = cells.Button("First Button", lambda: None)
+        secondButton = cells.Button("Another Button", lambda: None)
+        return cells.HorizontalSequence([firstButton] + buttonItems + [secondButton])
+
+    def text(self):
+        return "The vertical sequence should not be a flex container and should display all of its contents using as much space as it needs"

--- a/object_database/web/cells_demo/flex_and_shrinkwrap.py
+++ b/object_database/web/cells_demo/flex_and_shrinkwrap.py
@@ -1,0 +1,41 @@
+#   Coyright 2017-2019 Nativepython Authors
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+from object_database.web import cells
+from object_database.web.CellsTestPage import CellsTestPage
+from object_database.web.cells.util import Flex, ShrinkWrap
+
+
+class VertSequenceWithFlex(CellsTestPage):
+    def cell(self):
+        textItems = [cells.Text("Item %s" % i) for i in range(50)]
+        middleCard = cells.Card(cells.Sequence(textItems))
+        firstButton = cells.Button("First Button", lambda: None)
+        secondButton = cells.Button("Another Button", lambda: None)
+        return (firstButton + Flex(middleCard) + secondButton)
+
+    def text(self):
+        return "The vertical sequence should display two shrinkwrapped buttons sandwiching a flexed-out card containing a scrollable list of items"
+
+
+class VertSequenceWithoutFlex(CellsTestPage):
+    def cell(self):
+        textItems = [cells.Text("Item %s" % i) for i in range(50)]
+        middleCard = cells.Card(cells.Sequence(textItems))
+        firstButton = cells.Button("First Button", lambda: None)
+        secondButton = cells.Button("Another Button", lambda: None)
+        return (firstButton + middleCard + secondButton)
+
+    def text(self):
+        return "The vertical sequence should not be a flex container and should display all of its contents using as much space as it needs"

--- a/object_database/web/cells_demo/flex_and_shrinkwrap.py
+++ b/object_database/web/cells_demo/flex_and_shrinkwrap.py
@@ -17,6 +17,13 @@ from object_database.web.CellsTestPage import CellsTestPage
 from object_database.web.cells.util import Flex, ShrinkWrap
 
 
+class VertSequenceBasicConcat(CellsTestPage):
+    def cell(self):
+        return (cells.Text("Hello") + cells.Text("There") + cells.Text("This Is A") + cells.Button("Button", lambda: None))
+
+    def text(self):
+        return "Should use plus operator to produce a non-flexed vertical sequence"
+
 class VertSequenceWithFlex(CellsTestPage):
     def cell(self):
         textItems = [cells.Text("Item %s" % i) for i in range(50)]

--- a/object_database/web/cells_demo/flex_and_shrinkwrap.py
+++ b/object_database/web/cells_demo/flex_and_shrinkwrap.py
@@ -106,3 +106,12 @@ class HorizSequenceBasicConcat(CellsTestPage):
 
     def text(self):
         return "Should produce a non-flexed HorizontalSequence of the 4 elements"
+
+
+class MixedSequenceComposition(CellsTestPage):
+    def cell(self):
+        result = (cells.Text("Hi") >> cells.Text("Bye")) + (cells.Text("Go Away") >> cells.Button("Away", lambda: None))
+        return result
+
+    def text(self):
+        return "You should see a complex composition of both kinds of Sequences"

--- a/object_database/web/cells_demo/flex_and_shrinkwrap.py
+++ b/object_database/web/cells_demo/flex_and_shrinkwrap.py
@@ -55,6 +55,21 @@ class VertSequenceWithoutFlex(CellsTestPage):
         return "The vertical sequence should not be a flex container and should display all of its contents using as much space as it needs"
 
 
+class VertSequenceWithoutFlexNestedSeq(CellsTestPage):
+    def cell(self):
+        letteredTextItems = [cells.Text("Inner %s" % letter) for letter in ['A', 'B', 'C', 'D', 'E']]
+        numberedTextItems = [cells.Text("Item %s" % i) for i in range(50)]
+        numberedTextItems.append(cells.Sequence(letteredTextItems))
+
+        firstButton = cells.Button("Top Button", lambda: None)
+        lastButton = cells.Button("Bottom Button", lambda: None)
+
+        return (firstButton + cells.Sequence(numberedTextItems) + lastButton)
+
+    def text(self):
+        return "Non Flex-Parent Sequences should flatten any nested Sequences and overflow normally"
+
+
 class HorizSequenceWithFlex(CellsTestPage):
     def cell(self):
         textItems = [cells.Button("Inner Button %s" % i, lambda: None) for i in range(50)]

--- a/object_database/web/cells_demo/flex_and_shrinkwrap.py
+++ b/object_database/web/cells_demo/flex_and_shrinkwrap.py
@@ -29,6 +29,20 @@ class VertSequenceWithFlex(CellsTestPage):
         return "The vertical sequence should display two shrinkwrapped buttons sandwiching a flexed-out card containing a scrollable list of items"
 
 
+class VertSequenceWithMultiFlex(CellsTestPage):
+    def cell(self):
+        firstTextItems = [cells.Text("Item %s" % i) for i in range(50)]
+        firstCard = cells.Card(cells.Sequence(firstTextItems))
+        secondTextItems = [cells.Text("Item %s" % i) for i in range(60)]
+        secondCard = cells.Card(cells.Sequence(secondTextItems))
+        firstButton = cells.Button("First Button", lambda: None)
+        secondButton = cells.Button("Another Button", lambda: None)
+        return (firstButton + Flex(firstCard) + Flex(secondCard) + secondButton)
+
+    def text(self):
+        return "The vertical sequence should display two shrinkwrapped buttons sandwiching *two* flexed-out cards of equal, greedy size containing a scrollable list of items"
+
+
 class VertSequenceWithoutFlex(CellsTestPage):
     def cell(self):
         textItems = [cells.Text("Item %s" % i) for i in range(50)]

--- a/object_database/web/cells_demo/flex_and_shrinkwrap.py
+++ b/object_database/web/cells_demo/flex_and_shrinkwrap.py
@@ -91,3 +91,11 @@ class HorizSequenceWithoutFlex(CellsTestPage):
 
     def text(self):
         return "The vertical sequence should not be a flex container and should display all of its contents using as much space as it needs"
+
+class HorizSequenceBasicConcat(CellsTestPage):
+    def cell(self):
+        result = (cells.Text("Hi") >> cells.Text("Bye") >> cells.Text("Go Away") >> cells.Button("Away", lambda: None))
+        return result
+
+    def text(self):
+        return "Should produce a non-flexed HorizontalSequence of the 4 elements"

--- a/object_database/web/content/NewCellHandler.js
+++ b/object_database/web/content/NewCellHandler.js
@@ -152,7 +152,8 @@ class NewCellHandler {
     cellUpdated(message){
         let component = this._getUpdatedComponent(message);
         let velement = render(component);
-        let domElement = document.getElementById(component.props.id);
+        //let domElement = document.getElementById(component.props.id);
+        let domElement = component.getDOMElement();
         this.projector.replace(domElement, () => {
             return velement;
         });

--- a/object_database/web/content/app.css
+++ b/object_database/web/content/app.css
@@ -129,6 +129,14 @@
     align-items: center;
 }
 
+.sequence-horizontal.overflow {
+    /* We handle this for each type of sequence
+     * separately.
+     */
+    overflow-y: hidden;
+    overflow-x: auto;
+}
+
 /* Flex Parent and Flex Child (Sequences etc)
  *================================================================*/
 .sequence-vertical.flex-parent {
@@ -136,8 +144,19 @@
     flex-direction: column;
 }
 
-.flex-child {
+.sequence-horizontal.flex-parent {
+    display: flex;
+    flex-direction: row;
+    align-items: baseline;
+}
+
+.sequence-vertical > .flex-child {
     overflow-y: auto;
+    flex: 1;
+}
+
+.sequence-horizontal > .flex-child {
+    overflow-x: auto;
     flex: 1;
 }
 

--- a/object_database/web/content/app.css
+++ b/object_database/web/content/app.css
@@ -131,7 +131,7 @@
 .sequence-horizontal {
     display: flex;
     flex-direction: row;
-    align-items: center;
+    align-items: flex-start;
 }
 
 .sequence-horizontal.overflow {
@@ -204,6 +204,10 @@
  *======================================================*/
 .overflow {
     overflow: auto;
+}
+
+.flex-wrap {
+    flex-wrap: wrap;
 }
 
 .child-margin-1 > * {

--- a/object_database/web/content/app.css
+++ b/object_database/web/content/app.css
@@ -138,6 +138,7 @@
 
 .flex-child {
     overflow-y: auto;
+    flex: 1;
 }
 
 .shrinkwrapped {

--- a/object_database/web/content/app.css
+++ b/object_database/web/content/app.css
@@ -41,7 +41,7 @@
     flex-direction: column;
 }
 
-.split-view-column {
+.split-view-row {
     flex-direction: row;
 }
 

--- a/object_database/web/content/app.css
+++ b/object_database/web/content/app.css
@@ -148,7 +148,6 @@
 .sequence {
     display: inline-block;
     width: 100%;
-    height: 100%;
 }
 
 .sequence-vertical {

--- a/object_database/web/content/app.css
+++ b/object_database/web/content/app.css
@@ -2,6 +2,11 @@
  * Application Wide Stylesheet for ActiveWebService
  **/
 
+/* Global Styling Variables */
+:root {
+    --page-view-header-height: 75px;
+}
+
 /* Page Root  and other global-type elements*/
 #page_root {
     height: 100vh;
@@ -174,11 +179,11 @@
 }
 
 .page-view > header {
-    height: 5%;
+    height: var(--page-view-header-height);
 }
 
 .page-view > main {
-    height: 95%;
+    height: calc(100% - var(--page-view-header-height));
 }
 
 .page-view-header {

--- a/object_database/web/content/app.css
+++ b/object_database/web/content/app.css
@@ -113,7 +113,7 @@
 /* Sequence and HorizontalSequence
  *================================================================*/
 .sequence {
-    display: inline-flex;
+    display: inline-block;
     width: 100%;
     height: 100%;
 }
@@ -124,8 +124,24 @@
 }
 
 .sequence-horizontal {
+    display: flex;
     flex-direction: row;
     align-items: center;
+}
+
+/* Flex Parent and Flex Child (Sequences etc)
+ *================================================================*/
+.sequence-vertical.flex-parent {
+    display: flex;
+    flex-direction: column;
+}
+
+.flex-child {
+    overflow-y: auto;
+}
+
+.shrinkwrapped {
+    flex-grow: 0;
 }
 
 /* PageView

--- a/object_database/web/content/app.css
+++ b/object_database/web/content/app.css
@@ -17,6 +17,30 @@
     height: 100%;
 }
 
+/* Clickable and Button
+ * (Note that most of Button styling is from Bootstrap first)
+ * =====================================================*/
+[data-cell-type="Clickable"] {
+    display: inline-block;
+}
+
+/* SplitView
+ * =====================================================*/
+.split-view {
+    width: 100%;
+    height: 100%;
+    display: flex;
+    position: relative;
+}
+
+.split-view-column {
+    flex-direction: column;
+}
+
+.split-view-column {
+    flex-direction: row;
+}
+
 /* ResizablePanel and Friends
  * =====================================================*/
 .resizable-panel {
@@ -177,6 +201,12 @@
 
 .shrinkwrapped {
     flex-grow: 0;
+}
+
+/* Sequence and HorizontalSequence Special Cases
+ * ===============================================================*/
+.sequence-vertical > [data-cell-type="Clickable"] {
+    display: block;
 }
 
 /* PageView

--- a/object_database/web/content/app.css
+++ b/object_database/web/content/app.css
@@ -142,8 +142,14 @@
     overflow-x: auto;
 }
 
+
+
 /* Flex Parent and Flex Child (Sequences etc)
  *================================================================*/
+.seq-flex-wrap {
+    flex-wrap: wrap;
+}
+
 .sequence-vertical.flex-parent {
     display: flex;
     flex-direction: column;
@@ -152,7 +158,6 @@
 .sequence-horizontal.flex-parent {
     display: flex;
     flex-direction: row;
-    align-items: baseline;
 }
 
 .sequence-vertical > .flex-child {
@@ -163,6 +168,10 @@
 .sequence-horizontal > .flex-child {
     overflow-x: auto;
     flex: 1;
+}
+
+.sequence-horizontal > .flex-child.seq-flex-wrap {
+    flex-wrap: nowrap;
 }
 
 .shrinkwrapped {
@@ -204,10 +213,6 @@
  *======================================================*/
 .overflow {
     overflow: auto;
-}
-
-.flex-wrap {
-    flex-wrap: wrap;
 }
 
 .child-margin-1 > * {

--- a/object_database/web/content/app.css
+++ b/object_database/web/content/app.css
@@ -24,6 +24,10 @@
     display: inline-block;
 }
 
+[data-cell-type="Clickable"]:hover {
+    cursor: pointer;
+}
+
 /* SplitView
  * =====================================================*/
 .split-view {

--- a/object_database/web/content/app.css
+++ b/object_database/web/content/app.css
@@ -132,6 +132,7 @@
     display: flex;
     flex-direction: row;
     align-items: flex-start;
+    align-content: flex-start;
 }
 
 .sequence-horizontal.overflow {

--- a/object_database/web/content/components/AsyncDropdown.js
+++ b/object_database/web/content/components/AsyncDropdown.js
@@ -112,7 +112,7 @@ class AsyncDropdownContent extends Component {
         this.makeContent = this.makeContent.bind(this);
     }
 
-    render(){
+    build(){
         return (
             h('div', {
                 id: `dropdownContent-${this.props.id}`,

--- a/object_database/web/content/components/Clickable.js
+++ b/object_database/web/content/components/Clickable.js
@@ -32,6 +32,7 @@ class Clickable extends Component {
         return(
             h('div', {
                 id: this.props.id,
+                class: "cell clickable",
                 "data-cell-id": this.props.id,
                 "data-cell-type": "Clickable",
                 onclick: this._getEvent('onclick'),
@@ -45,9 +46,9 @@ class Clickable extends Component {
 
     getStyle(){
         if(this.props.extraData.bold){
-            return "cursor:pointer;*cursor:hand;font-weight:bold;display:inline-block;";
+            return "cursor:pointer;*cursor:hand;font-weight:bold;";
         } else {
-            return "display:inline-block;";
+            return "";
         }
     }
 

--- a/object_database/web/content/components/Component.js
+++ b/object_database/web/content/components/Component.js
@@ -23,6 +23,13 @@ class Component {
         this.replacements = new ReplacementsHandler(replacements);
         this.usesReplacements = (replacements.length > 0);
 
+        // Whether or not the the component
+        // is a Subscribed. We do this
+        // because Subscribed is a proxy
+        // for its children and we check it
+        // in NewCellHandler.
+        this.isSubscribed = false;
+
         // Setup parent relationship, if
         // any. In this abstract class
         // there isn't one by default
@@ -43,6 +50,7 @@ class Component {
         // Bind context to methods
         this.getReplacementElementFor = this.getReplacementElementFor.bind(this);
         this.getReplacementElementsFor = this.getReplacementElementsFor.bind(this);
+        this.getDOMElement = this.getDOMElement.bind(this);
         this.componentDidLoad = this.componentDidLoad.bind(this);
         this.componentDidUpdate = this.componentDidUpdate.bind(this);
         this.componentWillReceiveProps = this.componentWillReceiveProps.bind(this);
@@ -114,6 +122,20 @@ class Component {
      */
     componentDidUpdate(){
         return null;
+    }
+
+    /**
+     * Responds with an actual DOM Element
+     * instance into which one can project
+     * this Component's hyperscripts.
+     * Here we have the most commonly used
+     * default implementation.
+     * See `Subscribed` for an example of
+     * an alternative override/use.
+     * I am consumed by updates in the handler.
+     */
+    getDOMElement(){
+        return document.getElementById(this.props.id);
     }
 
     /**

--- a/object_database/web/content/components/HorizontalSequence.js
+++ b/object_database/web/content/components/HorizontalSequence.js
@@ -65,7 +65,7 @@ class HorizontalSequence extends Component {
             classes.push(`child-margin-${this.props.margin}`);
         }
         if(this.props.wrap){
-            classes.push('flex-wrap');
+            classes.push('seq-flex-wrap');
         }
         return classes.join(" ");
     }

--- a/object_database/web/content/components/HorizontalSequence.js
+++ b/object_database/web/content/components/HorizontalSequence.js
@@ -61,27 +61,27 @@ class HorizontalSequence extends Component {
         if(this.props.flexParent){
             classes.push("flex-parent");
         }
-        if(this.props.overflow){
-            classes.push("overflow");
-        }
         if (this.props.margin){
             classes.push(`child-margin-${this.props.margin}`);
+        }
+        if(this.props.wrap){
+            classes.push('flex-wrap');
         }
         return classes.join(" ");
     }
 }
 
 HorizontalSequence.propTypes = {
-    overflow: {
-        description: "If true, sets overflow of container to auto",
-        type: PropTypes.boolean
-    },
     margin: {
         description: "Bootstrap margin value for between element spacing",
         type: PropTypes.oneOf([PropTypes.number, PropTypes.string])
     },
     flexParent: {
         description: "Whether or not the HorizontalSequence should display using Flexbox",
+        type: PropTypes.boolean
+    },
+    wrap: {
+        description: "Whether or not the HorizontalSequence should wrap on overflow",
         type: PropTypes.boolean
     }
 };

--- a/object_database/web/content/components/HorizontalSequence.js
+++ b/object_database/web/content/components/HorizontalSequence.js
@@ -2,7 +2,7 @@
  * HorizontalSequence Cell Components
  */
 
-import {Component} from './Component';
+import {Component, render} from './Component';
 import {PropTypes} from './util/PropertyValidator';
 import {h} from 'maquette';
 
@@ -44,12 +44,23 @@ class HorizontalSequence extends Component {
         if(this.usesReplacements){
             return this.getReplacementElementsFor('c');
         } else {
-            return this.renderChildrenNamed('elements');
+            //return this.renderChildrenNamed('elements');
+            let elements = this.props.namedChildren['elements'];
+            return elements.map(childComponent => {
+                let hyperscript = render(childComponent);
+                if(childComponent.props.flexChild == true && this.props.flexParent){
+                    hyperscript.properties.class += " flex-child";
+                }
+                return hyperscript;
+            });
         }
     }
 
     makeClasses(){
         let classes = ["cell", "sequence", "sequence-horizontal"];
+        if(this.props.flexParent){
+            classes.push("flex-parent");
+        }
         if(this.props.overflow){
             classes.push("overflow");
         }
@@ -68,6 +79,10 @@ HorizontalSequence.propTypes = {
     margin: {
         description: "Bootstrap margin value for between element spacing",
         type: PropTypes.oneOf([PropTypes.number, PropTypes.string])
+    },
+    flexParent: {
+        description: "Whether or not the HorizontalSequence should display using Flexbox",
+        type: PropTypes.boolean
     }
 };
 

--- a/object_database/web/content/components/Sequence.js
+++ b/object_database/web/content/components/Sequence.js
@@ -36,8 +36,7 @@ class Sequence extends Component {
                 id: this.props.id,
                 class: this.makeClasses(),
                 "data-cell-id": this.props.id,
-                "data-cell-type": "Sequence",
-                //style: this.makeStyle()
+                "data-cell-type": "Sequence"
             }, this.makeElements())
         );
     }
@@ -62,9 +61,6 @@ class Sequence extends Component {
         if(this.props.flexParent){
             classes.push("flex-parent");
         }
-        if(this.props.overflow){
-            classes.push("overflow");
-        }
         if (this.props.margin){
             classes.push(`child-margin-${this.props.margin}`);
         }
@@ -74,16 +70,16 @@ class Sequence extends Component {
 }
 
 Sequence.propTypes = {
-    overflow: {
-        description: "Overflow-auto.",
-        type: PropTypes.boolean
-    },
     margin: {
         description: "Bootstrap margin value for between element spacing",
         type: PropTypes.oneOf([PropTypes.number, PropTypes.string])
     },
     flexParent: {
         description: "Whether or not the Sequence should display using Flexbox",
+        type: PropTypes.boolean
+    },
+    flexChild: {
+        description: "Whether or not this Sequence is a flexChild of some flexParent",
         type: PropTypes.boolean
     }
 };

--- a/object_database/web/content/components/Sequence.js
+++ b/object_database/web/content/components/Sequence.js
@@ -50,9 +50,7 @@ class Sequence extends Component {
             return elements.map(childComponent => {
                 let hyperscript = render(childComponent);
                 if(childComponent.props.flexChild == true && this.props.flexParent){
-                    console.log(`Sequence[${this.props.id}] has child [${childComponent.props.id}] that is specified as a flexChild!`);
                     hyperscript.properties.class += " flex-child";
-                    console.log(hyperscript);
                 }
                 return hyperscript;
             });

--- a/object_database/web/content/components/Sequence.js
+++ b/object_database/web/content/components/Sequence.js
@@ -2,7 +2,7 @@
  * Sequence Cell Component
  */
 
-import {Component} from './Component';
+import {Component, render} from './Component';
 import {PropTypes} from './util/PropertyValidator';
 import {h} from 'maquette';
 
@@ -46,12 +46,24 @@ class Sequence extends Component {
         if(this.usesReplacements){
             return this.getReplacementElementsFor('c');
         } else {
-            return this.renderChildrenNamed('elements');
+            let elements = this.props.namedChildren['elements'];
+            return elements.map(childComponent => {
+                let hyperscript = render(childComponent);
+                if(childComponent.props.flexChild == true && this.props.flexParent){
+                    console.log(`Sequence[${this.props.id}] has child [${childComponent.props.id}] that is specified as a flexChild!`);
+                    hyperscript.properties.class += " flex-child";
+                    console.log(hyperscript);
+                }
+                return hyperscript;
+            });
         }
     }
 
     makeClasses(){
         let classes = ["cell sequence sequence-vertical"];
+        if(this.props.flexParent){
+            classes.push("flex-parent");
+        }
         if(this.props.overflow){
             classes.push("overflow");
         }
@@ -71,6 +83,10 @@ Sequence.propTypes = {
     margin: {
         description: "Bootstrap margin value for between element spacing",
         type: PropTypes.oneOf([PropTypes.number, PropTypes.string])
+    },
+    flexParent: {
+        description: "Whether or not the Sequence should display using Flexbox",
+        type: PropTypes.boolean
     }
 };
 

--- a/object_database/web/content/components/SplitView.js
+++ b/object_database/web/content/components/SplitView.js
@@ -29,7 +29,7 @@ class SplitView extends Component {
         super(props, ...args);
 
         // Bind component methods
-        this.makeStyle = this.makeStyle.bind(this);
+        this.makeClasses = this.makeClasses.bind(this);
         this.makeChildStyle = this.makeChildStyle.bind(this);
         this.makeChildElements = this.makeChildElements.bind(this);
     }
@@ -38,21 +38,23 @@ class SplitView extends Component {
         return (
             h('div', {
                 id: this.props.id,
-                class: 'cell split-view',
+                class: this.makeClasses(),
                 'data-cell-id': this.props.id,
-                'data-cell-type': "SplitView",
-                style: this.makeStyle()
+                'data-cell-type': "SplitView"
             }, this.makeChildElements())
         );
     }
 
-    makeStyle(){
-        // Note: the server side uses "split" (axis) to denote the direction
-        let direction = "row";
+    makeClasses(){
+        // Note: the server side uses the "split" (axis) to
+        // denote the direction
+        let classes = ["cell", "split-view"];
+        let directionClass = "split-view-row";
         if(this.props.extraData.split == "horizontal"){
-            direction = "column";
+            directionClass = "split-view-column";
         }
-        return `width:100%;height:100%;display:flex;flex-direction:${direction};`;
+        classes.push(directionClass);
+        return classes.join(" ");
     }
 
     makeChildStyle(index){
@@ -69,14 +71,14 @@ class SplitView extends Component {
             return this.getReplacementElementsFor('element').map((child, idx) => {
                 return h('div', {
                     style: this.makeChildStyle(idx),
-                    class: "overflow"
+                    class: "split-view-area overflow"
                 }, [child]);
             });
         } else {
             return this.renderChildrenNamed('elements').map((child, idx) => {
                 return h('div', {
                     style: this.makeChildStyle(idx),
-                    class: "overflow"
+                    class: "split-view-area overflow"
                 }, [child]);
             });
         }

--- a/object_database/web/content/components/Subscribed.js
+++ b/object_database/web/content/components/Subscribed.js
@@ -22,19 +22,23 @@ class Subscribed extends Component {
     constructor(props, ...args){
         super(props, ...args);
 
+        // Responds true
+        this.isSubscribed = true;
+        this.previoudChildId = null;
+
         // Bind component methods
         this.makeContent = this.makeContent.bind(this);
     }
 
     build(){
-        return h('div',
-            {
-                class: "cell subscribed",
-                id: this.props.id,
-                "data-cell-id": this.props.id,
-                "data-cell-type": "Subscribed"
-            }, [this.makeContent()]
-        );
+        let velement = this.makeContent();
+        velement.properties['data-subscribed-to'] = this.props.id;
+        return velement;
+    }
+
+    getDOMElement(){
+        let el = document.querySelector(`[data-subscribed-to="${this.props.id}"]`);
+        return el;
     }
 
     makeContent(){

--- a/object_database/web/content/components/tests/card-component-tests.js
+++ b/object_database/web/content/components/tests/card-component-tests.js
@@ -8,7 +8,7 @@ class FakeHeader extends Component {
         super(props, ...args);
     }
 
-    render(){
+    build(){
         return (
             h('p', ["CARD HEADER"])
         );
@@ -20,7 +20,7 @@ class FakeContent extends Component {
         super(props, ...args);
     }
 
-    render(){
+    build(){
         return (
             h('p', {}, ["THIS IS THE BODY"])
         );


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
This PR implements changes to Sequence/HorizontalSequence that permit them to display according to specific rules (see below).

## Motivation and Context
<!-- Why is this change required? -->
In our ongoing quest to come up with a usable, declarative way to lay out Cells, Sequences have always been a bit of a problem -- especially when we want to use them as general purpose containers for other Cells across a UI.
<!-- What problem does it solve? -->
  
This PR adds some changes to the Cells and also to the Component/CSS side (detailed below), in addition to adding some new wrapping functionality for declarative structures.
<!--  If it fixes an open issue, please link to the issue here.-->

## Approach
<!-- Describe your changes in reasonable detail -->
### Initial Concepts ###
We introduce a few new concepts here: the idea of a `Flex` child, the idea of a `Flex` parent, and the idea of a `ShrinkWrapped` child.
  
A `Flex` parent is any Sequence that has one or more `Flex` child elements.
  
A `Flex` child is an element in a Sequence that will take up as much space as it can, and will overflow scroll as needed by its contents
  
A `ShrinkWrapped` child is an element in a Sequence that will only take up as much space as needed by its contents. If it overflows it will not produce scrollbars, but rather push all content as needed.
  
### Specified Behavior ###
Per our discussions, we decided that Sequences and HorizontalSequences should have the following behavior:

#### First Case ####
The Sequence has a `Flex()` member.
In this case, we set the Sequence to be a flex parent. We set all the items wrapped in `Flex()` to grow within the container, and to set their individual overflows to scroll. Other items in the Sequence should appear as shrinkwrapped. The Sequence itself should not overflow at all.
  
If one of the Sequence elements is itself  Sequence, we instead add all of its members to the original Sequence, except if that element is wrapped in `Flex()` in which case we leave it as a true nested Sequence with its own overflow.

#### Second Case ####
The Sequence does *not* have a `Flex()` member.
In this case, we simply fill the Sequence with elements. We do not set any overflow to scroll. Instead, any parent/wrapping Cells should handle that overflow.
  
If an element of the Sequence is another Sequence, we simply add all of its elements to the parent Sequence. This happens no matter what.
  
### Implementation ###
#### `Sequence` / `HorizontalSequence` Cells Changes ####
We have added `isFlex` and `isFlexParent` properties to all `Cell` objects. We set and unset these properties in the `recalculate` cycle of any Sequence. Whether or not a Sequence is a flex parent or flex child or whatever is then added to its `exportData` and sent to the frontend.
  
These properties are also used in determining whether nested Sequences need to be 'flattened' per the specification. If you recall, any elements of a flex-parent Sequence that are themselves Sequences will be flattened, except in cases where the child Sequence is itself a flex-child. The new properties really help here.
  
Finally, we are able to add a  new wrapping functions that allow better declarative behavior:
* `Flex(aCell)`: Function that takes a Cell object, sets its `isFlex` property to `True`, and adds that information to its `exportData`
  
Now you can do things like:
```python
menuItems = [Text("Item %s" % i for i in range(50)]
return (Button("Top Button", lambda: None) + Flex(Sequence(menuItems)) + Button("Bottom Button", lambda: None))
```
  
#### Component and CSS Changes ####
`Sequence` and `HorizontalSequence` Components now receive information about whether or not they or any of their children are flex-parent or flex-child. We use this information to add/remove specific CSS classes (updated in `app.css`) to implement the specified layout behavior.
  
### Important `Subscribed` Changes ###
This PR also implements an important, related change. `Subscribed` Components no longer render themselves to the DOM. Instead, they render their child content.
  
In order to do this we had to change a bit of the structure of the root `Component`. Instead of looking up the ID of the component element on any given `cellUpdated` message by querying the document, we call `getDOMElement()` on the Component itself, which allows it to say where it should ultimately be rendered. By default, we do the normal document lookup by ID. But in the case of `Subscribed`, which renders its child element initially with a `data-subscribed-to=<subscribedId>` attribute, we simply look up where the old child is an return that.

## How Has This Been Tested?
<!-- Describe in reasonable detail how you tested your changes. -->
We have added more unit tests to `Sequence` and `HorizontalSequence`.
  
We have also added half a dozen new examples that implement various combinations for testing the actual specified UI.
<!-- If appropriate, include details of your testing environment, -->
<!-- tests ran to see how your change affects other areas of the code, etc. -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.