### PR TITLE
pytest configuration for better logging

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -16,6 +16,10 @@ commands =
 testpaths =
     typed_python
 
+log_level = INFO
+log_format = [%(asctime)s.%(msecs)03d] %(levelname)8s %(filename)30s:%(lineno)4s | %(threadName)10s | %(message)s
+log_date_format = %Y-%m-%d %H:%M:%S
+
 
 # The pycodestyle section is used by autopep8
 [pycodestyle]


### PR DESCRIPTION
## Motivation and Context
Configure `pytest` logging to match our log-format (+ threadName info)

## Approach
Put the relevant config in `tox.ini` where pytest will look for its default configuration.

## How Has This Been Tested?
- By running `pytest` locally (e.g., with `-s` or with `log_cli = true` in tox.ini)
- TravisCI tests are still happy