### PR TITLE
Support compiled "and" and "or" that return non-boolean values.  Refs #267.

### DIFF
--- a/typed_python/compiler/tests/conversion_test.py
+++ b/typed_python/compiler/tests/conversion_test.py
@@ -115,6 +115,42 @@ class TestCompilationStructures(unittest.TestCase):
         self.assertEqual(f(0, 1, "s"), False)
         self.assertEqual(f(1, 1, "s"), True)
 
+    def test_boolean_operators_with_side_effects(self):
+        # a function that appends 'effect' onto a list of effects
+        # and then returns result, so that we can track when we
+        # are actually executing a particular expression
+        def effectAndResult(effectList, effect, result):
+            effectList.append(effect)
+            return result
+
+        @Compiled
+        def f_and(x: int, y: int, z: str) -> ListOf(str):
+            result = ListOf(str)()
+
+            (effectAndResult(result, "x", x)
+                and effectAndResult(result, "y", y)
+                and effectAndResult(result, "z", z))
+
+            return result
+
+        self.assertEqual(f_and(0, 1, "s"), ["x"])
+        self.assertEqual(f_and(1, 0, "s"), ["x", "y"])
+        self.assertEqual(f_and(1, 1, "s"), ["x", "y", "z"])
+
+        @Compiled
+        def f_or(x: int, y: int, z: str) -> ListOf(str):
+            result = ListOf(str)()
+
+            (effectAndResult(result, "x", x)
+                and effectAndResult(result, "y", y)
+                and effectAndResult(result, "z", z))
+
+            return result
+
+        self.assertEqual(f_or(0, 0, ""), ["x"])
+        self.assertEqual(f_or(1, 0, ""), ["x", "y"])
+        self.assertEqual(f_or(1, 1, ""), ["x", "y", "z"])
+
     def test_object_to_int_conversion(self):
         @Function
         def toObject(o: object):

--- a/typed_python/compiler/tests/conversion_test.py
+++ b/typed_python/compiler/tests/conversion_test.py
@@ -15,7 +15,6 @@
 import time
 import traceback
 import unittest
-import pytest
 from flaky import flaky
 
 from typed_python import Function, OneOf, TupleOf, ListOf, Tuple, NamedTuple, Class, _types
@@ -581,23 +580,61 @@ class TestCompilationStructures(unittest.TestCase):
         with self.assertRaises(AssertionError):
             check(10)
 
-    @pytest.mark.skip(reason="to be fixed")
     def test_conditional_eval_or(self):
         @Compiled
-        def f(x: int, y: float, z: str):
+        def f1(x: float, y: int):
+            return x or 1 / y
+
+        @Compiled
+        def f2(x: str, y: int):
+            return x or 1 / y
+
+        @Compiled
+        def f3(x: int, y: float, z: str):
             return x or y or z
 
-        self.assertEqual(f(0, 0.0, ""), "")
-        self.assertEqual(f(0, 0.0, "one"), "one")
-        self.assertEqual(f(0, 1.5, ""), 1.5)
-        self.assertEqual(f(0, 1.5, "one"), 1.5)
-        self.assertEqual(f(3, 0.0, ""), 3)
-        self.assertEqual(f(3, 0.0, "one"), 3)
-        self.assertEqual(f(3, 1.5, ""), 3)
-        self.assertEqual(f(3, 1.5, "one"), 3)
+        with self.assertRaises(ZeroDivisionError):
+            f1(0.0, 0)
+        self.assertEqual(f1(0.0, 2), 0.5)
+        self.assertEqual(f1(1.23, 0), 1.23)
+        self.assertEqual(f1(1.23, 2), 1.23)
 
-    @pytest.mark.skip(reason="to be fixed")
+        with self.assertRaises(ZeroDivisionError):
+            f2("", 0)
+        self.assertEqual(f2("", 2), 0.5)
+        self.assertEqual(f2("y", 0), "y")
+        self.assertEqual(f2("y", 2), "y")
+
+        self.assertEqual(f3(0, 0.0, ""), "")
+        self.assertEqual(f3(0, 0.0, "one"), "one")
+        self.assertEqual(f3(0, 1.5, ""), 1.5)
+        self.assertEqual(f3(0, 1.5, "one"), 1.5)
+        self.assertEqual(f3(3, 0.0, ""), 3)
+        self.assertEqual(f3(3, 0.0, "one"), 3)
+        self.assertEqual(f3(3, 1.5, ""), 3)
+        self.assertEqual(f3(3, 1.5, "one"), 3)
+
     def test_conditional_eval_and(self):
+        @Compiled
+        def f1(x: float, y: int):
+            return x and 1 / y
+
+        self.assertEqual(f1(0.0, 0), 0.0)
+        self.assertEqual(f1(0.0, 2), 0.0)
+        with self.assertRaises(ZeroDivisionError):
+            f1(2.5, 0)
+        self.assertEqual(f1(2.5, 2), 0.5)
+
+        @Compiled
+        def f2(x: str, y: int):
+            return x and 1 / y
+
+        self.assertEqual(f2("", 0), "")
+        self.assertEqual(f2("", 2), "")
+        with self.assertRaises(ZeroDivisionError):
+            f2("y", 0)
+        self.assertEqual(f2("y", 2), 0.5)
+
         @Compiled
         def f(x: int, y: str, z: float):
             return x and y and z

--- a/typed_python/compiler/tests/list_of_compilation_test.py
+++ b/typed_python/compiler/tests/list_of_compilation_test.py
@@ -371,7 +371,7 @@ class TestListOfCompilation(unittest.TestCase):
         x[0] = 100
         self.assertEqual(y[0], 1)
 
-    def test_list_short_circut_if(self):
+    def test_list_short_circuit_if(self):
         @Compiled
         def chkList(x: ListOf(int)):
             return len(x) > 0 and x[0]

--- a/typed_python/compiler/type_wrappers/one_of_wrapper.py
+++ b/typed_python/compiler/type_wrappers/one_of_wrapper.py
@@ -210,10 +210,6 @@ class OneOfWrapper(Wrapper):
         return "Maybe"
 
     def convert_to_type_with_target(self, context, expr, targetVal, explicit):
-        # TODO: Is this really what I want to do?
-        if not expr.isReference:
-            expr = context.pushMove(expr)
-
         isInitialized = context.push(bool, lambda tgt: tgt.expr.store(native_ast.const_bool_expr(False)))
 
         with context.switch(expr.expr.ElementPtrIntegers(0, 0).load(),

--- a/typed_python/compiler/type_wrappers/one_of_wrapper.py
+++ b/typed_python/compiler/type_wrappers/one_of_wrapper.py
@@ -210,7 +210,9 @@ class OneOfWrapper(Wrapper):
         return "Maybe"
 
     def convert_to_type_with_target(self, context, expr, targetVal, explicit):
-        assert expr.isReference
+        # TODO: Is this really what I want to do?
+        if not expr.isReference:
+            expr = context.pushMove(expr)
 
         isInitialized = context.push(bool, lambda tgt: tgt.expr.store(native_ast.const_bool_expr(False)))
 


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->

## Motivation and Context
This is handled properly in interpreted code.  E.g. `3 and "x"` returns `"x"`
Compiled code needs to be consistent with interpreted code.

## Approach
* Adjusted the compilation of BoolOp to calculate the return type and to return actual values instead of boolean constants.
*  `T1 and T2` has return type `OneOf(T1, T2`).  Same for `T1 or T2`.
* The conversion T1->OneOf(T1,T2) exposed some issues with isReference requirements in OneOfWrapper.  I worked around these issues in a direct way, but don't trust my approach.

## How Has This Been Tested?
Tests for same types, different types, 2 or 3 parameters, "and" and "or".

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.