### PR TITLE
internals: allow ClassMetaclass to receive a __name__ keyword argument

### DIFF
--- a/typed_python/internals.py
+++ b/typed_python/internals.py
@@ -263,6 +263,9 @@ class ClassMetaclass(type):
             else:
                 classMembers.append((eltName, elt))
 
+        if "__name__" in kwds:
+            name = kwds["__name__"]
+
         return typed_python._types.Class(
             name,
             tuple(bases),


### PR DESCRIPTION
which overloads its name

<!-- Provide a general summary of your changes in the Title above -->

## Motivation and Context

This allows us to put non alpha-numeric characters in class names and, more importantly, allow class names to depend on the inputs to a class constructor.

<!-- Why is this change required? -->
<!-- What problem does it solve? -->
<!--  If it fixes an open issue, please link to the issue here.-->

## Approach
<!-- Describe your changes in reasonable detail -->

## How Has This Been Tested?
<!-- Describe in reasonable detail how you tested your changes. -->
<!-- If appropriate, include details of your testing environment, -->
<!-- tests ran to see how your change affects other areas of the code, etc. -->

## Screenshots or console output (if appropriate)
<!-- if not appropriate, remove this section -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.