### PR TITLE
[Bugfix] CodeEditor Issue (229)

### DIFF
--- a/object_database/web/cells/cells.py
+++ b/object_database/web/cells/cells.py
@@ -2564,6 +2564,13 @@ class CodeEditor(Cell):
         self.onTextChange = onTextChange
         self.initialText = ""
 
+        # All CodeEditors will be
+        # flexed inside of Sequences,
+        # and will cause parent Sequences
+        # to become flex parent
+        self.isFlex = True
+        self.exportData['flexChild'] = True
+
     def getContents(self):
         return self._slot.get()[1]
 

--- a/object_database/web/cells_demo/code_editor.py
+++ b/object_database/web/cells_demo/code_editor.py
@@ -22,9 +22,9 @@ class CodeEditorDemo(CellsTestPage):
     def cell(self):
         isShown = cells.Slot(False)
 
-        return cells.Button("Toggle the editor", lambda: isShown.set(not isShown.get())) + cells.Subscribed(
+        return cells.Button("Toggle the editor", lambda: isShown.set(not isShown.get())) + cells.Flex(cells.Subscribed(
             lambda: cells.CodeEditor() if isShown.get() else None
-        )
+        ))
 
     def text(self):
         return "You should see a button that lets you see a text editor."
@@ -40,22 +40,19 @@ class CodeEditorInHorizSequence(CellsTestPage):
             contents.set(buffer)
 
         def toggle(aSlot):
-            print("Toggling")
-            print(aSlot.get())
             aSlot.toggle()
-            print(aSlot.get())
 
         return (
             cells.Button("Show the editor", lambda: toggle(editorShown)) +
             cells.Button("Show the editor's contents", lambda: toggle(contentsShown)) +
-            cells.HorizontalSubscribedSequence(lambda:
+            cells.Flex(cells.HorizontalSubscribedSequence(lambda:
                 (["Ed"] if editorShown.get() else []) +
                 (["Contents"] if contentsShown.get() else []),
                 lambda which:
                     cells.CodeEditor(onTextChange=onTextChange) if which == "Ed" else
                     cells.Subscribed(lambda: contents.get()) if which == "Contents" else
                     None
-            )
+            ))
         )
 
     def text(self):

--- a/object_database/web/cells_demo/code_editor.py
+++ b/object_database/web/cells_demo/code_editor.py
@@ -39,9 +39,15 @@ class CodeEditorInHorizSequence(CellsTestPage):
         def onTextChange(buffer, selection):
             contents.set(buffer)
 
+        def toggle(aSlot):
+            print("Toggling")
+            print(aSlot.get())
+            aSlot.toggle()
+            print(aSlot.get())
+
         return (
-            cells.Button("Show the editor", editorShown.toggle) +
-            cells.Button("Show the editor's contents", contentsShown.toggle) +
+            cells.Button("Show the editor", lambda: toggle(editorShown)) +
+            cells.Button("Show the editor's contents", lambda: toggle(contentsShown)) +
             cells.HorizontalSubscribedSequence(lambda:
                 (["Ed"] if editorShown.get() else []) +
                 (["Contents"] if contentsShown.get() else []),
@@ -54,6 +60,25 @@ class CodeEditorInHorizSequence(CellsTestPage):
 
     def text(self):
         return "You should see two buttons that let you turn the editor on and off, and also see its contents."
+
+
+class CodeEditorBasicHorizSequence(CellsTestPage):
+
+    def cell(self):
+        contents = cells.Slot("No Text Entered Yet!")
+
+        def onTextChange(content, selection):
+            contents.set(content)
+
+        return cells.HorizontalSequence([
+            cells.CodeEditor(onTextChange=onTextChange),
+            cells.Panel(
+                cells.Subscribed(contents.get)
+            )
+        ])
+
+    def text(self):
+        return "Should see a CodeEditor and its content (in panel) in a HorizontalSequence that is not a flex parent"
 
 class CodeEditorInSplitView(CellsTestPage):
     def cell(self):

--- a/object_database/web/content/app.css
+++ b/object_database/web/content/app.css
@@ -237,6 +237,10 @@
     height: 100%;
 }
 
+.sequence-vertical > .split-view {
+    display: flex;
+}
+
 /* Panel
  * ============================================================== */
 .cell-panel {

--- a/object_database/web/content/app.css
+++ b/object_database/web/content/app.css
@@ -232,8 +232,9 @@
     display: block;
 }
 
-.sequence-vertical > [data-cell-type="CodeEditor"].flex-child {
-    width: 100%;
+:not(.sequence) > .sequence-horizontal {
+    position: relative;
+    height: 100%;
 }
 
 /* Panel
@@ -265,6 +266,23 @@
 
 .sequence-vertical.flex-parent > .cell-panel {
     height: auto;
+    width: 100%;
+}
+
+/* CodeEditor
+ * ===============================================================*/
+.code-editor {
+    position: relative;
+    width: 100%;
+    height: 100%;
+}
+
+.sequence-horizontal:not(.flex-parent) > .code-editor {
+    min-width: 300px;
+    flex: 1;
+}
+
+.sequence-vertical > .code-editor.flex-child {
     width: 100%;
 }
 

--- a/object_database/web/content/app.css
+++ b/object_database/web/content/app.css
@@ -232,6 +232,10 @@
     display: block;
 }
 
+.sequence-vertical > [data-cell-type="CodeEditor"].flex-child {
+    width: 100%;
+}
+
 /* Panel
  * ============================================================== */
 .cell-panel {

--- a/object_database/web/content/app.css
+++ b/object_database/web/content/app.css
@@ -281,6 +281,13 @@
     height: 100%;
 }
 
+.code-editor-inner {
+    width: 100%;
+    min-height: 100%;
+    margin: auto;
+    border: 1px solid lightgray;
+}
+
 .sequence-horizontal:not(.flex-parent) > .code-editor {
     min-width: 300px;
     flex: 1;

--- a/object_database/web/content/components/CodeEditor.js
+++ b/object_database/web/content/components/CodeEditor.js
@@ -11,7 +11,7 @@ class CodeEditor extends Component {
         this.editor = null;
         // used to schedule regular server updates
         this.SERVER_UPDATE_DELAY_MS = 1;
-        this.editorStyle = 'width:100%;min-height:100%;margin:auto;border:1px solid lightgray;';
+        //this.editorStyle = 'width:100%;min-height:100%;margin:auto;border:1px solid lightgray;';
 
         this.setupEditor = this.setupEditor.bind(this);
         this.setupKeybindings = this.setupKeybindings.bind(this);
@@ -72,7 +72,7 @@ class CodeEditor extends Component {
                 "data-cell-id": this.props.id,
                 "data-cell-type": "CodeEditor",
             },
-            [h('div', { id: "editor" + this.props.id, style: this.editorStyle }, [])
+                 [h('div', { id: "editor" + this.props.id, class: "code-editor-inner" }, [])
         ]);
     }
 

--- a/object_database/web/content/components/CodeEditor.js
+++ b/object_database/web/content/components/CodeEditor.js
@@ -53,6 +53,8 @@ class CodeEditor extends Component {
 
             if (this.props.extraData.minLines !== undefined) {
                 this.editor.setOption("minLines", this.props.extraData.minLines);
+            } else {
+                this.editor.setOption("minLines", Infinity);
             }
 
             this.setupKeybindings();
@@ -61,10 +63,11 @@ class CodeEditor extends Component {
         }
     }
 
+
     build(){
         return h('div',
             {
-                class: "cell h-100",
+                class: "cell code-editor",
                 id: this.props.id,
                 "data-cell-id": this.props.id,
                 "data-cell-type": "CodeEditor",

--- a/object_database/web/content/components/CodeEditor.js
+++ b/object_database/web/content/components/CodeEditor.js
@@ -31,7 +31,6 @@ class CodeEditor extends Component {
         } else {
             console.log("setting up editor");
             this.editor.last_edit_millis = Date.now();
-
             this.editor.setTheme("ace/theme/textmate");
             this.editor.session.setMode("ace/mode/python");
             this.editor.setAutoScrollEditorIntoView(true);
@@ -63,6 +62,12 @@ class CodeEditor extends Component {
         }
     }
 
+    componentDidUpdate(){
+        let newEditor = ace.edit(`editor${this.props.id}`);
+        newEditor.setSession(this.editor.session);
+        this.editor = newEditor;
+    }
+
 
     build(){
         return h('div',
@@ -71,6 +76,7 @@ class CodeEditor extends Component {
                 id: this.props.id,
                 "data-cell-id": this.props.id,
                 "data-cell-type": "CodeEditor",
+                key: this
             },
                  [h('div', { id: "editor" + this.props.id, class: "code-editor-inner" }, [])
         ]);

--- a/object_database/web/content/components/Component.js
+++ b/object_database/web/content/components/Component.js
@@ -48,6 +48,7 @@ class Component {
         this.validateProps();
 
         // Bind context to methods
+        this.toString = this.toString.bind(this);
         this.getReplacementElementFor = this.getReplacementElementFor.bind(this);
         this.getReplacementElementsFor = this.getReplacementElementsFor.bind(this);
         this.getDOMElement = this.getDOMElement.bind(this);
@@ -254,6 +255,13 @@ class Component {
      */
     get name(){
         return this.constructor.name;
+    }
+
+    /**
+     * Override default string representation
+     */
+    toString(){
+        return `${this.name} [${this.props.id}]`;
     }
 
     /**

--- a/object_database/web/content/components/Subscribed.js
+++ b/object_database/web/content/components/Subscribed.js
@@ -28,6 +28,7 @@ class Subscribed extends Component {
 
         // Bind component methods
         this.makeContent = this.makeContent.bind(this);
+        this.toString = this.toString.bind(this);
     }
 
     build(){
@@ -47,6 +48,10 @@ class Subscribed extends Component {
         } else {
             return this.renderChildNamed('content');
         }
+    }
+
+    toString(){
+        return `Sub[${this.props.id}]<${this.props.namedChildren.content}>`;
     }
 }
 

--- a/object_database/web/content/components/Subscribed.js
+++ b/object_database/web/content/components/Subscribed.js
@@ -28,7 +28,6 @@ class Subscribed extends Component {
 
         // Bind component methods
         this.makeContent = this.makeContent.bind(this);
-        this.toString = this.toString.bind(this);
     }
 
     build(){
@@ -38,8 +37,18 @@ class Subscribed extends Component {
     }
 
     getDOMElement(){
+        // Sometimes you can have a Subscribed in another Subscribed,
+        // which can really throw off the whole "non-display"
+        // rendering process. So, as long as the parent of this
+        // instance isn't a Subscribed, we do a basic lookup.
+        // Otherwise, call the same method on the parent.
         let el = document.querySelector(`[data-subscribed-to="${this.props.id}"]`);
-        return el;
+        if(el){
+            return el;
+        } else if(this.parent && this.parent.name == "Subscribed"){
+            return this.parent.getDOMElement();
+        }
+        return null;
     }
 
     makeContent(){
@@ -48,10 +57,6 @@ class Subscribed extends Component {
         } else {
             return this.renderChildNamed('content');
         }
-    }
-
-    toString(){
-        return `Sub[${this.props.id}]<${this.props.namedChildren.content}>`;
     }
 }
 

--- a/object_database/web/content/components/SubscribedSequence.js
+++ b/object_database/web/content/components/SubscribedSequence.js
@@ -47,8 +47,6 @@ class SubscribedSequence extends Component {
             return elements.map(childComponent => {
                 let hyperscript = render(childComponent);
                 let childComponentName = childComponent.constructor.name;
-                console.log(`[${this}] rendering ${childComponent} flexing: ${childComponent.props.flexChild}`);
-                // End Debugging
                 if(childComponent.props.flexChild == true && this.props.flexParent){
                     hyperscript.properties.class += " flex-child";
                 }

--- a/object_database/web/content/components/SubscribedSequence.js
+++ b/object_database/web/content/components/SubscribedSequence.js
@@ -47,7 +47,7 @@ class SubscribedSequence extends Component {
             return elements.map(childComponent => {
                 let hyperscript = render(childComponent);
                 let childComponentName = childComponent.constructor.name;
-                console.log(`[${this.props.id}] rendering ${childComponentName}[${childComponent.props.id}] flexing: ${childComponent.props.flexChild}`);
+                console.log(`[${this}] rendering ${childComponent} flexing: ${childComponent.props.flexChild}`);
                 // End Debugging
                 if(childComponent.props.flexChild == true && this.props.flexParent){
                     hyperscript.properties.class += " flex-child";

--- a/object_database/web/content/package.json
+++ b/object_database/web/content/package.json
@@ -8,8 +8,8 @@
     "test-libs": "./node_modules/mocha/bin/mocha --require esm ./tests/",
     "test-components": "./node_modules/mocha/bin/mocha --require esm ./components/tests/",
     "build": "webpack",
-      "build:frontend": "webpack",
-      "frontend": "webpack && python ../../frontends/object_database_webtest.py"
+    "build:frontend": "webpack",
+    "frontend": "webpack && python ../../frontends/object_database_webtest.py"
   },
   "author": "",
   "license": "ISC",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
This PR implements a series of changes that resolve Issue #229 
  
## Motivation and Context
<!-- Why is this change required? -->
Issue #229 highlighted situations where `CodeEditor` components were not displaying properly, or at all, in certain combinations of Sequences. Additionally, in the course of dealing with this issue we discovered problems that can occur when a `CodeEditor` component re-renders as a part of a Subscribed process. 
<!-- What problem does it solve? -->
<!--  If it fixes an open issue, please link to the issue here.-->

## Approach
<!-- Describe your changes in reasonable detail -->
### Styling ###
Dealing with the presentation of `CodeEditor` components in plain Sequences involved several CSS class and styling alterations and additions. Some exceptions had to be made for CodeEditors in particular, since Ace normally wants you to supply some kind of defined dimension for the height of the editor.
  
Part of the solution was to assume that `CodeEditor` cells will *always* be Flex (ie we now set `cell.isFlex` to `True` in the constructor. This will work in most cases where Sequences are not updating dynamically due to Subscribed changes etc.
  
In dynamic cases, we had to fix the assumptions of the CellsTestPage examples that were not working. Often one needs to explicitly wrap `cells.Flex()` around CodeEditors or parents of CodeEditors that are in some kind of Subscribed structure. This is because a parent Sequence cannot know after the fact to change itself from being a flex-parent based on the changes in isFlex of any of its children. Otherwise it would have to rerender itself which might lead to an infinite loop.
  
### Subscribed Rendering ###
One knock-on issue that emerged dealt with how we render -- or rather don't render -- `Subscribed` components to the DOM.
  
Normally on any update to an existing `Subscribed` component, we simply call `component.getDOMNode()` when attempting to project with maquette:
https://github.com/APrioriInvestments/nativepython/blob/dev-cells/object_database/web/content/NewCellHandler.js#L156
  
The default behavior of this method for Components is to simply lookup the id in the DOM and return the corresponding element. But for Subscribed we override the method, and instead return the element corresponding to its *previous* content, which is accessed by `[data-subscribed-to="<subscribed-id"]`.
  
This pattern has worked well, but now for the first time we have discovered an exception: when a `Subscribed` is the direct child of another `Subscribed`, as in the CodeEditor Horizontal Sequence example. There are cases where fetching the DOM element this way might return nothing, which will lead to runtime errors. 
  
We have changed the implementation slightly, to attempt to call the `getDOMNode()` of the component's parent element if it is a Subscribed and no previous element was found ([see here](https://github.com/APrioriInvestments/nativepython/blob/dev-cells-issue-229/object_database/web/content/components/Subscribed.js#L39)). This seems to have done the trick.

## How Has This Been Tested?
<!-- Describe in reasonable detail how you tested your changes. -->
<!-- If appropriate, include details of your testing environment, -->
<!-- tests ran to see how your change affects other areas of the code, etc. -->

## Screenshots or console output (if appropriate)
<!-- if not appropriate, remove this section -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
  
## Closes
#229 