### PR TITLE
Remove convert_cast.  Refs #265, #256.

### DIFF
--- a/typed_python/StringType.hpp
+++ b/typed_python/StringType.hpp
@@ -234,5 +234,8 @@ public:
     void copy_constructor(instance_ptr self, instance_ptr other);
 
     void assign(instance_ptr self, instance_ptr other);
-};
 
+    static bool to_int64(layout* s, int64_t* value);
+
+    static bool to_float64(layout* s, double* value);
+};

--- a/typed_python/compiler/function_conversion_context.py
+++ b/typed_python/compiler/function_conversion_context.py
@@ -25,6 +25,7 @@ import typed_python.compiler.native_ast as native_ast
 from typed_python.compiler.expression_conversion_context import ExpressionConversionContext
 from typed_python.compiler.function_stack_state import FunctionStackState
 from typed_python.compiler.type_wrappers.none_wrapper import NoneWrapper
+from typed_python.compiler.type_wrappers.python_type_object_wrapper import PythonTypeObjectWrapper
 from typed_python.compiler.typed_expression import TypedExpression
 from typed_python.compiler.conversion_exception import ConversionException
 from typed_python import OneOf
@@ -934,7 +935,6 @@ class FunctionConversionContext(object):
                 context = ExpressionConversionContext(self, variableStates)
                 typeExpr = context.convert_expression_ast(condition.args[1])
 
-                PythonTypeObjectWrapper = typed_python.compiler.type_wrappers.python_type_object_wrapper.PythonTypeObjectWrapper
                 if typeExpr is not None and isinstance(typeExpr.expr_type, PythonTypeObjectWrapper):
                     variableStates.restrictTypeFor(condition.args[0].id, typeExpr.expr_type.typeRepresentation.Value, result)
 

--- a/typed_python/compiler/tests/alternative_compilation_test.py
+++ b/typed_python/compiler/tests/alternative_compilation_test.py
@@ -350,6 +350,8 @@ class TestAlternativeCompilation(unittest.TestCase):
             compiled_f = Compiled(f)
             r1 = f(A.a())
             r2 = compiled_f(A.a())
+            if r1 != r2:
+                print("mismatch")
             self.assertEqual(r1, r2)
 
     def test_compile_alternative_reverse_methods(self):

--- a/typed_python/compiler/tests/class_compilation_test.py
+++ b/typed_python/compiler/tests/class_compilation_test.py
@@ -931,6 +931,8 @@ class TestClassCompilationCompilation(unittest.TestCase):
             compiled_f = Compiled(f)
             r1 = f(C(""))
             r2 = compiled_f(C(""))
+            if r1 != r2:
+                print("mismatch")
             self.assertEqual(r1, r2)
 
     def test_compile_class_reverse_methods(self):

--- a/typed_python/compiler/tests/conversion_test.py
+++ b/typed_python/compiler/tests/conversion_test.py
@@ -15,8 +15,9 @@
 import time
 import traceback
 import unittest
-
+import pytest
 from flaky import flaky
+
 from typed_python import Function, OneOf, TupleOf, ListOf, Tuple, NamedTuple, Class, _types
 from typed_python.compiler.runtime import Runtime, Entrypoint
 
@@ -579,3 +580,33 @@ class TestCompilationStructures(unittest.TestCase):
 
         with self.assertRaises(AssertionError):
             check(10)
+
+    @pytest.mark.skip(reason="to be fixed")
+    def test_conditional_eval_or(self):
+        @Compiled
+        def f(x: int, y: float, z: str):
+            return x or y or z
+
+        self.assertEqual(f(0, 0.0, ""), "")
+        self.assertEqual(f(0, 0.0, "one"), "one")
+        self.assertEqual(f(0, 1.5, ""), 1.5)
+        self.assertEqual(f(0, 1.5, "one"), 1.5)
+        self.assertEqual(f(3, 0.0, ""), 3)
+        self.assertEqual(f(3, 0.0, "one"), 3)
+        self.assertEqual(f(3, 1.5, ""), 3)
+        self.assertEqual(f(3, 1.5, "one"), 3)
+
+    @pytest.mark.skip(reason="to be fixed")
+    def test_conditional_eval_and(self):
+        @Compiled
+        def f(x: int, y: str, z: float):
+            return x and y and z
+
+        self.assertEqual(f(0, "", 0.0), 0)
+        self.assertEqual(f(0, "", 1.5), 0)
+        self.assertEqual(f(0, "one", 0.0), 0)
+        self.assertEqual(f(0, "one", 1.5), 0)
+        self.assertEqual(f(3, "", 0.0), "")
+        self.assertEqual(f(3, "", 1.5), "")
+        self.assertEqual(f(3, "one", 0.0), 0.0)
+        self.assertEqual(f(3, "one", 1.5), 1.5)

--- a/typed_python/compiler/tests/pointer_to_compilation_test.py
+++ b/typed_python/compiler/tests/pointer_to_compilation_test.py
@@ -66,6 +66,7 @@ class TestPointerToCompilation(unittest.TestCase):
                 Runtime.singleton().compile(testfun, {'x': type(x)})(x)
             )
 
+        check(False)
         check(0)
         check(0.0)
         check(ListOf(int)([10]))

--- a/typed_python/compiler/tests/python_object_of_type_compilation_test.py
+++ b/typed_python/compiler/tests/python_object_of_type_compilation_test.py
@@ -321,7 +321,6 @@ class TestPythonObjectOfTypeCompilation(unittest.TestCase):
             (AClassWithBool, AClassWithBool(1)),
             (AClassWithBool, AClassWithBool(0)),
             (A1.a, A1.a()),
-            (A1.a, A1.a()),
             (A1.b, A1.b()),
             (A2.a, A2.a()),
             (A2.b, A2.b()),
@@ -331,8 +330,6 @@ class TestPythonObjectOfTypeCompilation(unittest.TestCase):
             (A4.b, A4.b()),
             (A5.a, A5.a()),
             (A5.b, A5.b()),
-            # (A6.a, A6.a()),
-            # (A6.b, A6.b()),
             (B1.a, B1.a(s='')),
             (B1.a, B1.a(s='a')),
             (B2.a, B2.a(s='')),
@@ -354,8 +351,6 @@ class TestPythonObjectOfTypeCompilation(unittest.TestCase):
             (A4, A4.b()),
             (A5, A5.a()),
             (A5, A5.b()),
-            # (A6, A6.a()),
-            # (A6, A6.b()),
             (B1, B1.a(s='')),
             (B1, B1.a(s='a')),
             (B2, B2.a(s='')),
@@ -487,3 +482,18 @@ class TestPythonObjectOfTypeCompilation(unittest.TestCase):
             self.assertEqual(r1, r2)
             self.assertEqual(r1, r3)
             self.assertEqual(r1, r4)
+
+    def test_some_object_operations(self):
+        @Compiled
+        def f(x: object, y: object):
+            x += y
+            y += x
+            x += y
+            return x
+
+        @Compiled
+        def g(x: object, y: object):
+            return x >= y
+
+        self.assertEqual(f(1, 2), 8)
+        self.assertEqual(g("a", "b"), False)

--- a/typed_python/compiler/type_wrappers/builtin_wrappers.py
+++ b/typed_python/compiler/type_wrappers/builtin_wrappers.py
@@ -22,7 +22,7 @@ class BuiltinWrapper(Wrapper):
     is_pod = True
     is_empty = False
     is_pass_by_ref = False
-    SUPPORTED_FUNCTIONS = (round, trunc, floor, ceil, format, bytes, dir)
+    SUPPORTED_FUNCTIONS = (round, trunc, floor, ceil, format, dir)
 
     def __init__(self, builtin):
         assert builtin in self.SUPPORTED_FUNCTIONS

--- a/typed_python/compiler/type_wrappers/bytes_wrapper.py
+++ b/typed_python/compiler/type_wrappers/bytes_wrapper.py
@@ -167,3 +167,15 @@ class BytesWrapper(RefcountedWrapper):
             return context.constant(True)
 
         return super().convert_to_type_with_target(context, e, targetVal, explicit)
+
+    def convert_bool_cast(self, context, expr):
+        return context.pushPod(bool, self.convert_len_native(expr.nonref_expr).neq(0))
+
+    def convert_int_cast(self, context, expr):
+        return context.pushPod(int, runtime_functions.bytes_to_int64.call(expr.nonref_expr.cast(VoidPtr)))
+
+    def convert_float_cast(self, context, expr):
+        return context.pushPod(float, runtime_functions.bytes_to_float64.call(expr.nonref_expr.cast(VoidPtr)))
+
+    def convert_bytes_cast(self, context, expr):
+        return expr

--- a/typed_python/compiler/type_wrappers/const_dict_wrapper.py
+++ b/typed_python/compiler/type_wrappers/const_dict_wrapper.py
@@ -341,6 +341,9 @@ class ConstDictWrapper(ConstDictWrapperBase):
 
         return super().convert_to_type_with_target(context, e, targetVal, explicit)
 
+    def convert_bool_cast(self, context, expr):
+        return context.pushPod(bool, self.convert_len_native(expr.nonref_expr).neq(0))
+
 
 class ConstDictMakeIteratorWrapper(ConstDictWrapperBase):
     def convert_method_call(self, context, expr, methodname, args, kwargs):

--- a/typed_python/compiler/type_wrappers/dict_wrapper.py
+++ b/typed_python/compiler/type_wrappers/dict_wrapper.py
@@ -669,6 +669,9 @@ class DictWrapper(DictWrapperBase):
 
         return super().convert_type_call(context, typeInst, args, kwargs)
 
+    def convert_bool_cast(self, context, expr):
+        return context.pushPod(bool, self.convert_len_native(expr.nonref_expr).neq(0))
+
 
 class DictMakeIteratorWrapper(DictWrapperBase):
     def convert_method_call(self, context, expr, methodname, args, kwargs):

--- a/typed_python/compiler/type_wrappers/none_wrapper.py
+++ b/typed_python/compiler/type_wrappers/none_wrapper.py
@@ -75,3 +75,6 @@ class NoneWrapper(Wrapper):
             return context.constant(True)
 
         return super().convert_to_type_with_target(context, e, targetVal, explicit)
+
+    def convert_bool_cast(self, context, expr):
+        return context.constant(False)

--- a/typed_python/compiler/type_wrappers/one_of_wrapper.py
+++ b/typed_python/compiler/type_wrappers/one_of_wrapper.py
@@ -321,3 +321,19 @@ class OneOfWrapper(Wrapper):
             return args[0].convert_to_type(self, True)
 
         return super().convert_type_call(context, typeInst, args, kwargs)
+
+    def convert_bool_cast(self, context, expr):
+        return expr.convert_to_type(bool)
+
+    def convert_int_cast(self, context, expr):
+        return expr.convert_to_type(int)
+
+    def convert_float_cast(self, context, expr):
+        return expr.convert_to_type(float)
+
+    # TODO:
+    # We're using the default convert_str_cast() for now, which goes to the interpreter.
+    # But would be good to have a direct convert_str_cast for OneOf.
+
+    def convert_bytes_cast(self, context, expr):
+        return expr.convert_to_type(bytes)

--- a/typed_python/compiler/type_wrappers/pointer_to_wrapper.py
+++ b/typed_python/compiler/type_wrappers/pointer_to_wrapper.py
@@ -16,7 +16,7 @@ from typed_python.compiler.type_wrappers.wrapper import Wrapper
 from typed_python.compiler.type_wrappers.python_type_object_wrapper import PythonTypeObjectWrapper
 from typed_python.compiler.type_wrappers.bound_compiled_method_wrapper import BoundCompiledMethodWrapper
 
-from typed_python import Int64, PointerTo, Bool, String
+from typed_python import PointerTo, Bool
 
 import typed_python.compiler.native_ast as native_ast
 import typed_python.compiler
@@ -71,37 +71,34 @@ class PointerToWrapper(Wrapper):
 
         return super().convert_to_type_with_target(context, e, targetVal, explicit)
 
-    def convert_cast(self, context, e, target_type):
-        if target_type.typeRepresentation == Int64:  # not Int32
-            return e.nonref_expr.cast(native_ast.Int64)
+    def convert_int_cast(self, context, e, raiseException=True):
+        return e.nonref_expr.cast(native_ast.Int64)
 
-        if target_type.typeRepresentation == String:
-            asInt = e.convert_to_type(int)
-            if asInt is None:
-                return None
+    def convert_str_cast(self, context, e):
+        asInt = e.convert_to_type(int)
+        if asInt is None:
+            return None
 
-            asStr = asInt.convert_to_type(str)
-            if asStr is None:
-                return None
+        asStr = asInt.convert_to_type(str)
+        if asStr is None:
+            return None
 
-            return context.constant("0x") + asStr
-
-        return super().convert_cast(context, e, target_type)
+        return context.constant("0x") + asStr
 
     def convert_bin_op(self, context, left, op, right, inplace):
         if op.matches.Add:
-            right_int = right.convert_cast(int)
+            right_int = right.expr_type.convert_int_cast(context, right, False)
             if right_int is None:
                 return super().convert_bin_op(context, left, op, right, inplace)
 
             return context.pushPod(self, left.nonref_expr.elemPtr(right_int.nonref_expr))
 
         if op.matches.Sub:
-            right_int = right.convert_cast(int)
+            right_int = right.expr_type.convert_int_cast(context, right, False)
             if right_int is None:
                 return super().convert_bin_op(context, left, op, right, inplace)
 
-            left_int = left.convert_cast(int)
+            left_int = left.expr_type.convert_int_cast(context, left, False)
             if left_int is None:
                 return super().convert_bin_op(context, left, op, right, inplace)
 
@@ -191,6 +188,9 @@ class PointerToWrapper(Wrapper):
             return context.push(self, lambda x: x.convert_default_initialize())
 
         if len(args) == 1 and not kwargs:
-            return args[0].convert_cast(self)
+            return args[0].convert_to_type(self, True)
 
         return super().convert_type_call(context, typeInst, args, kwargs)
+
+    def convert_bool_cast(self, context, e):
+        return e.convert_to_type(bool)

--- a/typed_python/compiler/type_wrappers/print_wrapper.py
+++ b/typed_python/compiler/type_wrappers/print_wrapper.py
@@ -23,7 +23,7 @@ class PrintWrapper(Wrapper):
     is_pass_by_ref = False
 
     def __init__(self):
-        super().__init__(len)
+        super().__init__(print)
 
     def getNativeLayoutType(self):
         return native_ast.Type.Void()
@@ -49,7 +49,7 @@ class PrintWrapper(Wrapper):
 
         # it would be better to use join
         for a in args:
-            converted = a.convert_cast(str)
+            converted = a.convert_str_cast()
             if converted is None:
                 return None
 

--- a/typed_python/compiler/type_wrappers/python_object_of_type_wrapper.py
+++ b/typed_python/compiler/type_wrappers/python_object_of_type_wrapper.py
@@ -145,10 +145,7 @@ class PythonObjectOfTypeWrapper(RefcountedWrapper):
         if rAsObj is None:
             return None
 
-        if not inplace:
-            tgt = runtime_functions.pyOpToBinaryCallTarget.get(op)
-        else:
-            tgt = runtime_functions.pyInplaceOpToBinaryCallTarget.get(op)
+        tgt = runtime_functions.pyOpToBinaryCallTarget.get(op)
 
         if tgt is not None:
             return context.push(
@@ -252,6 +249,9 @@ class PythonObjectOfTypeWrapper(RefcountedWrapper):
 
         return super()._can_convert_from_type(otherType, explicit)
 
+    def convert_bool_cast(self, context, e):
+        return e.convert_to_type(bool)
+
     def convert_to_type_with_target(self, context, e, targetVal, explicit):
         target_type = targetVal.expr_type
 
@@ -282,7 +282,7 @@ class PythonObjectOfTypeWrapper(RefcountedWrapper):
 
         if tp:
             if not sourceVal.isReference:
-                sourceVal = context.push(sourceVal.expr_type, lambda x: x.convert_copy_initialize(sourceVal))
+                sourceVal = context.pushMove(sourceVal)
 
             context.pushEffect(
                 targetVal.expr.store(

--- a/typed_python/compiler/type_wrappers/python_type_object_wrapper.py
+++ b/typed_python/compiler/type_wrappers/python_type_object_wrapper.py
@@ -27,12 +27,9 @@ class PythonTypeObjectWrapper(PythonFreeObjectWrapper):
     def __str__(self):
         return "TypeObject(%s)" % self.typeRepresentation.Value.__qualname__
 
-    def convert_cast(self, context, instance, targetType):
-        if targetType == typeWrapper(str):
-            typ = self.typedPythonTypeToRegularType(self.typeRepresentation.Value)
-            return context.constant(str(typ))
-
-        return super().convert_call(context, instance, targetType)
+    def convert_str_cast(self, context, instance):
+        typ = self.typedPythonTypeToRegularType(self.typeRepresentation.Value)
+        return context.constant(str(typ))
 
     @staticmethod
     def typedPythonTypeToRegularType(typeRep):
@@ -58,6 +55,17 @@ class PythonTypeObjectWrapper(PythonFreeObjectWrapper):
 
     @Wrapper.unwrapOneOfAndValue
     def convert_call(self, context, left, args, kwargs):
+        if self.typeRepresentation.Value is bool:
+            return args[0].convert_bool_cast()
+        if self.typeRepresentation.Value is int:
+            return args[0].convert_int_cast()
+        if self.typeRepresentation.Value is float:
+            return args[0].convert_float_cast()
+        if self.typeRepresentation.Value is str:
+            return args[0].convert_str_cast()
+        if self.typeRepresentation.Value is bytes:
+            return args[0].convert_bytes_cast()
+
         if self.typeRepresentation.Value is type:
             if len(args) != 1 or kwargs:
                 return super().convert_call(context, left, args, kwargs)

--- a/typed_python/compiler/type_wrappers/runtime_functions.py
+++ b/typed_python/compiler/type_wrappers/runtime_functions.py
@@ -76,12 +76,13 @@ pyOpToBinaryCallTarget = {
     python_ast.BinaryOp.BitOr(): binaryPyobjCallTarget("np_pyobj_Or"),
     python_ast.BinaryOp.BitXor(): binaryPyobjCallTarget("np_pyobj_Xor"),
     python_ast.BinaryOp.BitAnd(): binaryPyobjCallTarget("np_pyobj_And"),
-    python_ast.ComparisonOp.Eq(): binaryPyobjCallTarget("np_pyobj_Eq"),
+    python_ast.ComparisonOp.Eq(): binaryPyobjCallTarget("np_pyobj_EQ"),
+    python_ast.ComparisonOp.NotEq(): binaryPyobjCallTarget("np_pyobj_NE"),
+    python_ast.ComparisonOp.Lt(): binaryPyobjCallTarget("np_pyobj_LT"),
+    python_ast.ComparisonOp.Gt(): binaryPyobjCallTarget("np_pyobj_GT"),
+    python_ast.ComparisonOp.LtE(): binaryPyobjCallTarget("np_pyobj_LE"),
+    python_ast.ComparisonOp.GtE(): binaryPyobjCallTarget("np_pyobj_GE"),
 }
-
-
-pyInplaceOpToBinaryCallTarget = {}
-
 
 pyOpToUnaryCallTarget = {
     python_ast.UnaryOp.Not(): externalCallTarget("np_pyobj_Not", Bool, Void.pointer()),
@@ -656,5 +657,29 @@ pyobj_locktype_unlock = externalCallTarget(
 pyobj_locktype_lock = externalCallTarget(
     "np_pyobj_locktype_lock",
     Bool,
+    Void.pointer()
+)
+
+str_to_int64 = externalCallTarget(
+    "np_str_to_int64",
+    Int64,
+    Void.pointer()
+)
+
+str_to_float64 = externalCallTarget(
+    "np_str_to_float64",
+    Float64,
+    Void.pointer()
+)
+
+bytes_to_int64 = externalCallTarget(
+    "np_bytes_to_int64",
+    Int64,
+    Void.pointer()
+)
+
+bytes_to_float64 = externalCallTarget(
+    "np_bytes_to_float64",
+    Float64,
     Void.pointer()
 )

--- a/typed_python/compiler/type_wrappers/set_wrapper.py
+++ b/typed_python/compiler/type_wrappers/set_wrapper.py
@@ -131,3 +131,6 @@ class SetWrapper(SetWrapperBase):
             return context.constant(True)
 
         return super().convert_to_type_with_target(context, e, targetVal, explicit)
+
+    def convert_bool_cast(self, context, expr):
+        return context.pushPod(bool, self.convert_len_native(expr.nonref_expr).neq(0))

--- a/typed_python/compiler/type_wrappers/tuple_of_wrapper.py
+++ b/typed_python/compiler/type_wrappers/tuple_of_wrapper.py
@@ -319,6 +319,9 @@ class TupleOrListOfWrapper(RefcountedWrapper):
 
         return super().convert_type_call(context, typeInst, args, kwargs)
 
+    def convert_bool_cast(self, context, expr):
+        return context.pushPod(bool, self.convert_len_native(expr.nonref_expr).neq(0))
+
 
 class TupleOrListOfIteratorWrapper(Wrapper):
     is_pod = False

--- a/typed_python/compiler/type_wrappers/tuple_wrapper.py
+++ b/typed_python/compiler/type_wrappers/tuple_wrapper.py
@@ -85,6 +85,9 @@ class TupleWrapper(Wrapper):
     def convert_len(self, context):
         return context.constant(len(self.subTypeWrappers))
 
+    def convert_bool_cast(self, context, e):
+        return context.constant(len(self.subTypeWrappers) != 0)
+
     def convert_getitem(self, context, expr, index):
         index = index.convert_to_type(int)
         if index is None:

--- a/typed_python/compiler/typed_expression.py
+++ b/typed_python/compiler/typed_expression.py
@@ -142,6 +142,21 @@ class TypedExpression(object):
     def convert_abs(self):
         return self.expr_type.convert_abs(self.context, self)
 
+    def convert_bool_cast(self):
+        return self.expr_type.convert_bool_cast(self.context, self)
+
+    def convert_int_cast(self):
+        return self.expr_type.convert_int_cast(self.context, self)
+
+    def convert_float_cast(self):
+        return self.expr_type.convert_float_cast(self.context, self)
+
+    def convert_str_cast(self):
+        return self.expr_type.convert_str_cast(self.context, self)
+
+    def convert_bytes_cast(self):
+        return self.expr_type.convert_bytes_cast(self.context, self)
+
     def convert_builtin(self, f, a1=None):
         return self.expr_type.convert_builtin(f, self.context, self, a1)
 
@@ -165,10 +180,6 @@ class TypedExpression(object):
 
     def convert_method_call(self, methodname, args, kwargs):
         return self.expr_type.convert_method_call(self.context, self, methodname, args, kwargs)
-
-    def convert_cast(self, target_type):
-        """Convert an explicit cast to another type (e.g. str(x))."""
-        return self.expr_type.convert_cast(self.context, self, typeWrapper(target_type))
 
     def convert_to_type(self, target_type, explicit=True):
         """Convert to a target type as a function argument.


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Motivation and Context
Treat these casts like operators.

## Approach
Replace convert_cast with specific convert_*_cast for each builtin type, which can then be implemented by types that support those casts.
convert_bool_cast
convert_int_cast
convert_float_cast
convert_str_cast
convert_bytes_cast

Not meant to change any functionality.

## How Has This Been Tested?
Check that these 5 casts (applied to a variety of types) behave the same for compiled and interpreted code.

## Screenshots or console output (if appropriate)
<!-- if not appropriate, remove this section -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.