### PR TITLE
Not works on lists and tuples

### DIFF
--- a/typed_python/compiler/tests/list_of_compilation_test.py
+++ b/typed_python/compiler/tests/list_of_compilation_test.py
@@ -423,3 +423,22 @@ class TestListOfCompilation(unittest.TestCase):
 
         x = ListOf(int)([])
         self.assertFalse(chkList(x))
+
+    def test_not_list(self):
+        @Compiled
+        def chkListInt(x: ListOf(int)):
+            return not x
+
+        x = ListOf(int)([])
+        self.assertTrue(chkListInt(x))
+        x.append(0)
+        self.assertFalse(chkListInt(x))
+
+        @Compiled
+        def chkListListInt(x: ListOf(ListOf(int))):
+            return not x
+
+        x = ListOf(ListOf(int))()
+        self.assertTrue(chkListListInt(x))
+        x.append(ListOf(int)())
+        self.assertFalse(chkListListInt(x))

--- a/typed_python/compiler/type_wrappers/wrapper.py
+++ b/typed_python/compiler/type_wrappers/wrapper.py
@@ -291,6 +291,9 @@ class Wrapper(object):
         )
 
     def convert_unary_op(self, context, expr, op):
+        if op.matches.Not:
+            return self.convert_bool_cast(context, expr).convert_unary_op(op)
+
         return context.pushException(
             TypeError,
             "Can't apply unary op %s to type '%s'" % (op, expr.expr_type)


### PR DESCRIPTION
Fixes Issue 283: 'not' operator not compiling on ListOf
'not' operator should now work for any type wrapper that implements convert_not_cast

<!-- Provide a general summary of your changes in the Title above -->

## Motivation and Context
https://github.com/APrioriInvestments/typed_python/issues/283

## Approach
Modified the convert_unary_op method of the Wrapper class to first check if the op is 'not' in which case its output is deduced from convert_bool_cast (if implemented).

## How Has This Been Tested?
With a simple new test test_not_list in list_of_compilation_test.py

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.