### PR TITLE
Support magic methods for Class types.  Refs #240, #254.

### DIFF
--- a/typed_python/AlternativeType.hpp
+++ b/typed_python/AlternativeType.hpp
@@ -37,10 +37,12 @@ public:
             m_default_construction_ix(0),
             m_default_construction_type(nullptr),
             m_subtypes(subtypes),
-            m_methods(methods)
+            m_methods(methods),
+            m_hasGetAttributeMagicMethod(false)
     {
         m_name = name;
         m_is_simple = false;
+        m_hasGetAttributeMagicMethod = m_methods.find("__getattribute__") != m_methods.end();
 
         if (m_subtypes.size() > 255) {
             throw std::runtime_error("Can't have an alternative with more than 255 subelements");
@@ -51,6 +53,10 @@ public:
         _updateAfterForwardTypesChanged();
 
         endOfConstructorInitialization(); // finish initializing the type object.
+    }
+
+    bool hasGetAttributeMagicMethod() const {
+        return m_hasGetAttributeMagicMethod;
     }
 
     bool isBinaryCompatibleWithConcrete(Type* other);
@@ -179,5 +185,6 @@ private:
     std::map<std::string, Function*> m_methods;
 
     std::map<std::string, int> m_arg_positions;
-};
 
+    bool m_hasGetAttributeMagicMethod;
+};

--- a/typed_python/ClassType.cpp
+++ b/typed_python/ClassType.cpp
@@ -53,6 +53,12 @@ bool Class::checkInitializationFlag(instance_ptr self, int64_t ix) const {
     return m_heldClass->checkInitializationFlag(l.data, ix);
 }
 
+//static
+bool Class::cmpStatic(Class* t, instance_ptr left, instance_ptr right, int64_t pyComparisonOp) {
+    // TODO: assert that t is a Class pointer
+    return t->cmp(left, right, pyComparisonOp, false);
+}
+
 bool Class::cmp(instance_ptr left, instance_ptr right, int pyComparisonOp, bool suppressExceptions) {
     const char* method = nullptr;
     switch (pyComparisonOp) {

--- a/typed_python/ClassType.hpp
+++ b/typed_python/ClassType.hpp
@@ -140,6 +140,7 @@ public:
     bool checkInitializationFlag(instance_ptr self, int64_t ix) const;
 
     bool cmp(instance_ptr left, instance_ptr right, int pyComparisonOp, bool suppressExceptions);
+    static bool cmpStatic(Class* T, instance_ptr left, instance_ptr right, int64_t pyComparisonOp);
 
     template<class buf_t>
     void deserialize(instance_ptr self, buf_t& buffer, size_t inWireType) {
@@ -290,4 +291,3 @@ public:
 private:
     HeldClass* m_heldClass;
 };
-

--- a/typed_python/HeldClassType.hpp
+++ b/typed_python/HeldClassType.hpp
@@ -297,7 +297,8 @@ public:
             m_own_staticFunctions(staticFunctions),
             m_own_propertyFunctions(propertyFunctions),
             m_own_classMembers(classMembers),
-            m_hasComparisonOperators(false)
+            m_hasComparisonOperators(false),
+            m_hasGetAttributeMagicMethod(false)
     {
         m_name = inName;
 
@@ -307,6 +308,8 @@ public:
         if (m_memberFunctions.find("__gt__") != m_memberFunctions.end()) { m_hasComparisonOperators = true; }
         if (m_memberFunctions.find("__le__") != m_memberFunctions.end()) { m_hasComparisonOperators = true; }
         if (m_memberFunctions.find("__ge__") != m_memberFunctions.end()) { m_hasComparisonOperators = true; }
+
+        if (m_own_memberFunctions.find("__getattribute__") != m_own_memberFunctions.end()) { m_hasGetAttributeMagicMethod = true; }
     }
 
     bool isBinaryCompatibleWithConcrete(Type* other);
@@ -582,6 +585,10 @@ public:
         return m_hasComparisonOperators;
     }
 
+    bool hasGetAttributeMagicMethod() const {
+        return m_hasGetAttributeMagicMethod;
+    }
+
     void initializeMRO() {
         // this is not how the MRO actually works, but we have yet to actually
         // code it correctly.
@@ -808,6 +815,5 @@ private:
     std::unordered_map<const char*, BoundMethod*, HashConstCharPtr, ConstCharPtrsAreEqual> m_memberFunctionMethodTypes;
 
     bool m_hasComparisonOperators;
-
+    bool m_hasGetAttributeMagicMethod;
 };
-

--- a/typed_python/PyAlternativeInstance.cpp
+++ b/typed_python/PyAlternativeInstance.cpp
@@ -174,13 +174,15 @@ PyObject* PyAlternativeInstance::tp_getattr_concrete(PyObject* pyAttrName, const
 }
 
 PyObject* PyConcreteAlternativeInstance::tp_getattr_concrete(PyObject* pyAttrName, const char* attrName) {
-    auto p = callMethod("__getattribute__", pyAttrName);
-    if (PyErr_Occurred() && PyErr_ExceptionMatches(PyExc_AttributeError)) {
-        PyErr_Clear();
-    }
-    else {
-        if (p.first) {
-            return p.second;
+    if (type()->getAlternative()->hasGetAttributeMagicMethod()) {
+        auto p = callMethod("__getattribute__", pyAttrName);
+        if (PyErr_Occurred() && PyErr_ExceptionMatches(PyExc_AttributeError)) {
+            PyErr_Clear();
+        }
+        else {
+            if (p.first) {
+                return p.second;
+            }
         }
     }
 
@@ -191,7 +193,7 @@ PyObject* PyConcreteAlternativeInstance::tp_getattr_concrete(PyObject* pyAttrNam
         return incref(Py_False);
     }
 
-    if (strcmp(attrName,"matches") == 0) {
+    if (strcmp(attrName, "matches") == 0) {
         PyInstance* self = duplicate();
 
         self->mIteratorOffset = -1;

--- a/typed_python/PyAlternativeInstance.hpp
+++ b/typed_python/PyAlternativeInstance.hpp
@@ -24,12 +24,6 @@ public:
 
     Alternative* type();
 
-    PyObject* pyTernaryOperatorConcrete(PyObject* rhs, PyObject* ternary, const char* op, const char* opErr);
-
-    PyObject* pyOperatorConcrete(PyObject* rhs, const char* op, const char* opErr);
-
-    PyObject* pyUnaryOperatorConcrete(const char* op, const char* opErr);
-
     PyObject* tp_getattr_concrete(PyObject* pyAttrName, const char* attrName);
 
     static void mirrorTypeInformationIntoPyTypeConcrete(Alternative* alt, PyTypeObject* pyType);
@@ -59,6 +53,7 @@ public:
     PyObject* pyTernaryOperatorConcrete(PyObject* rhs, PyObject* ternary, const char* op, const char* opErr);
 
     PyObject* pyOperatorConcrete(PyObject* rhs, const char* op, const char* opErr);
+    PyObject* pyOperatorConcreteReverse(PyObject* rhs, const char* op, const char* opErr);
 
     PyObject* pyUnaryOperatorConcrete(const char* op, const char* opErr);
 
@@ -78,8 +73,8 @@ public:
 
     Py_ssize_t mp_and_sq_length_concrete();
 
-    PyObject* sq_item_concrete(Py_ssize_t ix);
-    int sq_ass_item_concrete(Py_ssize_t ix, PyObject* v);
+    PyObject* mp_subscript_concrete(PyObject* item);
+    int mp_ass_subscript_concrete(PyObject* item, PyObject* v);
 
     PyObject* tp_iter_concrete();
 

--- a/typed_python/PyBoundMethodInstance.cpp
+++ b/typed_python/PyBoundMethodInstance.cpp
@@ -21,8 +21,6 @@ BoundMethod* PyBoundMethodInstance::type() {
     return (BoundMethod*)extractTypeFrom(((PyObject*)this)->ob_type);
 }
 
-
-
 PyObject* PyBoundMethodInstance::tp_call_concrete(PyObject* args, PyObject* kwargs) {
     Function* f = type()->getFunction();
     Type* c = type()->getFirstArgType();

--- a/typed_python/PyClassInstance.cpp
+++ b/typed_python/PyClassInstance.cpp
@@ -149,7 +149,7 @@ int PyClassInstance::classInstanceSetAttributeFromPyObject(Class* cls, instance_
 }
 
 PyObject* PyClassInstance::pyUnaryOperatorConcrete(const char* op, const char* opErr) {
-    std::pair<bool, PyObject*> res = callMemberFunction(op);
+    auto res = callMemberFunction(op);
 
     if (!res.first) {
         return PyInstance::pyUnaryOperatorConcrete(op, opErr);
@@ -159,13 +159,22 @@ PyObject* PyClassInstance::pyUnaryOperatorConcrete(const char* op, const char* o
 }
 
 PyObject* PyClassInstance::pyOperatorConcrete(PyObject* rhs, const char* op, const char* opErr) {
-    std::pair<bool, PyObject*> res = callMemberFunction(op, rhs);
+    auto res = callMemberFunction(op, rhs);
 
-    if (!res.first) {
-        return PyInstance::pyOperatorConcrete(rhs, op, opErr);
+    if (res.first) {
+        return res.second;
     }
 
-    return res.second;
+    if (strlen(op) > 2 && strlen(op) < 16 && op[2] == 'i') { // an inplace operator should fall back to the regular operator
+        char reg_op[16] = "__";
+        strcpy(&reg_op[2], op + 3);
+
+        auto res = callMemberFunction(reg_op, rhs);
+        if (res.first)
+            return res.second;
+    }
+
+    return PyInstance::pyOperatorConcrete(rhs, op, opErr);
 }
 
 PyObject* PyClassInstance::pyOperatorConcreteReverse(PyObject* lhs, const char* op, const char* opErr) {
@@ -174,7 +183,7 @@ PyObject* PyClassInstance::pyOperatorConcreteReverse(PyObject* lhs, const char* 
     buf[0] = '_';
     buf[2] = 'r';
 
-    std::pair<bool, PyObject*> res = callMemberFunction(buf, lhs);
+    auto res = callMemberFunction(buf, lhs);
 
     if (!res.first) {
         return PyInstance::pyOperatorConcreteReverse(lhs, buf, opErr);
@@ -183,7 +192,7 @@ PyObject* PyClassInstance::pyOperatorConcreteReverse(PyObject* lhs, const char* 
     return res.second;
 }
 
-PyObject* PyClassInstance::pyTernaryUnaryOperatorConcrete(PyObject* rhs, PyObject* ternaryArg, const char* op, const char* opErr) {
+PyObject* PyClassInstance::pyTernaryOperatorConcrete(PyObject* rhs, PyObject* ternaryArg, const char* op, const char* opErr) {
     if (ternaryArg == Py_None) {
         //if you pass 'None' as the third argument, python calls your class
         //__pow__ function with two arguments. This is the behavior for
@@ -191,7 +200,7 @@ PyObject* PyClassInstance::pyTernaryUnaryOperatorConcrete(PyObject* rhs, PyObjec
         return pyOperatorConcrete(rhs, op, opErr);
     }
 
-    std::pair<bool, PyObject*> res = callMemberFunction(op, rhs, ternaryArg);
+    auto res = callMemberFunction(op, rhs, ternaryArg);
 
     if (!res.first) {
         return PyInstance::pyTernaryOperatorConcrete(rhs, ternaryArg, op, opErr);
@@ -202,9 +211,9 @@ PyObject* PyClassInstance::pyTernaryUnaryOperatorConcrete(PyObject* rhs, PyObjec
 
 int PyClassInstance::pyInquiryConcrete(const char* op, const char* opErrRep) {
     // op == '__bool__'
-    std::pair<bool, PyObject*> p = callMemberFunction("__bool__", nullptr, nullptr);
+    auto p = callMemberFunction("__bool__");
     if (!p.first) {
-        p = callMemberFunction("__len__", nullptr, nullptr);
+        p = callMemberFunction("__len__");
         // if neither __bool__ nor __len__ is available, return True
         if (!p.first)
             return 1;
@@ -212,7 +221,18 @@ int PyClassInstance::pyInquiryConcrete(const char* op, const char* opErrRep) {
     return PyObject_IsTrue(p.second);
 }
 
-std::pair<bool, PyObject*> PyClassInstance::callMemberFunction(const char* name, PyObject* arg0, PyObject* arg1) {
+// try to call user-defined hash method
+// returns -1 if not defined or if it returns an invalid value
+int64_t PyClassInstance::tryCallHashMemberFunction() {
+    auto result = callMemberFunction("__hash__");
+    if (!result.first)
+        return -1;
+    if (!PyLong_Check(result.second))
+        return -1;
+    return PyLong_AsLong(result.second);
+}
+
+std::pair<bool, PyObject*> PyClassInstance::callMemberFunction(const char* name, PyObject* arg0, PyObject* arg1, PyObject* arg2) {
     auto it = type()->getMemberFunctions().find(name);
 
     if (it == type()->getMemberFunctions().end()) {
@@ -228,6 +248,9 @@ std::pair<bool, PyObject*> PyClassInstance::callMemberFunction(const char* name,
     if (arg1) {
         argCount += 1;
     }
+    if (arg2) {
+        argCount += 1;
+    }
 
     PyObjectStealer targetArgTuple(PyTuple_New(argCount));
 
@@ -236,9 +259,11 @@ std::pair<bool, PyObject*> PyClassInstance::callMemberFunction(const char* name,
     if (arg0) {
         PyTuple_SetItem(targetArgTuple, 1, incref(arg0)); //steals a reference
     }
-
     if (arg1) {
         PyTuple_SetItem(targetArgTuple, 2, incref(arg1)); //steals a reference
+    }
+    if (arg2) {
+        PyTuple_SetItem(targetArgTuple, 3, incref(arg2)); //steals a reference
     }
 
     auto res = PyFunctionInstance::tryToCallAnyOverload(method, nullptr, targetArgTuple, nullptr);
@@ -254,18 +279,8 @@ std::pair<bool, PyObject*> PyClassInstance::callMemberFunction(const char* name,
     return res;
 }
 
-PyObject* PyClassInstance::mp_subscript_concrete(PyObject* item) {
-    std::pair<bool, PyObject*> res = callMemberFunction("__getitem__", item);
-
-    if (res.first) {
-        return res.second;
-    }
-
-    return PyInstance::mp_subscript_concrete(item);
-}
-
 Py_ssize_t PyClassInstance::mp_and_sq_length_concrete() {
-    std::pair<bool, PyObject*> res = callMemberFunction("__len__");
+    auto res = callMemberFunction("__len__");
 
     if (!res.first) {
         return PyInstance::mp_and_sq_length_concrete();
@@ -332,6 +347,16 @@ void PyClassInstance::constructFromPythonArgumentsConcrete(Class* classT, uint8_
 }
 
 PyObject* PyClassInstance::tp_getattr_concrete(PyObject* pyAttrName, const char* attrName) {
+    auto p = callMemberFunction("__getattribute__", pyAttrName);
+    if (PyErr_Occurred() && PyErr_ExceptionMatches(PyExc_AttributeError)) {
+        PyErr_Clear();
+    }
+    else {
+        if (p.first) {
+            return p.second;
+        }
+    }
+
     int index = type()->getMemberIndex(attrName);
 
     if (index >= 0) {
@@ -359,7 +384,7 @@ PyObject* PyClassInstance::tp_getattr_concrete(PyObject* pyAttrName, const char*
     {
         auto it = type()->getPropertyFunctions().find(attrName);
         if (it != type()->getPropertyFunctions().end()) {
-            std::pair<bool, PyObject*> res = PyFunctionInstance::tryToCall(it->second, (PyObject*)this);
+            auto res = PyFunctionInstance::tryToCall(it->second, (PyObject*)this);
             if (res.first) {
                 return res.second;
             }
@@ -380,7 +405,18 @@ PyObject* PyClassInstance::tp_getattr_concrete(PyObject* pyAttrName, const char*
         }
     }
 
-    return PyInstance::tp_getattr_concrete(pyAttrName, attrName);
+    PyObject* ret = PyInstance::tp_getattr_concrete(pyAttrName, attrName);
+    if (PyErr_Occurred() && PyErr_ExceptionMatches(PyExc_AttributeError)) {
+        PyErr_Clear();
+        auto p = callMemberFunction("__getattr__", pyAttrName);
+        if (p.first) {
+            return p.second;
+        }
+        else {
+            PyErr_Format(PyExc_AttributeError, "no attribute %s for instance of type %s", attrName, type()->name().c_str());
+        }
+    }
+    return ret;
 }
 
 void PyClassInstance::mirrorTypeInformationIntoPyTypeConcrete(Class* classT, PyTypeObject* pyType) {
@@ -439,7 +475,15 @@ void PyClassInstance::mirrorTypeInformationIntoPyTypeConcrete(Class* classT, PyT
 
     for (auto p: classT->getMemberFunctions()) {
         PyDict_SetItemString(memberFunctions, p.first.c_str(), typePtrToPyTypeRepresentation(p.second));
-        PyDict_SetItemString(pyType->tp_dict, p.first.c_str(), typePtrToPyTypeRepresentation(p.second));
+
+        // TODO: find a predefined function that does this method search
+        PyMethodDef* defined = pyType->tp_methods;
+        while (defined && defined->ml_name && !!strcmp(defined->ml_name, p.first.c_str()))
+            defined++;
+
+        if (!defined || !defined->ml_name) {
+            PyDict_SetItemString(pyType->tp_dict, p.first.c_str(), typePtrToPyTypeRepresentation(p.second));
+        }
     }
 
     //expose 'ElementType' as a member of the type object
@@ -473,6 +517,16 @@ void PyClassInstance::mirrorTypeInformationIntoPyTypeConcrete(Class* classT, PyT
 }
 
 int PyClassInstance::tp_setattr_concrete(PyObject* attrName, PyObject* attrVal) {
+    if (!attrVal) {
+        auto p = callMemberFunction("__delattr__", attrName);
+        if (p.first)
+            return 0;
+    }
+    else {
+        auto p = callMemberFunction("__setattr__", attrName, attrVal);
+        if (p.first)
+            return 0;
+    }
     return PyClassInstance::classInstanceSetAttributeFromPyObject(type(), dataPtr(), attrName, attrVal);
 }
 
@@ -498,4 +552,326 @@ PyObject* PyClassInstance::tp_call_concrete(PyObject* args, PyObject* kwargs) {
     }
     // else
     throw PythonExceptionSet();
+}
+
+
+int PyClassInstance::sq_contains_concrete(PyObject* item) {
+    auto p = callMemberFunction("__contains__", item);
+    if (!p.first) {
+        return 0;
+    }
+    return PyObject_IsTrue(p.second);
+}
+
+PyObject* PyClassInstance::mp_subscript_concrete(PyObject* item) {
+    auto p = callMemberFunction("__getitem__", item);
+    if (!p.first) {
+        PyErr_Format(PyExc_TypeError, "__getitem__ not defined for type %s", type()->name().c_str());
+        return NULL;
+    }
+    return p.second;
+}
+
+int PyClassInstance::mp_ass_subscript_concrete(PyObject* item, PyObject* v) {
+    auto p = callMemberFunction("__setitem__", item, v);
+    if (!p.first) {
+        PyErr_Format(PyExc_TypeError, "__setitem__ not defined for type %s", type()->name().c_str());
+        return -1;
+    }
+    return 0;
+}
+
+PyObject* PyClassInstance::tp_iter_concrete() {
+    auto p = callMemberFunction("__iter__");
+    if (!p.first) {
+        PyErr_Format(PyExc_TypeError, "__iter__ not defined for type %s", type()->name().c_str());
+        return NULL;
+    }
+    return p.second;
+}
+
+PyObject* PyClassInstance::tp_iternext_concrete() {
+    auto p = callMemberFunction("__next__");
+    if (!p.first) {
+        PyErr_Format(PyExc_TypeError, "__next__ not defined for type %s", type()->name().c_str());
+        return NULL;
+    }
+    return p.second;
+}
+
+// static
+PyObject* PyClassInstance::clsFormat(PyObject* o, PyObject* args, PyObject* kwargs) {
+    PyClassInstance* self = (PyClassInstance*)o;
+
+    if (PyTuple_Size(args) != 1 || kwargs) {
+        PyErr_Format(PyExc_TypeError, "__format__ invalid number of parameters");
+        return NULL;
+    }
+    PyObjectStealer arg0(PyTuple_GetItem(args, 0));
+
+    auto result = self->callMemberFunction("__format__", arg0);
+    if (!result.first) {
+        PyErr_Format(PyExc_TypeError, "__format__ not defined for type %s", self->type()->name().c_str());
+        return NULL;
+    }
+    if (!PyUnicode_Check(result.second)) {
+        PyErr_Format(PyExc_TypeError, "__format__ returned non-string for type %s", self->type()->name().c_str());
+        return NULL;
+    }
+
+    return result.second;
+}
+
+// static
+PyObject* PyClassInstance::clsBytes(PyObject* o, PyObject* args, PyObject* kwargs) {
+    PyClassInstance* self = (PyClassInstance*)o;
+
+    if (PyTuple_Size(args) > 0 || kwargs) {
+        PyErr_Format(PyExc_TypeError, "__bytes__ invalid number of parameters");
+        return NULL;
+    }
+
+    auto result = self->callMemberFunction("__bytes__");
+    if (!result.first) {
+        PyErr_Format(PyExc_TypeError, "__bytes__ not defined for type %s", self->type()->name().c_str());
+        return NULL;
+    }
+    if (!PyBytes_Check(result.second)) {
+        PyErr_Format(PyExc_TypeError, "__bytes__ returned non-bytes %s for type %s", result.second->ob_type->tp_name, self->type()->name().c_str());
+        return NULL;
+    }
+
+    return result.second;
+}
+
+// static
+PyObject* PyClassInstance::clsDir(PyObject* o, PyObject* args, PyObject* kwargs) {
+    PyClassInstance* self = (PyClassInstance*)o;
+
+    if (PyTuple_Size(args) > 0 || kwargs) {
+        PyErr_Format(PyExc_TypeError, "__dir__ invalid number of parameters");
+        return NULL;
+    }
+
+    auto result = self->callMemberFunction("__dir__");
+    if (!result.first) {
+        PyErr_Format(PyExc_TypeError, "__dir__ missing");
+        return NULL;
+    }
+    if (!PySequence_Check(result.second)) {
+        PyErr_Format(PyExc_TypeError, "__dir__ returned non-sequence %s for type %s", result.second->ob_type->tp_name, self->type()->name().c_str());
+        return NULL;
+    }
+
+    return result.second;
+}
+
+// static
+PyObject* PyClassInstance::clsReversed(PyObject* o, PyObject* args, PyObject* kwargs) {
+    PyClassInstance* self = (PyClassInstance*)o;
+
+    if (PyTuple_Size(args) > 0 || kwargs) {
+        PyErr_Format(PyExc_TypeError, "__reversed__ invalid number of parameters");
+        return NULL;
+    }
+
+    auto result = self->callMemberFunction("__reversed__");
+    if (!result.first) {
+        PyErr_Format(PyExc_TypeError, "__reversed__ missing");
+        return NULL;
+    }
+
+    return result.second;
+}
+
+// static
+PyObject* PyClassInstance::clsComplex(PyObject* o, PyObject* args, PyObject* kwargs) {
+    PyClassInstance* self = (PyClassInstance*)o;
+
+    if (PyTuple_Size(args) > 0 || kwargs) {
+        PyErr_Format(PyExc_TypeError, "__complex__ invalid number of parameters");
+        return NULL;
+    }
+
+    auto result = self->callMemberFunction("__complex__");
+    if (!result.first) {
+        PyErr_Format(PyExc_TypeError, "__complex__ missing");
+        return NULL;
+    }
+    if (!PyComplex_Check(result.second)) {
+        PyErr_Format(PyExc_TypeError, "__complex__ returned non-complex %s for type %s", result.second->ob_type->tp_name, self->type()->name().c_str());
+        return NULL;
+    }
+
+    return result.second;
+}
+
+// static
+PyObject* PyClassInstance::clsRound(PyObject* o, PyObject* args, PyObject* kwargs) {
+    PyClassInstance* self = (PyClassInstance*)o;
+
+    if (PyTuple_Size(args) > 1 || kwargs) {
+        PyErr_Format(PyExc_TypeError, "__round__ invalid number of parameters %d %d", PyTuple_Size(args), kwargs);
+        return NULL;
+    }
+
+    if (PyTuple_Size(args) == 1) {
+        PyObjectStealer arg0(PyTuple_GetItem(args, 0));
+        auto result = self->callMemberFunction("__round__", arg0);
+        if (!result.first) {
+            PyErr_Format(PyExc_TypeError, "__round__ missing");
+            return NULL;
+        }
+        return result.second;
+    }
+
+    auto result = self->callMemberFunction("__round__");
+    if (!result.first) {
+        PyErr_Format(PyExc_TypeError, "__round__ missing");
+        return NULL;
+    }
+    if (!PyLong_Check(result.second)) {
+        PyErr_Format(PyExc_TypeError, "__round__ returned non-integer %s for type %s", result.second->ob_type->tp_name, self->type()->name().c_str());
+        return NULL;
+    }
+
+    return result.second;
+}
+
+// static
+PyObject* PyClassInstance::clsTrunc(PyObject* o, PyObject* args, PyObject* kwargs) {
+    PyClassInstance* self = (PyClassInstance*)o;
+
+    if (PyTuple_Size(args) > 0 || kwargs) {
+        PyErr_Format(PyExc_TypeError, "__trunc__ invalid number of parameters");
+        return NULL;
+    }
+
+    auto result = self->callMemberFunction("__trunc__");
+    if (!result.first) {
+        PyErr_Format(PyExc_TypeError, "__trunc__ missing");
+        return NULL;
+    }
+    if (!PyLong_Check(result.second)) {
+        PyErr_Format(PyExc_TypeError, "__trunc__ returned non-integer %s for type %s", result.second->ob_type->tp_name, self->type()->name().c_str());
+        return NULL;
+    }
+
+    return result.second;
+}
+
+// static
+PyObject* PyClassInstance::clsFloor(PyObject* o, PyObject* args, PyObject* kwargs) {
+    PyClassInstance* self = (PyClassInstance*)o;
+
+    if (PyTuple_Size(args) > 0 || kwargs) {
+        PyErr_Format(PyExc_TypeError, "__floor__ invalid number of parameters");
+        return NULL;
+    }
+
+    auto result = self->callMemberFunction("__floor__");
+    if (!result.first) {
+        PyErr_Format(PyExc_TypeError, "__floor__ missing");
+        return NULL;
+    }
+    if (!PyLong_Check(result.second)) {
+        PyErr_Format(PyExc_TypeError, "__floor__ returned non-integer %s for type %s", result.second->ob_type->tp_name, self->type()->name().c_str());
+        return NULL;
+    }
+
+    return result.second;
+}
+
+// static
+PyObject* PyClassInstance::clsCeil(PyObject* o, PyObject* args, PyObject* kwargs) {
+    PyClassInstance* self = (PyClassInstance*)o;
+
+    if (PyTuple_Size(args) > 0 || kwargs) {
+        PyErr_Format(PyExc_TypeError, "__ceil__ invalid number of parameters");
+        return NULL;
+    }
+
+    auto result = self->callMemberFunction("__ceil__");
+    if (!result.first) {
+        PyErr_Format(PyExc_TypeError, "__ceil__ missing");
+        return NULL;
+    }
+    if (!PyLong_Check(result.second)) {
+        PyErr_Format(PyExc_TypeError, "__ceil__ returned non-integer %s for type %s", result.second->ob_type->tp_name, self->type()->name().c_str());
+        return NULL;
+    }
+
+    return result.second;
+}
+
+// static
+PyObject* PyClassInstance::clsEnter(PyObject* o, PyObject* args, PyObject* kwargs) {
+    PyClassInstance* self = (PyClassInstance*)o;
+
+    if (PyTuple_Size(args) > 0 || kwargs) {
+        PyErr_Format(PyExc_TypeError, "__enter__ invalid number of parameters");
+        return NULL;
+    }
+
+    auto result = self->callMemberFunction("__enter__");
+    if (!result.first) {
+        PyErr_Format(PyExc_TypeError, "__enter__ missing");
+        return NULL;
+    }
+
+    return result.second;
+}
+
+// static
+PyObject* PyClassInstance::clsExit(PyObject* o, PyObject* args, PyObject* kwargs) {
+    PyClassInstance* self = (PyClassInstance*)o;
+
+    if (PyTuple_Size(args) != 3 || kwargs) {
+        PyErr_Format(PyExc_TypeError, "__exit__ invalid number of parameters");
+        return NULL;
+    }
+    PyObjectStealer arg0(PyTuple_GetItem(args, 0));
+    PyObjectStealer arg1(PyTuple_GetItem(args, 1));
+    PyObjectStealer arg2(PyTuple_GetItem(args, 2));
+
+    auto result = self->callMemberFunction("__exit__", arg0, arg1, arg2);
+    if (!result.first) {
+        PyErr_Format(PyExc_TypeError, "__exit__ missing");
+        return NULL;
+    }
+
+    return result.second;
+}
+
+// static
+PyMethodDef* PyClassInstance::typeMethodsConcrete(Type* t) {
+
+    // List of magic methods that are not attached to direct function pointers in PyTypeObject.
+    //   These need to be defined by adding entries to PyTypeObject.tp_methods
+    //   and we need to avoid adding them to PyTypeObject.tp_dict ourselves.
+    //   Also, we only want to add the entry to tp_methods if they are explicitly defined.
+    const std::map<const char*, PyCFunction> special_magic_methods = {
+            {"__format__", (PyCFunction)clsFormat},
+            {"__bytes__", (PyCFunction)clsBytes},
+            {"__dir__", (PyCFunction)clsDir},
+            {"__reversed__", (PyCFunction)clsReversed},
+            {"__complex__", (PyCFunction)clsComplex},
+            {"__round__", (PyCFunction)clsRound},
+            {"__trunc__", (PyCFunction)clsTrunc},
+            {"__floor__", (PyCFunction)clsFloor},
+            {"__ceil__", (PyCFunction)clsCeil},
+            {"__enter__", (PyCFunction)clsEnter},
+            {"__exit__", (PyCFunction)clsExit}
+        };
+
+    int cur = 0;
+    auto clsMethods = ((Class*)t)->getMemberFunctions();
+    PyMethodDef* ret = new PyMethodDef[special_magic_methods.size() + 1];
+    for (auto m: special_magic_methods) {
+        if (clsMethods.find(m.first) != clsMethods.end()) {
+            ret[cur++] =  {m.first, m.second, METH_VARARGS | METH_KEYWORDS, NULL};
+        }
+    }
+    ret[cur] = {NULL, NULL};
+    return ret;
 }

--- a/typed_python/PyClassInstance.cpp
+++ b/typed_python/PyClassInstance.cpp
@@ -347,13 +347,15 @@ void PyClassInstance::constructFromPythonArgumentsConcrete(Class* classT, uint8_
 }
 
 PyObject* PyClassInstance::tp_getattr_concrete(PyObject* pyAttrName, const char* attrName) {
-    auto p = callMemberFunction("__getattribute__", pyAttrName);
-    if (PyErr_Occurred() && PyErr_ExceptionMatches(PyExc_AttributeError)) {
-        PyErr_Clear();
-    }
-    else {
-        if (p.first) {
-            return p.second;
+    if (type()->getHeldClass()->hasGetAttributeMagicMethod()) {
+        auto p = callMemberFunction("__getattribute__", pyAttrName);
+        if (PyErr_Occurred() && PyErr_ExceptionMatches(PyExc_AttributeError)) {
+            PyErr_Clear();
+        }
+        else {
+            if (p.first) {
+                return p.second;
+            }
         }
     }
 

--- a/typed_python/PyClassInstance.hpp
+++ b/typed_python/PyClassInstance.hpp
@@ -36,15 +36,24 @@ public:
 
     static void constructFromPythonArgumentsConcrete(Class* t, uint8_t* data, PyObject* args, PyObject* kwargs);
 
-    PyObject* mp_subscript_concrete(PyObject* item);
+    std::pair<bool, PyObject*> callMemberFunction(const char* name, PyObject* arg0=nullptr, PyObject* arg1=nullptr, PyObject* arg2=nullptr);
 
-    Py_ssize_t mp_and_sq_length_concrete();
-
-    std::pair<bool, PyObject*> callMemberFunction(const char* name, PyObject* arg0=nullptr, PyObject* arg1=nullptr);
+    int64_t tryCallHashMemberFunction();
 
     PyObject* tp_getattr_concrete(PyObject* pyAttrName, const char* attrName);
 
     PyObject* tp_call_concrete(PyObject* args, PyObject* kwargs);
+
+    int sq_contains_concrete(PyObject* item);
+
+    Py_ssize_t mp_and_sq_length_concrete();
+
+    PyObject* mp_subscript_concrete(PyObject* item);
+    int mp_ass_subscript_concrete(PyObject* item, PyObject* v);
+
+    PyObject* tp_iter_concrete();
+
+    PyObject* tp_iternext_concrete();
 
     PyObject* pyUnaryOperatorConcrete(const char* op, const char* opErr);
 
@@ -52,11 +61,25 @@ public:
 
     PyObject* pyOperatorConcreteReverse(PyObject* lhs, const char* op, const char* opErr);
 
-    PyObject* pyTernaryUnaryOperatorConcrete(PyObject* rhs, PyObject* ternaryArg, const char* op, const char* opErr);
+    PyObject* pyTernaryOperatorConcrete(PyObject* rhs, PyObject* ternaryArg, const char* op, const char* opErr);
 
     int pyInquiryConcrete(const char* op, const char* opErrRep);
 
     static void mirrorTypeInformationIntoPyTypeConcrete(Class* classT, PyTypeObject* pyType);
 
     int tp_setattr_concrete(PyObject* attrName, PyObject* attrVal);
+
+    static PyMethodDef* typeMethodsConcrete(Type* t);
+private:
+    static PyObject* clsFormat(PyObject* o, PyObject* args, PyObject* kwargs);
+    static PyObject* clsBytes(PyObject* o, PyObject* args, PyObject* kwargs);
+    static PyObject* clsDir(PyObject* o, PyObject* args, PyObject* kwargs);
+    static PyObject* clsReversed(PyObject* o, PyObject* args, PyObject* kwargs);
+    static PyObject* clsComplex(PyObject* o, PyObject* args, PyObject* kwargs);
+    static PyObject* clsRound(PyObject* o, PyObject* args, PyObject* kwargs);
+    static PyObject* clsTrunc(PyObject* o, PyObject* args, PyObject* kwargs);
+    static PyObject* clsFloor(PyObject* o, PyObject* args, PyObject* kwargs);
+    static PyObject* clsCeil(PyObject* o, PyObject* args, PyObject* kwargs);
+    static PyObject* clsEnter(PyObject* o, PyObject* args, PyObject* kwargs);
+    static PyObject* clsExit(PyObject* o, PyObject* args, PyObject* kwargs);
 };

--- a/typed_python/PyConstDictInstance.cpp
+++ b/typed_python/PyConstDictInstance.cpp
@@ -234,6 +234,8 @@ PyObject* PyConstDictInstance::pyOperatorConcrete(PyObject* rhs, const char* op,
                 type()->addDicts(dataPtr(), w_rhs->dataPtr(), data);
             });
         } else {
+            if (!PyDict_Check(rhs))
+                return incref(Py_NotImplemented);
             Instance other(type(), [&](instance_ptr data) {
                 copyConstructFromPythonInstance(type(), data, rhs, true);
             });
@@ -244,6 +246,8 @@ PyObject* PyConstDictInstance::pyOperatorConcrete(PyObject* rhs, const char* op,
         }
     }
     if (strcmp(op, "__sub__") == 0) {
+        if (!PySequence_Check(rhs))
+            return incref(Py_NotImplemented);
         Type* tupleOfKeysType = type()->tupleOfKeysType();
 
         //convert rhs to a relevant dict type.
@@ -256,7 +260,7 @@ PyObject* PyConstDictInstance::pyOperatorConcrete(PyObject* rhs, const char* op,
         });
     }
 
-    return ((PyInstance*)this)->pyOperatorConcrete(rhs, op, opErr);
+    return PyInstance::pyOperatorConcrete(rhs, op, opErr);
 }
 
 PyObject* PyConstDictInstance::mp_subscript_concrete(PyObject* item) {

--- a/typed_python/PyDictInstance.cpp
+++ b/typed_python/PyDictInstance.cpp
@@ -184,7 +184,7 @@ int PyDictInstance::sq_contains_concrete(PyObject* item) {
 }
 
 PyObject* PyDictInstance::pyOperatorConcrete(PyObject* rhs, const char* op, const char* opErr) {
-    return ((PyInstance*)this)->pyOperatorConcrete(rhs, op, opErr);
+    return PyInstance::pyOperatorConcrete(rhs, op, opErr);
 }
 
 PyObject* PyDictInstance::mp_subscript_concrete(PyObject* item) {

--- a/typed_python/PyInstance.cpp
+++ b/typed_python/PyInstance.cpp
@@ -332,7 +332,7 @@ PyObject* PyInstance::pyOperator(PyObject* lhs, PyObject* rhs, const char* op, c
 
         if (ret && ret != Py_NotImplemented) {
             return ret;
-            }
+        }
 
         if (extractTypeFrom(rhs->ob_type)) {
             return specializeForType(rhs, [&](auto& subtype) {
@@ -611,8 +611,6 @@ PySequenceMethods* PyInstance::sequenceMethodsFor(Type* t) {
             new PySequenceMethods {0,0,0,0,0,0,0,0};
             res->sq_contains = (objobjproc)PyInstance::sq_contains;
             res->sq_length = (lenfunc)PyInstance::mp_and_sq_length;
-            //res->sq_item = (ssizeargfunc)PyInstance::sq_item;
-            //res->sq_ass_item = (ssizeobjargproc)PyInstance::sq_ass_item;
         return res;
     }
 

--- a/typed_python/PyPointerToInstance.cpp
+++ b/typed_python/PyPointerToInstance.cpp
@@ -136,6 +136,8 @@ PyObject* PyPointerToInstance::pointerCast(PyObject* o, PyObject* args) {
 
 PyObject* PyPointerToInstance::pyOperatorConcrete(PyObject* rhs, const char* op, const char* opErr) {
     if (strcmp(op, "__add__") == 0) {
+        if (!PyLong_Check(rhs))
+            return PyInstance::pyOperatorConcrete(rhs, op, opErr);
         int64_t ix = PyLong_AsLongLong(rhs);
         void* output;
 
@@ -149,7 +151,7 @@ PyObject* PyPointerToInstance::pyOperatorConcrete(PyObject* rhs, const char* op,
 
         if (otherPointer != type()) {
             //call 'super'
-            return ((PyInstance*)this)->pyOperatorConcrete(rhs, op, opErr);
+            return PyInstance::pyOperatorConcrete(rhs, op, opErr);
         }
 
         PyInstance* other_w = (PyPointerToInstance*)rhs;
@@ -160,7 +162,7 @@ PyObject* PyPointerToInstance::pyOperatorConcrete(PyObject* rhs, const char* op,
         return PyLong_FromLong((ptr-other_ptr) / type()->getEltType()->bytecount());
     }
 
-    return ((PyInstance*)this)->pyOperatorConcrete(rhs, op, opErr);
+    return PyInstance::pyOperatorConcrete(rhs, op, opErr);
 }
 
 PyMethodDef* PyPointerToInstance::typeMethodsConcrete(Type* t) {
@@ -182,4 +184,7 @@ void PyPointerToInstance::mirrorTypeInformationIntoPyTypeConcrete(PointerTo* poi
             );
 }
 
-
+int PyPointerToInstance::pyInquiryConcrete(const char* op, const char* opErrRep) {
+    // op == '__bool__'
+    return *(void**)dataPtr() != nullptr;
+}

--- a/typed_python/PyPointerToInstance.hpp
+++ b/typed_python/PyPointerToInstance.hpp
@@ -42,5 +42,6 @@ public:
         return true;
     }
 
+    int pyInquiryConcrete(const char* op, const char* opErrRep);
     static PyMethodDef* typeMethodsConcrete(Type* t);
 };

--- a/typed_python/PyRegisterTypeInstance.hpp
+++ b/typed_python/PyRegisterTypeInstance.hpp
@@ -408,8 +408,10 @@ public:
 
     static void copyConstructFromPythonInstanceConcrete(RegisterType<T>* eltType, instance_ptr tgt, PyObject* pyRepresentation, bool isExplicit) {
         Type::TypeCategory cat = eltType->getTypeCategory();
+        Type* other = extractTypeFrom(pyRepresentation->ob_type);
+        Type::TypeCategory otherCat = other ? other->getTypeCategory() : Type::TypeCategory::catNone;
 
-        if (Type* other = extractTypeFrom(pyRepresentation->ob_type)) {
+        if (other) {
             Type::TypeCategory otherCat = other->getTypeCategory();
 
             if (otherCat == cat || isExplicit) {
@@ -474,7 +476,10 @@ public:
                 return;
             }
 
-            if (isInteger(cat)) {
+            bool otherIsAlternativeOrClass = otherCat == Type::TypeCategory::catConcreteAlternative
+                    || otherCat == Type::TypeCategory::catClass;
+
+            if (isInteger(cat) && !otherIsAlternativeOrClass) {
                 int64_t l = PyLong_AsLongLong(pyRepresentation);
                 if (l == -1 && PyErr_Occurred()) {
                     PyErr_Clear();
@@ -491,7 +496,7 @@ public:
                 return;
             }
 
-            if (isFloat(cat)) {
+            if (isFloat(cat) && !otherIsAlternativeOrClass) {
                 double d = PyFloat_AsDouble(pyRepresentation);
                 if (d == -1.0 && PyErr_Occurred()) {
                     throw PythonExceptionSet();
@@ -976,5 +981,4 @@ public:
             {NULL, NULL}
             };
         }
-
 };

--- a/typed_python/PySetInstance.cpp
+++ b/typed_python/PySetInstance.cpp
@@ -601,7 +601,7 @@ void PySetInstance::copyConstructFromPythonInstanceConcrete(SetType* setType, in
             setType->destroy(tgt);
         }
 
-        throw;
+        throw PythonExceptionSet();
     }
 }
 

--- a/typed_python/PySetInstance.cpp
+++ b/typed_python/PySetInstance.cpp
@@ -601,7 +601,7 @@ void PySetInstance::copyConstructFromPythonInstanceConcrete(SetType* setType, in
             setType->destroy(tgt);
         }
 
-        throw PythonExceptionSet();
+        throw;
     }
 }
 

--- a/typed_python/_runtime.cpp
+++ b/typed_python/_runtime.cpp
@@ -32,6 +32,11 @@ extern "C" {
         return Alternative::cmpStatic(tp, lhs, rhs, pyComparisonOp);
     }
 
+    bool np_runtime_class_cmp(Class* tp, instance_ptr lhs, instance_ptr rhs, int64_t pyComparisonOp) {
+        PyEnsureGilAcquired acquireTheGil;
+        return Class::cmpStatic(tp, lhs, rhs, pyComparisonOp);
+    }
+
     StringType::layout* nativepython_runtime_string_concat(StringType::layout* lhs, StringType::layout* rhs) {
         return StringType::concatenate(lhs, rhs);
     }
@@ -666,9 +671,16 @@ extern "C" {
     }
 
     int32_t nativepython_hash_alternative(Alternative::layout* s, Alternative* tp) {
-        if (tp->getTypeCategory() != Type::TypeCategory::catAlternative)
-            throw std::logic_error("Called hash_alternative with a non-Alternative type");
+        // TODO: assert tp is an Alternative
+        //if (tp->getTypeCategory() != Type::TypeCategory::catAlternative)
+        //    throw std::logic_error("Called hash_alternative with a non-Alternative type");
+        return tp->hash((instance_ptr)&s);
+    }
 
+    int32_t nativepython_hash_class(Class::layout* s, Class* tp) {
+        // TODO: assert tp is a Class
+        //if (tp->getTypeCategory() != Type::TypeCategory::catClass)
+        //    throw std::logic_error("Called hash_class with a non-Class type");
         return tp->hash((instance_ptr)&s);
     }
 

--- a/typed_python/compiler/native_ast.py
+++ b/typed_python/compiler/native_ast.py
@@ -458,6 +458,7 @@ Expression = Expression.define(Alternative(
     rshift=lambda self, other: Expression.Binop(op=BinaryOp.RShift(), left=self, right=ensureExpr(other)),
     bitand=lambda self, other: Expression.Binop(op=BinaryOp.BitAnd(), left=self, right=ensureExpr(other)),
     bitor=lambda self, other: Expression.Binop(op=BinaryOp.BitOr(), left=self, right=ensureExpr(other)),
+    bitxor=lambda self, other: Expression.Binop(op=BinaryOp.BitXor(), left=self, right=ensureExpr(other)),
     load=lambda self: Expression.Load(ptr=self),
     store=lambda self, val: Expression.Store(ptr=self, val=ensureExpr(val)),
     atomic_add=lambda self, val: Expression.AtomicAdd(ptr=self, val=ensureExpr(val)),

--- a/typed_python/compiler/tests/alternative_compilation_test.py
+++ b/typed_python/compiler/tests/alternative_compilation_test.py
@@ -1217,10 +1217,9 @@ class TestAlternativeCompilation(unittest.TestCase):
             self.assertEqual(f_getattr2(v), "4")
             self.assertEqual(f_getattr2(v), c_getattr2(v))
             f_delattr1(v)
-            # TODO: exception types are different.  Should this be made consistent?
             with self.assertRaises(KeyError):
                 f_getattr1(v)
-            with self.assertRaises(TypeError):
+            with self.assertRaises(KeyError):
                 c_getattr1(v)
             self.assertEqual(f_getattr2(v), "4")
             self.assertEqual(f_getattr2(v), c_getattr2(v))

--- a/typed_python/compiler/tests/class_compilation_test.py
+++ b/typed_python/compiler/tests/class_compilation_test.py
@@ -12,11 +12,14 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-from typed_python import Function, Class, TupleOf, ListOf, Member, OneOf, Int64, Float64, String, Final
+from typed_python import Function, Class, Dict, ConstDict, TupleOf, ListOf, Member, OneOf, Int64, UInt64, Int16, \
+    Float32, Float64, String, Final, PointerTo
 import typed_python._types as _types
 from typed_python.compiler.runtime import Runtime, Entrypoint
 import unittest
 import time
+import psutil
+from math import trunc, floor, ceil
 
 
 def Compiled(f):
@@ -729,3 +732,804 @@ class TestClassCompilationCompilation(unittest.TestCase):
         # verify that we don't segfault
         c_f = Compiled(f)
         self.assertIsInstance(c_f(C()), C)
+
+    def test_compile_class_magic_methods(self):
+
+        class C(Class, Final):
+            s = Member(str)
+
+            def __init__(self, label=""):
+                self.s = label
+
+            def __eq__(self, other):
+                return self.s == other.s
+
+            __bool__ = lambda self: False
+            __str__ = lambda self: "my str"
+            __repr__ = lambda self: "my repr"
+            __call__ = lambda self, i: "my call"
+            __len__ = lambda self: 42
+            __contains__ = lambda self, item: item == 1
+            __bytes__ = lambda self: b'my bytes'
+
+            __int__ = lambda self: 43
+            __float__ = lambda self: 44.44
+            __complex__ = lambda self: 3+4j
+
+            __add__ = lambda self, other: C("add")
+            __sub__ = lambda self, other: C("sub")
+            __mul__ = lambda self, other: C("mul")
+            __matmul__ = lambda self, other: C("matmul")
+            __truediv__ = lambda self, other: C("truediv")
+            __floordiv__ = lambda self, other: C("floordiv")
+            __divmod__ = lambda self, other: C("divmod")
+            __mod__ = lambda self, other: C("mod")
+            __pow__ = lambda self, other: C("pow")
+            __lshift__ = lambda self, other: C("lshift")
+            __rshift__ = lambda self, other: C("rshift")
+            __and__ = lambda self, other: C("and")
+            __or__ = lambda self, other: C("or")
+            __xor__ = lambda self, other: C("xor")
+
+            __iadd__ = lambda self, other: C("iadd")
+            __isub__ = lambda self, other: C("isub")
+            __imul__ = lambda self, other: C("imul")
+            __imatmul__ = lambda self, other: C("imatmul")
+            __itruediv__ = lambda self, other: C("itruediv")
+            __ifloordiv__ = lambda self, other: C("ifloordiv")
+            __imod__ = lambda self, other: C("imod")
+            __ipow__ = lambda self, other: C("ipow")
+            __ilshift__ = lambda self, other: C("ilshift")
+            __irshift__ = lambda self, other: C("irshift")
+            __iand__ = lambda self, other: C("iand")
+            __ior__ = lambda self, other: C("ior")
+            __ixor__ = lambda self, other: C("ixor")
+
+            __neg__ = lambda self: C("neg")
+            __pos__ = lambda self: C("pos")
+            __invert__ = lambda self: C("invert")
+
+            __abs__ = lambda self: C("abs")
+
+        def f_bool(x: C):
+            return bool(x)
+
+        def f_str(x: C):
+            return str(x)
+
+        def f_repr(x: C):
+            return repr(x)
+
+        def f_call(x: C):
+            return x(1)
+
+        def f_1in(x: C):
+            return 1 in x
+
+        def f_0in(x: C):
+            return 0 in x
+
+        def f_len(x: C):
+            return len(x)
+
+        def f_int(x: C):
+            return int(x)
+
+        def f_float(x: C):
+            return float(x)
+
+        def f_add(x: C):
+            return x + C("")
+
+        def f_sub(x: C):
+            return x - C("")
+
+        def f_mul(x: C):
+            return x * C("")
+
+        def f_div(x: C):
+            return x / C("")
+
+        def f_floordiv(x: C):
+            return x // C("")
+
+        def f_matmul(x: C):
+            return x @ C("")
+
+        def f_mod(x: C):
+            return x % C("")
+
+        def f_and(x: C):
+            return x & C("")
+
+        def f_or(x: C):
+            return x | C("")
+
+        def f_xor(x: C):
+            return x ^ C("")
+
+        def f_rshift(x: C):
+            return x >> C("")
+
+        def f_lshift(x: C):
+            return x << C("")
+
+        def f_pow(x: C):
+            return x ** C("")
+
+        def f_neg(x: C):
+            return -x
+
+        def f_pos(x: C):
+            return +x
+
+        def f_invert(x: C):
+            return ~x
+
+        def f_abs(x: C):
+            return abs(x)
+
+        def f_iadd(x: C):
+            x += C("")
+            return x
+
+        def f_isub(x: C):
+            x -= C("")
+            return x
+
+        def f_imul(x: C):
+            x *= C("")
+            return x
+
+        def f_idiv(x: C):
+            x /= C("")
+            return x
+
+        def f_ifloordiv(x: C):
+            x //= C("")
+            return x
+
+        def f_imatmul(x: C):
+            x @= C("")
+            return x
+
+        def f_imod(x: C):
+            x %= C("")
+            return x
+
+        def f_iand(x: C):
+            x &= C("")
+            return x
+
+        def f_ior(x: C):
+            x |= C("")
+            return x
+
+        def f_ixor(x: C):
+            x ^= C("")
+            return x
+
+        def f_irshift(x: C):
+            x >>= C("")
+            return x
+
+        def f_ilshift(x: C):
+            x <<= C("")
+            return x
+
+        def f_ipow(x: C):
+            x **= C("")
+            return x
+
+        test_cases = [f_int, f_float, f_bool, f_str, f_repr, f_call, f_0in, f_1in, f_len,
+                      f_add, f_sub, f_mul, f_div, f_floordiv, f_matmul, f_mod, f_and, f_or, f_xor, f_rshift, f_lshift, f_pow,
+                      f_neg, f_pos, f_invert, f_abs,
+                      f_iadd, f_isub, f_imul, f_idiv, f_ifloordiv, f_imatmul,
+                      f_imod, f_iand, f_ior, f_ixor, f_irshift, f_ilshift, f_ipow]
+
+        for f in test_cases:
+            compiled_f = Compiled(f)
+            r1 = f(C(""))
+            r2 = compiled_f(C(""))
+            self.assertEqual(r1, r2)
+
+    def test_compile_class_reverse_methods(self):
+
+        class C(Class, Final):
+            s = Member(str)
+            __radd__ = lambda self, other: "radd" + repr(other)
+            __rsub__ = lambda self, other: "rsub" + repr(other)
+            __rmul__ = lambda self, other: "rmul" + repr(other)
+            __rmatmul__ = lambda self, other: "rmatmul" + repr(other)
+            __rtruediv__ = lambda self, other: "rtruediv" + repr(other)
+            __rfloordiv__ = lambda self, other: "rfloordiv" + repr(other)
+            __rmod__ = lambda self, other: "rmod" + repr(other)
+            __rpow__ = lambda self, other: "rpow" + repr(other)
+            __rlshift__ = lambda self, other: "rlshift" + repr(other)
+            __rrshift__ = lambda self, other: "rrshift" + repr(other)
+            __rand__ = lambda self, other: "rand" + repr(other)
+            __rxor__ = lambda self, other: "rxor" + repr(other)
+            __ror__ = lambda self, other: "ror" + repr(other)
+
+        values = [1, Int16(1), UInt64(1), 1.234, Float32(1.234), True, "abc",
+                  ListOf(int)((1, 2)), ConstDict(str, str)({"a": "1"}), PointerTo(int)()]
+        for v in values:
+            T = type(v)
+
+            def f_radd(v: T, x: C):
+                return v + x
+
+            def f_rsub(v: T, x: C):
+                return v - x
+
+            def f_rmul(v: T, x: C):
+                return v * x
+
+            def f_rmatmul(v: T, x: C):
+                return v @ x
+
+            def f_rtruediv(v: T, x: C):
+                return v * x
+
+            def f_rfloordiv(v: T, x: C):
+                return v * x
+
+            def f_rmod(v: T, x: C):
+                return v * x
+
+            def f_rpow(v: T, x: C):
+                return v * x
+
+            def f_rlshift(v: T, x: C):
+                return v * x
+
+            def f_rrshift(v: T, x: C):
+                return v * x
+
+            def f_rand(v: T, x: C):
+                return v * x
+
+            def f_rxor(v: T, x: C):
+                return v * x
+
+            def f_ror(v: T, x: C):
+                return v * x
+
+            for f in [f_radd, f_rsub, f_rmul, f_rmatmul, f_rtruediv, f_rfloordiv, f_rmod, f_rpow,
+                      f_rlshift, f_rrshift, f_rand, f_rxor, f_ror]:
+                r1 = f(v, C())
+                compiled_f = Compiled(f)
+                r2 = compiled_f(v, C())
+                self.assertEqual(r1, r2)
+
+    def test_compile_class_format(self):
+
+        class C1(Class, Final):
+            pass
+
+        class C2(Class, Final):
+            __str__ = lambda self: "my str"
+
+        class C3(Class, Final):
+            __format__ = lambda self, spec="": "my format " + spec
+
+        def format1(x: C1):
+            return format(x)
+
+        def format2(x: C2):
+            return format(x)
+
+        def format3(x: C3):
+            return format(x)
+
+        def format3_spec(x: C3):
+            return format(x, "spec")
+
+        r1 = format1(C1())
+        c_format1 = Compiled(format1)
+        r2 = c_format1(C1())
+        self.assertEqual(r1, r2)
+
+        r1 = format2(C2())
+        c_format2 = Compiled(format2)
+        r2 = c_format2(C2())
+        self.assertEqual(r1, r2)
+
+        r1 = format3(C3())
+        c_format3 = Compiled(format3)
+        r2 = c_format3(C3())
+        self.assertEqual(r1, r2)
+
+        r1 = format3_spec(C3())
+        c_format3_spec = Compiled(format3_spec)
+        r2 = c_format3_spec(C3())
+        self.assertEqual(r1, r2)
+
+        @Entrypoint
+        def specialized_format(x):
+            return format(x)
+
+        test_values = [C1(), C2(), C3()]
+        for v in test_values:
+            r1 = format(v)
+            r2 = specialized_format(v)
+            self.assertEqual(r1, r2)
+
+    def test_compile_class_bytes(self):
+        class C(Class, Final):
+            __bytes__ = lambda self: b'my bytes'
+
+        def f_bytes(x: C):
+            return bytes(x)
+
+        v = C()
+        r1 = f_bytes(v)
+        c_f = Compiled(f_bytes)
+        r2 = c_f(v)
+        self.assertEqual(r1, r2)
+
+    def test_compile_class_attr(self):
+
+        class C(Class, Final):
+            d = Member(Dict(str, str))
+            i = Member(int)
+
+            def __getattr__(self, n):
+                return self.d[n]
+
+            def __setattr__(self, n, v):
+                self.d[n] = v
+
+            def __delattr__(self, n):
+                del self.d[n]
+
+        def f_getattr1(x: C):
+            return x.q
+
+        def f_getattr2(x: C):
+            return x.z
+
+        def f_setattr1(x: C, s: str):
+            x.q = s
+
+        def f_setattr2(x: C, s: str):
+            x.z = s
+
+        def f_delattr1(x: C):
+            del x.q
+
+        def f_delattr2(x: C):
+            del x.z
+
+        c_getattr1 = Compiled(f_getattr1)
+        c_getattr2 = Compiled(f_getattr2)
+        c_setattr1 = Compiled(f_setattr1)
+        c_setattr2 = Compiled(f_setattr2)
+        c_delattr1 = Compiled(f_delattr1)
+        c_delattr2 = Compiled(f_delattr2)
+        for v in [C()]:
+            f_setattr1(v, "0")
+            f_setattr2(v, "0")
+            self.assertEqual(f_getattr1(v), "0")
+            self.assertEqual(f_getattr1(v), c_getattr1(v))
+            self.assertEqual(f_getattr2(v), "0")
+            self.assertEqual(f_getattr2(v), c_getattr2(v))
+            f_setattr1(v, "1")
+            self.assertEqual(f_getattr1(v), "1")
+            self.assertEqual(f_getattr1(v), c_getattr1(v))
+            self.assertEqual(f_getattr2(v), "0")
+            self.assertEqual(f_getattr2(v), c_getattr2(v))
+            c_setattr1(v, "2")
+            self.assertEqual(f_getattr1(v), "2")
+            self.assertEqual(f_getattr1(v), c_getattr1(v))
+            self.assertEqual(f_getattr2(v), "0")
+            self.assertEqual(f_getattr2(v), c_getattr2(v))
+            f_setattr2(v, "3")
+            self.assertEqual(f_getattr1(v), "2")
+            self.assertEqual(f_getattr1(v), c_getattr1(v))
+            self.assertEqual(f_getattr2(v), "3")
+            self.assertEqual(f_getattr2(v), c_getattr2(v))
+            c_setattr2(v, "4")
+            self.assertEqual(f_getattr1(v), "2")
+            self.assertEqual(f_getattr1(v), c_getattr1(v))
+            self.assertEqual(f_getattr2(v), "4")
+            self.assertEqual(f_getattr2(v), c_getattr2(v))
+            f_delattr1(v)
+            with self.assertRaises(KeyError):
+                f_getattr1(v)
+            with self.assertRaises(KeyError):
+                c_getattr1(v)
+            self.assertEqual(f_getattr2(v), "4")
+            self.assertEqual(f_getattr2(v), c_getattr2(v))
+            f_delattr2(v)
+            with self.assertRaises(KeyError):
+                f_getattr1(v)
+            with self.assertRaises(KeyError):
+                c_getattr1(v)
+            with self.assertRaises(KeyError):
+                f_getattr2(v)
+            with self.assertRaises(KeyError):
+                c_getattr2(v)
+            f_setattr1(v, "5")
+            f_setattr2(v, "6")
+            c_delattr1(v)
+            with self.assertRaises(KeyError):
+                f_getattr1(v)
+            with self.assertRaises(KeyError):
+                c_getattr1(v)
+            self.assertEqual(f_getattr2(v), "6")
+            self.assertEqual(f_getattr2(v), c_getattr2(v))
+            c_delattr2(v)
+            with self.assertRaises(KeyError):
+                f_getattr1(v)
+            with self.assertRaises(KeyError):
+                c_getattr1(v)
+            with self.assertRaises(KeyError):
+                f_getattr2(v)
+            with self.assertRaises(KeyError):
+                c_getattr2(v)
+
+    def test_compile_class_float_methods(self):
+        # if __float__ is defined, then floor() and ceil() are based off this conversion,
+        # when __floor__ and __ceil__ are not defined
+        class C(Class, Final):
+            __float__ = lambda self: 1234.5
+
+        def f_floor(x: C):
+            return floor(x)
+
+        def f_ceil(x: C):
+            return ceil(x)
+
+        test_cases = [f_floor, f_ceil]
+        for f in test_cases:
+            r1 = f(C())
+            compiled_f = Compiled(f)
+            r2 = compiled_f(C())
+            self.assertEqual(r1, r2)
+
+        class C2(Class, Final):
+            __round__ = lambda self, n: 1234 + n
+            __trunc__ = lambda self: 1
+            __floor__ = lambda self: 2
+            __ceil__ = lambda self: 3
+
+        def f_round0(x: C2):
+            return round(x, 0)
+
+        def f_round1(x: C2):
+            return round(x, 1)
+
+        def f_round2(x: C2):
+            return round(x, 2)
+
+        def f_round_1(x: C2):
+            return round(x, -1)
+
+        def f_round_2(x: C2):
+            return round(x, -2)
+
+        def f_trunc(x: C2):
+            return trunc(x)
+
+        def f_floor(x: C2):
+            return floor(x)
+
+        def f_ceil(x: C2):
+            return ceil(x)
+
+        test_cases = [f_round0, f_round1, f_round2, f_round_1, f_round_2, f_trunc, f_floor, f_ceil]
+        for f in test_cases:
+            r1 = f(C2())
+            compiled_f = Compiled(f)
+            r2 = compiled_f(C2())
+            self.assertEqual(r1, r2)
+
+    def test_compile_class_dir(self):
+        # The interpreted dir() calls __dir__() and sorts the result.
+        # I expected the compiled dir() to do the same thing, but it doesn't sort.
+        # So if you append these elements out of order, the test will fail.
+
+        class C0(Class, Final):
+            i = Member(int)
+
+            def one(self):
+                pass
+
+            def two(self):
+                pass
+
+        class C(Class, Final):
+            i = Member(int)
+
+            def __dir__(self):
+                x = ListOf(str)()
+                x.append("x")
+                x.append("y")
+                x.append("z")
+                return x
+
+        def f_dir0(x: C0):
+            return dir(x)
+
+        def f_dir(x: C):
+            return dir(x)
+
+        for f in [f_dir0]:
+            compiled_f = Compiled(f)
+            r1 = f(C0())
+            r2 = compiled_f(C0())
+            self.assertEqual(r1, r2)
+
+        for f in [f_dir]:
+            compiled_f = Compiled(f)
+            r1 = f(C())
+            r2 = compiled_f(C())
+            self.assertEqual(r1, r2)
+
+        c0 = Compiled(f_dir0)
+        c = Compiled(f_dir)
+        initMem = psutil.Process().memory_info().rss / 1024 ** 2
+
+        for i in range(10000):
+            c0(C0(i=i))
+            c(C(i=i))
+
+        finalMem = psutil.Process().memory_info().rss / 1024 ** 2
+
+        self.assertTrue(finalMem < initMem + 2)
+
+    def test_compile_class_comparison_defaults(self):
+
+        def result_or_exception(f, *p):
+            try:
+                return f(*p)
+            except Exception:
+                return "exception"
+
+        class C(Class, Final):
+            i = Member(int)
+            s = Member(str)
+
+        def f_eq(x: C, y: C):
+            return x == y
+
+        def f_ne(x: C, y: C):
+            return x != y
+
+        def f_lt(x: C, y: C):
+            return x < y
+
+        def f_gt(x: C, y: C):
+            return x > y
+
+        def f_le(x: C, y: C):
+            return x <= y
+
+        def f_ge(x: C, y: C):
+            return x >= y
+
+        def f_hash(x: C):
+            return hash(x)
+
+        values = [C(i=0), C(i=1), C(s="a"), C(s="b")]
+        for f in [f_lt, f_eq, f_ne, f_lt, f_gt, f_le, f_ge]:
+            for v1 in values:
+                for v2 in values:
+                    compiled_f = Compiled(f)
+                    r1 = result_or_exception(f, v1, v2)
+                    r2 = result_or_exception(compiled_f, v1, v2)
+                    self.assertEqual(r1, r2)
+        for f in [f_hash]:
+            for v in values:
+                compiled_f = Compiled(f)
+                r1 = result_or_exception(f, v)
+                r2 = result_or_exception(compiled_f, v)
+                if r1 != r2:
+                    print("mismatch")
+                self.assertEqual(r1, r2)
+
+    def test_compile_class_comparison_methods(self):
+
+        class C(Class, Final):
+            i = Member(int)
+            s = Member(str)
+
+            def __eq__(x, y):
+                return x.i == y.i
+
+            def __ne__(x, y):
+                return x.i != y.i
+
+            def __lt__(x, y):
+                return x.s < y.s
+
+            def __gt__(x, y):
+                return x.s > y.s
+
+            def __le__(x, y):
+                return x.i <= y.i
+
+            def __ge__(x, y):
+                return x.i >= y.i
+
+            def __hash__(self):
+                return 123
+
+        def f_eq(x: C, y: C):
+            return x == C()
+
+        def f_ne(x: C, y: C):
+            return x != C()
+
+        def f_lt(x: C, y: C):
+            return x < C()
+
+        def f_gt(x: C, y: C):
+            return x > C()
+
+        def f_le(x: C, y: C):
+            return x <= C()
+
+        def f_ge(x: C, y: C):
+            return x >= C()
+
+        def f_hash(x: C):
+            return hash(x)
+
+        values = [C(i=0), C(i=1), C(s="a"), C(s="b")]
+        for f in [f_eq, f_ne, f_lt, f_gt, f_le, f_ge]:
+            compiled_f = Compiled(f)
+            for v1 in values:
+                for v2 in values:
+                    r1 = f(v1, v2)
+                    r2 = compiled_f(v1, v2)
+                    self.assertEqual(r1, r2)
+        for f in [f_hash]:
+            compiled_f = Compiled(f)
+            for v in values:
+                r1 = f(v)
+                r2 = compiled_f(v)
+                self.assertEqual(r1, r2)
+
+    def test_compile_class_getsetitem(self):
+
+        class C(Class, Final):
+            d = Member(Dict(int, int))
+
+            def __getitem__(self, i):
+                if i not in self.d:
+                    return i
+                return self.d[i]
+
+            def __setitem__(self, i, v):
+                self.d[i] = v
+
+        def f_getitem(c: C, i: int) -> int:
+            return c[i]
+
+        def f_setitem(c: C, i: int, v: int):
+            c[i] = v
+
+        c_getitem = Compiled(f_getitem)
+        c_setitem = Compiled(f_setitem)
+
+        c = C()
+        c[123] = 7
+        self.assertEqual(c[123], 7)
+        for i in range(10, 20):
+            self.assertEqual(f_getitem(c, i), i)
+            self.assertEqual(c_getitem(c, i), i)
+            f_setitem(c, i, i + 100)
+            self.assertEqual(f_getitem(c, i), i + 100)
+            self.assertEqual(c_getitem(c, i), i + 100)
+            c_setitem(c, i, i + 200)
+            self.assertEqual(f_getitem(c, i), i + 200)
+            self.assertEqual(c_getitem(c, i), i + 200)
+
+    def test_compile_class_float_conv(self):
+
+        class C0(Class, Final):
+            __int__ = lambda self: 123
+            __float__ = lambda self: 1234.5
+
+        class C(Class, Final):
+            __int__ = lambda self: 123
+            __float__ = lambda self: 1234.5
+
+        def f(x: float):
+            return x
+
+        def g(x: int):
+            return x
+
+        c_f = Compiled(f)
+        c_g = Compiled(g)
+        with self.assertRaises(TypeError):
+            c_f(C())
+        with self.assertRaises(TypeError):
+            c_f(C0())
+        with self.assertRaises(TypeError):
+            c_g(C())
+        with self.assertRaises(TypeError):
+            c_g(C0())
+
+    def test_compile_class_missing_inplace_fallback(self):
+        class ClassWithoutInplaceOp(Class, Final):
+            s = Member(str)
+
+            def __add__(self, other):
+                self.s += " add" + other.s
+                return self
+
+            def __sub__(self, other):
+                self.s += " sub" + other.s
+                return self
+
+            def __mul__(self, other):
+                self.s += " mul" + other.s
+                return self
+
+            def __matmul__(self, other):
+                self.s += " matmul" + other.s
+                return self
+
+            def __truediv__(self, other):
+                self.s += " truediv" + other.s
+                return self
+
+            def __floordiv__(self, other):
+                self.s += " floordiv" + other.s
+                return self
+
+            def __mod__(self, other):
+                self.s += " mod" + other.s
+                return self
+
+            def __pow__(self, other):
+                self.s += " pow" + other.s
+                return self
+
+            def __lshift__(self, other):
+                self.s += " lshift" + other.s
+                return self
+
+            def __rshift__(self, other):
+                self.s += " rshift" + other.s
+                return self
+
+            def __and__(self, other):
+                self.s += " and" + other.s
+                return self
+
+            def __or__(self, other):
+                self.s += " or" + other.s
+                return self
+
+            def __xor__(self, other):
+                self.s += " xor" + other.s
+                return self
+
+        def inplace(x: ClassWithoutInplaceOp):
+            x += ClassWithoutInplaceOp()
+            x -= ClassWithoutInplaceOp()
+            x *= ClassWithoutInplaceOp()
+            x @= ClassWithoutInplaceOp()
+            x /= ClassWithoutInplaceOp()
+            x //= ClassWithoutInplaceOp()
+            x %= ClassWithoutInplaceOp()
+            x **= ClassWithoutInplaceOp()
+            x <<= ClassWithoutInplaceOp()
+            x >>= ClassWithoutInplaceOp()
+            x &= ClassWithoutInplaceOp()
+            x |= ClassWithoutInplaceOp()
+            x ^= ClassWithoutInplaceOp()
+            return x
+
+        expected = ClassWithoutInplaceOp(s="start add sub mul matmul truediv floordiv mod pow lshift rshift and or xor")
+        v = ClassWithoutInplaceOp(s="start")
+        r1 = inplace(v)
+        self.assertEqual(r1.s, expected.s)
+        v = ClassWithoutInplaceOp(s="start")
+        r2 = Compiled(inplace)(v)
+        self.assertEqual(r2.s, expected.s)

--- a/typed_python/compiler/tests/class_compilation_test.py
+++ b/typed_python/compiler/tests/class_compilation_test.py
@@ -1284,8 +1284,8 @@ class TestClassCompilationCompilation(unittest.TestCase):
         def result_or_exception(f, *p):
             try:
                 return f(*p)
-            except Exception:
-                return "exception"
+            except Exception as e:
+                return type(e)
 
         class C(Class, Final):
             i = Member(int)
@@ -1313,7 +1313,7 @@ class TestClassCompilationCompilation(unittest.TestCase):
             return hash(x)
 
         values = [C(i=0), C(i=1), C(s="a"), C(s="b")]
-        for f in [f_lt, f_eq, f_ne, f_lt, f_gt, f_le, f_ge]:
+        for f in [f_eq, f_ne, f_lt, f_gt, f_le, f_ge]:
             for v1 in values:
                 for v2 in values:
                     compiled_f = Compiled(f)
@@ -1325,8 +1325,6 @@ class TestClassCompilationCompilation(unittest.TestCase):
                 compiled_f = Compiled(f)
                 r1 = result_or_exception(f, v)
                 r2 = result_or_exception(compiled_f, v)
-                if r1 != r2:
-                    print("mismatch")
                 self.assertEqual(r1, r2)
 
     def test_compile_class_comparison_methods(self):
@@ -1391,6 +1389,23 @@ class TestClassCompilationCompilation(unittest.TestCase):
                 r1 = f(v)
                 r2 = compiled_f(v)
                 self.assertEqual(r1, r2)
+
+    def test_compile_class_hash_special_value(self):
+
+        class C(Class, Final):
+            i = Member(int)
+
+            def __hash__(self):
+                return self.i
+
+        def f_hash(x: C):
+            return hash(x)
+
+        c_hash = Compiled(f_hash)
+        self.assertEqual(f_hash(C(i=123)), 123)
+        self.assertEqual(c_hash(C(i=123)), 123)
+        self.assertEqual(f_hash(C(i=-1)), -2)
+        self.assertEqual(c_hash(C(i=-1)), -2)
 
     def test_compile_class_getsetitem(self):
 

--- a/typed_python/compiler/tests/dict_compilation_test.py
+++ b/typed_python/compiler/tests/dict_compilation_test.py
@@ -12,9 +12,8 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-from typed_python import Dict, ListOf, Tuple, TupleOf
+from typed_python import Dict, ListOf, Tuple, TupleOf, Entrypoint
 import typed_python._types as _types
-from typed_python import Entrypoint
 import unittest
 import time
 import threading
@@ -83,6 +82,18 @@ class TestDictCompilation(unittest.TestCase):
 
         with self.assertRaisesRegex(KeyError, "2"):
             dict_getitem(x, 2)
+
+    def test_dict_get_default(self):
+        @Entrypoint
+        def dict_get(x, y):
+            return x.get(y, -1)
+
+        x = Dict(int, int)()
+
+        x[1] = 2
+
+        self.assertEqual(dict_get(x, 1), 2)
+        self.assertEqual(dict_get(x, 2), -1)
 
     def test_dict_setitem(self):
         @Entrypoint

--- a/typed_python/compiler/tests/python_object_of_type_compilation_test.py
+++ b/typed_python/compiler/tests/python_object_of_type_compilation_test.py
@@ -17,7 +17,8 @@ from typed_python import (
     Alternative, OneOf, NoneType, Bool,
     Int8, Int16, Int32, Int64,
     UInt8, UInt16, UInt32, UInt64,
-    Float32, Float64, Final
+    Float32, Float64, Final,
+    PointerTo
 )
 
 import unittest
@@ -220,7 +221,8 @@ class TestPythonObjectOfTypeCompilation(unittest.TestCase):
             (OneOf(String, Int64), "ab"),
             (OneOf(String, Int64), 34),
             (NT1, NT1(a=1, b=2.3, c="c", d="d")),
-            (NT2, NT2(s="xyz", t=tuple(range(10000))))
+            (NT2, NT2(s="xyz", t=tuple(range(10000)))),
+            (PointerTo(int), PointerTo(int)() + 4),
         ]
 
         for T, v in cases:
@@ -305,6 +307,7 @@ class TestPythonObjectOfTypeCompilation(unittest.TestCase):
             (Bytes, b""), (Bytes, b"0"), (Bytes, b"\x00"), (Bytes, b"\x01"),
             (IDict, IDict()), (IDict, IDict({0: 0})), (IDict, IDict({1: 1, 2: 4})),
             (IConstDict, IConstDict()), (IConstDict, IConstDict({0: 0})), (IConstDict, IConstDict({1: 1, 2: 4})),
+
             (NamedTuple0, NamedTuple0()),
             (NamedTuple1, NamedTuple1(a=0)), (NamedTuple1, NamedTuple1(a=1)),
             (OneOf2, OneOf2(0)), (OneOf2, OneOf2("")),
@@ -362,6 +365,9 @@ class TestPythonObjectOfTypeCompilation(unittest.TestCase):
             (B4, B4.a(s='')),
             (B4, B4.a(s='a')),
             (B5, B5.a(s='')),
+            # TODO: The line below segfaults in the specialized entrypoint case,
+            # due to attempting set iteration on this type
+            # (PointerTo(Int64), x0.pointerUnsafe(0)),
         ]
 
         @Entrypoint

--- a/typed_python/compiler/type_wrappers/runtime_functions.py
+++ b/typed_python/compiler/type_wrappers/runtime_functions.py
@@ -317,6 +317,12 @@ alternative_cmp = externalCallTarget(
     UInt64, Void.pointer(), Void.Pointer(), Int64
 )
 
+class_cmp = externalCallTarget(
+    "np_runtime_class_cmp",
+    Bool,
+    UInt64, Void.pointer(), Void.Pointer(), Int64
+)
+
 string_getitem_int64 = externalCallTarget(
     "nativepython_runtime_string_getitem_int64",
     Void.pointer(),
@@ -572,6 +578,13 @@ hash_bytes = externalCallTarget(
 
 hash_alternative = externalCallTarget(
     "nativepython_hash_alternative",
+    Int32,
+    Void.pointer(),
+    UInt64
+)
+
+hash_class = externalCallTarget(
+    "nativepython_hash_class",
     Int32,
     Void.pointer(),
     UInt64

--- a/typed_python/compiler/type_wrappers/string_wrapper.py
+++ b/typed_python/compiler/type_wrappers/string_wrapper.py
@@ -69,18 +69,18 @@ class StringWrapper(RefcountedWrapper):
 
         return super().convert_type_call(context, typeInst, args, kwargs)
 
+    def convert_hash(self, context, expr):
+        return context.pushPod(Int32, runtime_functions.hash_string.call(expr.nonref_expr.cast(VoidPtr)))
+
+    def getNativeLayoutType(self):
+        return self.layoutType
+
     def convert_default_initialize(self, context, target):
         context.pushEffect(
             target.expr.store(
                 self.layoutType.zero()
             )
         )
-
-    def convert_hash(self, context, expr):
-        return context.pushPod(Int32, runtime_functions.hash_string.call(expr.nonref_expr.cast(VoidPtr)))
-
-    def getNativeLayoutType(self):
-        return self.layoutType
 
     def on_refcount_zero(self, context, instance):
         assert instance.isReference

--- a/typed_python/types_test.py
+++ b/typed_python/types_test.py
@@ -29,8 +29,8 @@ from typed_python import (
     UInt8, UInt16, UInt32, UInt64,
     Float32, Float64,
     NoneType, TupleOf, ListOf, OneOf, Tuple, NamedTuple, Dict,
-    ConstDict, Alternative, serialize, deserialize, Class, Member,
-    TypeFilter, Function, Forward, Set, Final
+    ConstDict, Alternative, serialize, deserialize, Class,
+    TypeFilter, Function, Forward, Set, PointerTo
 )
 from typed_python.type_promotion import computeArithmeticBinaryResultType
 from typed_python.test_util import currentMemUsageMb
@@ -273,36 +273,6 @@ class NativeTypesTests(unittest.TestCase):
         with self.assertRaises(TypeError):
             two = alt.Two()
             two()
-
-    def test_callable_class(self):
-        class CallableClass(Class, Final):
-            x = Member(int)
-
-            def __call__(self, x):
-                return self.x + x
-
-            def __call__(self):  # noqa: F811
-                return -1
-
-        class RegularClass(Class, Final):
-            x = Member(int)
-
-            def call(self, x):
-                return self.x + x
-
-        obj = CallableClass(x=42)
-        self.assertEqual(obj(0), 42)
-        self.assertEqual(obj(1), 43)
-        self.assertEqual(obj(), -1 )
-
-        exceptionMsg = "Cannot find a valid overload of '__call__' with arguments of type"
-        with self.assertRaisesRegex(TypeError, exceptionMsg):
-            obj(1, 2, 3)
-
-        obj = RegularClass(x=42)
-        self.assertEqual(obj.call(5), 47)
-        with self.assertRaises(TypeError):
-            obj()
 
     def test_object_bytecounts(self):
         self.assertEqual(_types.bytecount(NoneType), 0)
@@ -1354,6 +1324,22 @@ class NativeTypesTests(unittest.TestCase):
         self.assertEqual(a+a, (a, a))
 
     @flaky(max_runs=3, min_passes=1)
+    def test_alternatives_radd_operator(self):
+        alt = Alternative(
+            "Alt",
+            child_ints={'x': int, 'y': int},
+            __radd__=lambda lhs, rhs: "radd"
+        )
+
+        a = alt.child_ints(x=0, y=2)
+
+        values = [1, Int16(1), UInt64(1), 1.234, Float32(1.234), True, "abc",
+                  ListOf(int)((1, 2)), ConstDict(str, str)({"a": "1"})]
+        for v in values:
+            self.assertEqual(v + a, "radd")
+            with self.assertRaises(Exception):
+                print(a + v)
+
     def test_alternatives_perf(self):
         alt = Alternative(
             "Alt",
@@ -1707,22 +1693,6 @@ class NativeTypesTests(unittest.TestCase):
         with self.assertRaises(TypeError):
             a.HasOne(a.HasTwo(a='1', b='b'))
 
-    def test_recursive_classes_repr(self):
-        A0 = Forward("A0")
-
-        class ASelfRecursiveClass(Class):
-            x = Member(OneOf(None, A0))
-
-        A0 = A0.define(ASelfRecursiveClass)
-
-        a = ASelfRecursiveClass()
-        a.x = a
-
-        b = ASelfRecursiveClass()
-        b.x = b
-
-        print(repr(a))
-
     def test_unsafe_pointers_to_list_internals(self):
         x = ListOf(int)()
         x.resize(100)
@@ -2030,44 +2000,6 @@ class NativeTypesTests(unittest.TestCase):
     def test_list_of_indexing_with_numpy_ints(self):
         x = ListOf(ListOf(int))([[1, 2, 3], [4, 5, 6]])
         self.assertEqual(x[numpy.int64(0)][numpy.int64(0)], 1)
-
-    def test_dispatch_tries_without_conversion_first(self):
-        class ClassWithForcedConversion(Class, Final):
-            def f(self, x: float):
-                return "float"
-
-        class ClassWithBoth(Class, Final):
-            def f(self, x: float):
-                return "float"
-
-            def f(self, x: int):  # noqa: F811
-                return "int"
-
-            def f(self, x: bool):  # noqa: F811
-                return "bool"
-
-        # swap the order
-        class ClassWithBoth2(Class, Final):
-            def f(self, x: bool):
-                return "bool"
-
-            def f(self, x: int):  # noqa: F811
-                return "int"
-
-            def f(self, x: float):  # noqa: F811
-                return "float"
-
-        self.assertEqual(ClassWithForcedConversion().f(10), "float")
-        self.assertEqual(ClassWithForcedConversion().f(10.5), "float")
-        self.assertEqual(ClassWithForcedConversion().f(True), "float")
-
-        self.assertEqual(ClassWithBoth().f(10), "int")
-        self.assertEqual(ClassWithBoth().f(10.5), "float")
-        self.assertEqual(ClassWithBoth().f(True), "bool")
-
-        self.assertEqual(ClassWithBoth2().f(10), "int")
-        self.assertEqual(ClassWithBoth2().f(10.5), "float")
-        self.assertEqual(ClassWithBoth2().f(True), "bool")
 
     def test_error_message_on_bad_dispatch(self):
         @Function
@@ -2865,3 +2797,122 @@ class NativeTypesTests(unittest.TestCase):
         self.assertEqual(repr(NT(x="asdf\rbsdf")), '(x="asdf\\rbsdf",)')
         self.assertEqual(repr(NT(x="asdf\tbsdf")), '(x="asdf\\tbsdf",)')
         self.assertEqual(repr(NT(x="asdf\x12bsdf")), '(x="asdf\\x12bsdf",)')
+
+    def test_alternative_reverse_operators(self):
+
+        A = Alternative("A", a={'a': int}, b={'b': str},
+                        __radd__=lambda lhs, rhs: "radd",
+                        __rsub__=lambda lhs, rhs: "rsub",
+                        __rmul__=lambda lhs, rhs: "rmul",
+                        __rmatmul__=lambda lhs, rhs: "rmatmul",
+                        __rtruediv__=lambda lhs, rhs: "rtruediv",
+                        __rfloordiv__=lambda lhs, rhs: "rfloordiv",
+                        __rmod__=lambda lhs, rhs: "rmod",
+                        __rpow__=lambda lhs, rhs: "rpow",
+                        __rlshift__=lambda lhs, rhs: "rlshift",
+                        __rrshift__=lambda lhs, rhs: "rrshift",
+                        __rand__=lambda lhs, rhs: "rand",
+                        __rxor__=lambda lhs, rhs: "rxor",
+                        __ror__=lambda lhs, rhs: "ror"
+                        )
+
+        values = [1, Int16(1), UInt64(1), 1.234, Float32(1.234), True, "abc",
+                  ListOf(int)((1, 2)), ConstDict(str, str)({"a": "1"}), PointerTo(int)()]
+        for v in values:
+            self.assertEqual(v + A.a(), "radd")
+            self.assertEqual(v - A.a(), "rsub")
+            self.assertEqual(v * A.a(), "rmul")
+            self.assertEqual(v @ A.a(), "rmatmul")
+            self.assertEqual(v / A.a(), "rtruediv")
+            self.assertEqual(v // A.a(), "rfloordiv")
+            if type(v) != str:
+                self.assertEqual(v % A.a(), "rmod")
+            self.assertEqual(v ** A.a(), "rpow")
+            self.assertEqual(v << A.a(), "rlshift")
+            self.assertEqual(v >> A.a(), "rrshift")
+            self.assertEqual(v & A.a(), "rand")
+            self.assertEqual(v ^ A.a(), "rxor")
+            self.assertEqual(v | A.a(), "ror")
+            with self.assertRaises(Exception):
+                A.a() + v
+            with self.assertRaises(Exception):
+                A.a() - v
+            with self.assertRaises(Exception):
+                A.a() * v
+            with self.assertRaises(Exception):
+                A.a() @ v
+            with self.assertRaises(Exception):
+                A.a() / v
+            with self.assertRaises(Exception):
+                A.a() // v
+            with self.assertRaises(Exception):
+                A.a() % v
+            with self.assertRaises(Exception):
+                A.a() ** v
+            with self.assertRaises(Exception):
+                A.a() << v
+            with self.assertRaises(Exception):
+                A.a() >> v
+            with self.assertRaises(Exception):
+                A.a() & v
+            with self.assertRaises(Exception):
+                A.a() ^ v
+            with self.assertRaises(Exception):
+                A.a() | v
+
+    def test_alternative_missing_inplace_operators_fallback(self):
+        A = Alternative("A", a={'a': int}, b={'b': str},
+                        __add__=lambda self, other: "worked",
+                        __sub__=lambda self, other: "worked",
+                        __mul__=lambda self, other: "worked",
+                        __matmul__=lambda self, other: "worked",
+                        __truediv__=lambda self, other: "worked",
+                        __floordiv__=lambda self, other: "worked",
+                        __mod__=lambda self, other: "worked",
+                        __pow__=lambda self, other: "worked",
+                        __lshift__=lambda self, other: "worked",
+                        __rshift__=lambda self, other: "worked",
+                        __and__=lambda self, other: "worked",
+                        __or__=lambda self, other: "worked",
+                        __xor__=lambda self, other: "worked",
+                        )
+
+        v = A.a()
+        v += 10
+        self.assertEqual(v, "worked")
+        v = A.a()
+        v -= 10
+        self.assertEqual(v, "worked")
+        v = A.a()
+        v *= 10
+        self.assertEqual(v, "worked")
+        v = A.a()
+        v @= 10
+        self.assertEqual(v, "worked")
+        v = A.a()
+        v /= 10
+        self.assertEqual(v, "worked")
+        v = A.a()
+        v //= 10
+        self.assertEqual(v, "worked")
+        v = A.a()
+        v %= 10
+        self.assertEqual(v, "worked")
+        v = A.a()
+        v **= 10
+        self.assertEqual(v, "worked")
+        v = A.a()
+        v <<= 10
+        self.assertEqual(v, "worked")
+        v = A.a()
+        v >>= 10
+        self.assertEqual(v, "worked")
+        v = A.a()
+        v &= 10
+        self.assertEqual(v, "worked")
+        v = A.a()
+        v |= 10
+        self.assertEqual(v, "worked")
+        v = A.a()
+        v ^= 10
+        self.assertEqual(v, "worked")


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Motivation and Context
* For Class types, interpreted or compiled, support magic methods, except for `__getattribute__`, `__complex__`, `__enter__`, `__exit__`.

## Approach
* Fix inplace default fallback for Alternative and Class types.
* Support reverse operator magic methods (`__radd__`, etc.) for Alternative and Class types.
* Not supported: `__getattribute__`, `__complex__`, `__enter__`,` __exit__`.
* Avoid Alternative (and Class) types inadvertently converting to float or int.
    * Test case is test_compile_alternative_float_conv (and test_compile_class_float_conv).
    * Want numerics (including numpy) to convert, but Alternative (and Class) to require a cast.
* Fix interpreted default Alternative len().
* Fix interpreted `__setitem__` for Alternative types.
* For ConstDict, check types for + and - operators (interpreted).
* Fix TupleOfListOfInstance operator not implemented behavior.
* Add bool conversions for PointerTo, but not testable yet.
* Compile Dict.get with 2 parameters.  Refs #254.
<!-- Describe your changes in reasonable detail -->

## How Has This Been Tested?
* Tests were written first.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.