### PR TITLE
Cell Padding and Margin Helpers

### DIFF
--- a/object_database/web/cells/__init__.py
+++ b/object_database/web/cells/__init__.py
@@ -74,7 +74,12 @@ from object_database.web.cells.CellsTestMixin import CellsTestMixin
 
 from object_database.web.cells.util import waitForCellsCondition
 
-from object_database.web.cells.util import Flex, ShrinkWrap
+from object_database.web.cells.util import (
+    Flex,
+    ShrinkWrap,
+    Padding,
+    Margin
+)
 
 from object_database.web.cells.views.resizable_panel import ResizablePanel
 

--- a/object_database/web/cells/cells_test.py
+++ b/object_database/web/cells/cells_test.py
@@ -42,6 +42,7 @@ from object_database.test_util import (
     log_cells_stats
 )
 from object_database.web.cells.Messenger import getStructure
+from object_database.web.cells import Padding, Margin
 
 import logging
 import unittest
@@ -786,6 +787,24 @@ class CellsSubscribedSequenceHandlingTests(unittest.TestCase):
         sub_seq = HSubscribedSequence(self.itemsFun, self.rendererFun)
         self.assertEqual(sub_seq.orientation, 'horizontal')
         self.assertIsInstance(sub_seq, SubscribedSequence)
+
+
+class CellsUtilTests(unittest.TestCase):
+
+    def test_padding_all_dimensions(self):
+        cell = Text('test')
+        Padding(10, cell)
+        self.assertTrue('padding' in cell.exportData['customStyle'])
+        self.assertEqual('10px', cell.exportData['customStyle']['padding'])
+
+    def test_margin_all_dimensions(self):
+        cell = Text("test")
+        Margin(15, cell)
+        self.assertTrue('margin' in cell.exportData['customStyle'])
+        self.assertEqual('15px', cell.exportData['customStyle']['margin'])
+
+
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/object_database/web/cells/util.py
+++ b/object_database/web/cells/util.py
@@ -38,18 +38,83 @@ def waitForCellsCondition(cells: Cells, condition, timeout=10.0):
 
 
 def ShrinkWrap(aCell):
+    """Cell modifier function
+    that marks the cell as shrinkwrapped.
+
+    Parameters
+    ----------
+    aCell: Cell
+        The Cell instance that will be marked
+        as shrinkwrapped (for frontend)
+
+    Returns
+    -------
+    The modified Cell instance
+    """
     aCell.isShrinkWrapped = True
     aCell.exportData['shrinkwrap'] = True
     return aCell
 
 
 def Flex(aCell):
+    """Cell modifier function
+    that marks the cell as flexed.
+
+    Parameters
+    ----------
+    aCell: Cell
+        The Cell instance that will be marked
+        as flexed (for frontend)
+
+    Returns
+    -------
+    The modified Cell instance
+    """
     aCell.isFlex = True
     aCell.exportData['flexChild'] = True
     return aCell
 
 
 def CustomInset(aCell, kind='padding', top=None, right=None, bottom=None, left=None):
+    """Cell modifier function that sets
+    insets across varying dimensions of
+    the visible Cell component.
+
+    Notes
+    -----
+    This convenience function is designed to
+    be used by simpler helper functions like
+    `Padding()` and `Margin()`.
+    However, consumers can use it directly
+    in order to provide very specific
+    insets on the given sides.
+
+    Parameters
+    ----------
+    aCell: Cell
+        The Cell instance whose resulting
+        visual component will be given inset
+        values on the desired dimension(s)
+    kind: str
+        Whether the inset is `padding` or
+        `margin`. Defaults to `padding`
+    top: integer
+        The number of pixels of the inset
+        (specified by `kind`) at the top
+        dimension. Defaults to None.
+    right: integer
+        The number of pixels of the inset
+        (specified by `kind`) at the right
+        dimension. Defaults to None.
+    bottom: integer
+        The number of pixels of the inset
+        (specified by `kind`) at the bottom
+        dimension. Defaults to None.
+    left: integer
+        The number of pixels of the inset
+        (specified by `kind`) at the left
+        dimension. Defaults to None.
+    """
     dimensions = {
         'top': top,
         'right': right,
@@ -81,10 +146,46 @@ def CustomInset(aCell, kind='padding', top=None, right=None, bottom=None, left=N
 
 
 def Padding(amount, cell):
+    """Cell modifier function that
+    adds Padding on all dimensions
+    to the resulting Cell component.
+
+    Parameters
+    ----------
+    amount: integer
+        The number of pixels in padding
+        on all sides that the resulting
+        cell's component will display with
+    cell: Cell
+        The Cell instance that will be
+        modified.
+
+    Returns
+    -------
+    A modified Cell instance
+    """
     return CustomInset(cell, 'padding', top=amount,
                        right=amount, bottom=amount, left=amount)
 
 
 def Margin(amount, cell):
+    """Cell modifier function that
+    adds Margin on all dimensions
+    to the resulting Cell component.
+
+    Parameters
+    ----------
+    amount: integer
+        The number of pixels in margin
+        on all sides that the resulting
+        cell's component will display with
+    cell: Cell
+        The Cell instance that will be
+        modified.
+
+    Returns
+    -------
+    A modified Cell instance
+    """
     return CustomInset(cell, 'margin', top=amount,
                        right=amount, bottom=amount, left=amount)

--- a/object_database/web/cells/util.py
+++ b/object_database/web/cells/util.py
@@ -47,3 +47,44 @@ def Flex(aCell):
     aCell.isFlex = True
     aCell.exportData['flexChild'] = True
     return aCell
+
+
+def CustomInset(aCell, kind='padding', top=None, right=None, bottom=None, left=None):
+    dimensions = {
+        'top': top,
+        'right': right,
+        'bottom': bottom,
+        'left': left
+    }
+
+    if 'customStyle' not in aCell.exportData:
+        aCell.exportData['customStyle'] = {}
+
+    assert kind in ['padding', 'margin'], "Inset kind must be 'padding' or 'margin'"
+
+    # Check if all values are the same.
+    # If so, we only set the global inset
+    # value instead of doing so by dimension
+    vals = set(dimensions.values())
+    if len(vals) == 1:
+        inset_val = "{}px".format(list(vals)[0])
+        aCell.exportData["customStyle"][kind] = inset_val
+    # Otherwise we set the value
+    # on a per-dimension basis
+    else:
+        for dimension, val in dimensions.items():
+            inset_val = "{}px".format(val)
+            inset_name = "{}-{}".format(kind, dimension)
+            aCell.exportData["customStyle"][inset_name] = inset_val
+
+    return aCell
+
+
+def Padding(amount, cell):
+    return CustomInset(cell, 'padding', top=amount,
+                       right=amount, bottom=amount, left=amount)
+
+
+def Margin(amount, cell):
+    return CustomInset(cell, 'margin', top=amount,
+                       right=amount, bottom=amount, left=amount)

--- a/object_database/web/cells_demo/insets.py
+++ b/object_database/web/cells_demo/insets.py
@@ -1,0 +1,44 @@
+#   Coyright 2017-2019 Nativepython Authors
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+from object_database.web import cells
+from object_database.web.CellsTestPage import CellsTestPage
+from object_database.web.cells.util import Padding, Margin
+
+
+class BasicPadding(CellsTestPage):
+
+    def cell(self):
+        buttons = [
+            Padding(10, cells.Button("First", lambda: None)),
+            Padding(10, cells.Button("Second", lambda: None)),
+            Padding(10, cells.Button("Third", lambda: None))
+        ]
+        return cells.HorizontalSequence(buttons)
+
+    def text(self):
+        return "Should see a horizontal sequence of three buttons each with 10px padding"
+
+
+class BasicMargin(CellsTestPage):
+    def cell(self):
+        buttons = [
+            Margin(10, cells.Button("First", lambda: None)),
+            Margin(10, cells.Button("Second", lambda: None)),
+            Margin(10, cells.Button("Third", lambda: None))
+        ]
+        return cells.HorizontalSequence(buttons)
+
+    def text(self):
+        return "Should see a horizontal sequence of three buttons each with 10px margin"

--- a/object_database/web/content/components/Component.js
+++ b/object_database/web/content/components/Component.js
@@ -360,6 +360,22 @@ class Component {
     }
 };
 
+/**
+ * Given a dictionary of `customStyles`
+ * (usually provided by a Component),
+ * adds those styles to a given `velement`'s
+ * existing `style` string.
+ * Note that we use helper methods to translate
+ * to and from dicts/strings for convenience.
+ * @param {object} customStyles - An object
+ * mapping CSS style names to values.
+ * @param {maquette.VNode} velement - A Maquette
+ * virtual element whose `properties.style` string
+ * we will update with the new given styles.
+ * @returns {maquette.VNode} - The modified
+ * maquette virtual element with updated
+ * styling.
+ */
 const addCustomStyles = (customStyles, velement) => {
     let sourceStyle = velement.properties.style;
     let styleDict = {};
@@ -376,6 +392,18 @@ const addCustomStyles = (customStyles, velement) => {
     return velement.properties.style = styleString;
 };
 
+
+/**
+ * Helper function that translates
+ * HTML style attribute strings
+ * (ie, `style="width:100%;padding-left:10px;"`)
+ * to dictionary/object form for easier
+ * manipulation.
+ * @param {String} styleString - The source
+ * HTML attribute style string
+ * @param {object} - An object/dictionary
+ * like version of the styles
+ */
 const styleToDict = (styleString) => {
     let items = styleString.split(";");
     let keysAndVals = items.map(item => {
@@ -387,6 +415,18 @@ const styleToDict = (styleString) => {
     });
 };
 
+/**
+ * Helper function that translates
+ * objects/dictionaries of HTML/CSS
+ * style names (keys) and values to
+ * an HTML attribute string form
+ * (ie, inline HTML style string)
+ * @param {object} styleDict - An object
+ * whose keys are the style names and
+ * values are the style values.
+ * @returns {String} - An HTML attribute
+ * style string, ie inline style string.
+ */
 const dictToStyle = (styleDict) => {
     let items = Object.keys(styleDict).map(key => {
         return `${key}:${styleDict[key]}`;

--- a/object_database/web/content/components/Component.js
+++ b/object_database/web/content/components/Component.js
@@ -88,6 +88,15 @@ class Component {
         if(this.props.flexChild){
             velement.properties.class += " flex-child";
         }
+
+        // Add any custom inline styles required
+        // from the server side. For now this is
+        // limited to `padding` and `margin`
+        // inset values.
+        if(this.props.customStyle){
+            addCustomStyles(this.props.customStyle, velement);
+        }
+
         return velement;
     }
 
@@ -349,6 +358,40 @@ class Component {
             }
         });
     }
+};
+
+const addCustomStyles = (customStyles, velement) => {
+    let sourceStyle = velement.properties.style;
+    let styleDict = {};
+    if(sourceStyle){
+        styleDict = styleToDict(sourceStyle);
+    }
+
+    Object.keys(customStyles).forEach(key => {
+        styleDict[key] = customStyles[key];
+    });
+
+    let styleString = dictToStyle(styleDict);
+
+    return velement.properties.style = styleString;
+};
+
+const styleToDict = (styleString) => {
+    let items = styleString.split(";");
+    let keysAndVals = items.map(item => {
+        return item.split(":");
+    });
+    let result = {};
+    keysAndVals.forEach(part => {
+        result[part[0]] = part[1];
+    });
+};
+
+const dictToStyle = (styleDict) => {
+    let items = Object.keys(styleDict).map(key => {
+        return `${key}:${styleDict[key]}`;
+    });
+    return items.join(";");
 };
 
 export {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
This PR implements `Padding` and `Margin` helper functions, along with
changes to `Component` that allow these functions to provide the
given styling.

## Motivation and Context
<!-- Why is this change required? -->
Before this PR, we did not have a way to declaratively specify Padding or Margins within or between different Cell objects. With these new changes, users of Cells can now specify in more detail these inset values.
<!-- What problem does it solve? -->
<!--  If it fixes an open issue, please link to the issue here.-->

## Approach
### The New Functions ###
We introduce several new helper functions that are "Cell modifiers", ie functions that take a Cell instance as an argument and return that instance in some modified form.
  
#### `Padding()` ####
The new [`Padding()`](https://github.com/APrioriInvestments/nativepython/blob/eric-dev-cells-padding/object_database/web/cells/util.py#L148) function takes two arguments: an integer (specifying padding pixels) and a Cell whose resulting frontend component will add the padding amount on all 4 dimensions.
  
For example:
```
Padding(10, Text("Hello"))
```
will result in a Text cell whose content is padded at 10 pixels on each side.
  
#### `Margin()` ####
The new [`Margin()` ](https://github.com/APrioriInvestments/nativepython/blob/eric-dev-cells-padding/object_database/web/cells/util.py#L171)function takes two arguments: an integer (specifying margins in pixels) and a Cell whose resulting frontend component will add the padding amount on all 4 dimensions.
  
For example:
```
(Text("One") + Margin(25, Text("Two")) + Text("Three"))
```
will ensure that the middle Text cell in the resulting sequence will have
25px margin on all sides separating neighboring elements.
  
#### `CustomInset()` ####
The above two helper functions are simple configurations of the new [`CustomInset()`](https://github.com/APrioriInvestments/nativepython/blob/eric-dev-cells-padding/object_database/web/cells/util.py#L78) helper function, which takes the following arguments:
* `cell` - The `Cell` instance to modify;
* `kind` - Can be `"padding"` or `"margin"`. Defaults to `"padding"`;
* `top` - Keyword arg that expects an integer for value in top dimension;
* `right` - Keyword arg that expects an integer for value in right dimension;
* `bottom` - Keyword arg that expects an integer for value in bottom dimension;
* `left` - Keyword arg that expects an integer for value in left dimension;
  
You can feel free to use this helper function directly, or to create new helpers from it (think `PaddingRight()`, `MarginTop()` etc) that might be more readable in a declarative structure.
  
### JS / Component Changes ###
Each Component now handles a custom `props.customStyle` dictionary *after build* but before top-level render. This handler will update the corresponding virtual element's inline style string to add any additional, component specific styles that cannot be separated as CSS classes. Padding and Margins are our first such example of this new functionality.
<!-- Describe your changes in reasonable detail -->

## How Has This Been Tested?
<!-- Describe in reasonable detail how you tested your changes. -->
We have added new tests in both the JS and Cells unit tests. We have also added a couple of basic Cells examples demonstrating each.
<!-- If appropriate, include details of your testing environment, -->
<!-- tests ran to see how your change affects other areas of the code, etc. -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.