### PR TITLE
Implement missing Set operations and Set compilation.  Refs #170.

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -8,3 +8,5 @@ coverage:
         base: auto
         threshold: 0.5
         informational: true
+ignore:
+  - "typed_python/compiler/type_wrappers/native_hash.py"

--- a/typed_python/PySetInstance.hpp
+++ b/typed_python/PySetInstance.hpp
@@ -35,6 +35,10 @@ class PySetInstance : public PyInstance {
     static PyObject* setUnion(PyObject* o, PyObject* args);
     static PyObject* setIntersection(PyObject* o, PyObject* args);
     static PyObject* setDifference(PyObject* o, PyObject* args);
+    static PyObject* setSymmetricDifference(PyObject* o, PyObject* args);
+    static PyObject* setIsSubset(PyObject* o, PyObject* args);
+    static PyObject* setIsSuperset(PyObject* o, PyObject* args);
+    static PyObject* setIsDisjoint(PyObject* o, PyObject* args);
     Py_ssize_t mp_and_sq_length_concrete();
     int sq_contains_concrete(PyObject* item);
     PyObject* tp_iter_concrete();
@@ -48,17 +52,32 @@ class PySetInstance : public PyInstance {
                                            bool isExplicit) {
         return true;
     }
+    static bool compare_to_python_concrete(SetType* setT, instance_ptr self, PyObject* other, bool exact, int pyComparisonOp);
     int pyInquiryConcrete(const char* op, const char* opErrRep);
+    PyObject* pyOperatorConcrete(PyObject* rhs, const char* op, const char* opErr);
+    PyObject* pyOperatorDifference(PyObject* rhs, const char* op, const char* opErr, bool reversed);
+    PyObject* pyOperatorSymmetricDifference(PyObject* rhs, const char* op, const char* opErr, bool reversed);
+    PyObject* pyOperatorUnion(PyObject* rhs, const char* op, const char* opErr, bool reversed);
+    PyObject* pyOperatorIntersection(PyObject* rhs, const char* op, const char* opErr, bool reversed);
 
   private:
     static void insertKey(PySetInstance* self, PyObject* pyKey, instance_ptr key);
     static PyObject* try_remove(PyObject* o, PyObject* item, bool assertKeyError = false);
+    static PyObject* try_add_if_not_found(PyObject* o, PySetInstance* to_be_added, PyObject* item);
     static void copy_elements(PyObject* dst, PyObject* src);
-    static PyObject* set_intersection(PyObject* o, PyObject* other);
     static PyObject* set_difference(PyObject* o, PyObject* other);
     static int set_difference_update(PyObject* o, PyObject* other);
+    static PyObject* set_symmetric_difference(PyObject* o, PyObject* other);
+    static int set_symmetric_difference_update(PyObject* o, PyObject* other);
+    static PyObject* set_union(PyObject* o, PyObject* other);
+    static PyObject* set_intersection(PyObject* o, PyObject* other);
+    static bool set_is_subset(PyObject* o, PyObject* other);
+    static bool set_is_superset(PyObject* o, PyObject* other);
+    static bool set_is_disjoint(PyObject* o, PyObject* other);
     SetType* type();
     static void getDataFromNative(PySetInstance* src, std::function<void(instance_ptr)> func);
     static void getDataFromNative(PyTupleOrListOfInstance* src,
                                   std::function<void(instance_ptr)> func);
+    static bool subset(SetType* setT, instance_ptr left, PyObject* right);
+    static bool superset(SetType* setT, instance_ptr left, PyObject* right);
 };

--- a/typed_python/SetType.hpp
+++ b/typed_python/SetType.hpp
@@ -149,4 +149,5 @@ class SetType : public Type {
   private:
     Type* m_key_type;
     size_t m_bytes_per_el;
+    bool subset(instance_ptr left, instance_ptr right);
 };

--- a/typed_python/_runtime.cpp
+++ b/typed_python/_runtime.cpp
@@ -900,7 +900,7 @@ extern "C" {
             return StringType::createFromUtf8("False", 5);
     }
 
-    hash_table_layout* nativepython_dict_create() {
+    hash_table_layout* nativepython_tableCreate() {
         hash_table_layout* result;
 
         result = (hash_table_layout*)malloc(sizeof(hash_table_layout));
@@ -912,15 +912,25 @@ extern "C" {
         return result;
     }
 
-    int32_t nativepython_dict_allocateNewSlot(hash_table_layout* layout, size_t kvPairSize) {
+    int32_t nativepython_tableAllocateNewSlot(hash_table_layout* layout, size_t kvPairSize) {
         return layout->allocateNewSlot(kvPairSize);
     }
 
-    void nativepython_dict_resizeTable(hash_table_layout* layout) {
+    hash_table_layout* nativepython_tableCopy(hash_table_layout* layout, Type* tp) {
+        SetType* setT = (SetType*)tp;
+
+        return layout->copyTable(
+            setT->keyType()->bytecount(),
+            setT->keyType()->isPOD(),
+            [&](instance_ptr self, instance_ptr other) {setT->copy_constructor(self, other);}
+        );
+    }
+
+    void nativepython_tableResize(hash_table_layout* layout) {
         layout->resizeTable();
     }
 
-    void nativepython_dict_compressItemTable(hash_table_layout* layout, size_t kvPairSize) {
+    void nativepython_tableCompress(hash_table_layout* layout, size_t kvPairSize) {
         layout->compressItemTable(kvPairSize);
     }
 

--- a/typed_python/compiler/tests/conversion_test.py
+++ b/typed_python/compiler/tests/conversion_test.py
@@ -1850,6 +1850,8 @@ class TestCompilationStructures(unittest.TestCase):
             # osx memory usage rises, but not others
             if sys.platform != "darwin":
                 self.assertLessEqual(m3 - m2, m1 - m0 + 512, (f.__name__, a))
+            else:
+                self.assertLessEqual(m3 - m2, m1 - m0 + 1024, (f.__name__, a))
 
         for f in [g1]:
             c_f = Compiled(f)
@@ -2442,7 +2444,7 @@ class TestCompilationStructures(unittest.TestCase):
             # performance is poor, so don't compare yet
             # self.assertLessEqual(ratio, limit, (f1.__name__, a))
 
-            self.assertLessEqual(m3 - m2, m1 - m0 + 512, (f1.__name__, a))
+            self.assertLessEqual(m3 - m2, m1 - m0 + 1024, (f1.__name__, a))
 
     def test_context_manager_assignment(self):
 

--- a/typed_python/compiler/tests/set_compilation_test.py
+++ b/typed_python/compiler/tests/set_compilation_test.py
@@ -1,0 +1,687 @@
+#   Copyright 2017-2020 typed_python Authors
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+from typed_python import Set, ListOf, Entrypoint, Compiled, String, Tuple, TupleOf
+import typed_python._types as _types
+import time
+import numpy
+import unittest
+
+
+class TestSetCompilation(unittest.TestCase):
+    def test_can_copy_set(self):
+        @Entrypoint
+        def f(x: Set(int)):
+            y = x
+            return y
+
+        self.assertEqual(f({1, 2}), {1, 2})
+
+        @Entrypoint
+        def reversed(x: ListOf(Set(int))):
+            res = ListOf(Set(int))()
+
+            i = len(x) - 1
+            while i >= 0:
+                res.append(x[i])
+                i -= 1
+
+            return res
+
+        for length in range(100):
+            sets = [{x * 2 + 1} for x in range(length)]
+
+            aList = ListOf(Set(int))(sets)
+
+            refcounts = [_types.refcount(x) for x in aList]
+            aListRev = reversed(aList)
+            self.assertEqual(aListRev, list(reversed(sets)))
+            aListRev = None
+
+            refcounts2 = [_types.refcount(x) for x in aList]
+
+            self.assertEqual(refcounts, refcounts2)
+
+    def test_set_length(self):
+        @Entrypoint
+        def set_len(x):
+            return len(x)
+
+        x = Set(int)({1})
+
+        self.assertEqual(set_len(x), 1)
+        x.add(2)
+
+        self.assertEqual(set_len(x), 2)
+
+        x.remove(2)
+
+        self.assertEqual(set_len(x), 1)
+
+        x.clear()
+        self.assertEqual(set_len(x), 0)
+
+    def test_set_in(self):
+        @Entrypoint
+        def set_in(x, y):
+            return y in x
+
+        x = Set(int)()
+
+        x.add(1)
+
+        self.assertEqual(set_in(x, 1), True)
+        self.assertEqual(set_in(x, 2), False)
+        # TODO: Is this the desired behavior?
+        with self.assertRaises(TypeError):
+            set_in(x, 1.5)
+        with self.assertRaises(TypeError):
+            set_in(x, 1.0)
+
+        x1 = Set(float)()
+
+        x1.add(1.0)
+        self.assertEqual(set_in(x1, 1.0), True)
+        self.assertEqual(set_in(x1, 1.2), False)
+        with self.assertRaises(TypeError):
+            set_in(x1, 1)
+
+    def test_set_add(self):
+        S = Set(int)
+
+        @Entrypoint
+        def set_add(s, k):
+            s.add(k)
+
+        x = S({1})
+
+        self.assertEqual(x, {1})
+        set_add(x, 9)
+        self.assertEqual(x, {1, 9})
+        set_add(x, 4)
+        self.assertEqual(x, {1, 4, 9})
+
+        with self.assertRaises(TypeError):
+            set_add(x, 1.5)
+
+        x.clear()
+        self.assertEqual(x, set())
+
+        @Entrypoint
+        def set_many(s, count):
+            for i in range(count):
+                s.add(i * i)
+
+        set_many(x, 1000)
+        self.assertEqual(x, {i * i for i in range(1000)})
+
+        T = Set(str)
+        y = T({"abc"})
+        self.assertEqual(y, {"abc"})
+        set_add(y, "def")
+        self.assertEqual(y, {"abc", "def"})
+        set_add(y, "ghi")
+        self.assertEqual(y, {"abc", "def", "ghi"})
+        y.clear()
+        self.assertEqual(y, set())
+
+        @Entrypoint
+        def set_many2(s, count):
+            for i in range(count):
+                s.add(str(i * i))
+
+        set_many2(y, 1000)
+        self.assertEqual(y, {str(i * i) for i in range(1000)})
+
+        @Compiled
+        def f(x: str):
+            s = Set(String)({"initial", "value"})
+            s.add(x)
+            s.add(x + x)
+            return s
+
+        self.assertEqual(f("a"), {"initial", "value", "a", "aa"})
+        self.assertEqual(f("xyz" * 100), {"initial", "value", "xyz" * 100, "xyz" * 200})
+
+    def test_set_remove_discard(self):
+        @Entrypoint
+        def set_remove(s, k):
+            s.remove(k)
+
+        @Entrypoint
+        def set_discard(s, k):
+            s.discard(k)
+
+        s = Set(int)({1, 2, 3})
+        with self.assertRaises(KeyError):
+            set_remove(s, 4)
+        set_remove(s, 2)
+        self.assertEqual(s, {1, 3})
+        set_remove(s, 1)
+        self.assertEqual(s, {3})
+        set_remove(s, 3)
+        self.assertEqual(s, set())
+        with self.assertRaises(KeyError):
+            set_remove(s, 4)
+
+        s = Set(str)({'aa', 'bb', 'cc'})
+        with self.assertRaises(KeyError):
+            set_remove(s, 'dd')
+        set_remove(s, 'bb')
+        self.assertEqual(s, {'aa', 'cc'})
+        set_remove(s, 'aa')
+        self.assertEqual(s, {'cc'})
+        set_remove(s, 'cc')
+        self.assertEqual(s, set())
+        with self.assertRaises(KeyError):
+            set_remove(s, 'dd')
+
+        s = Set(int)({1, 2, 3})
+        set_discard(s, 4)
+        self.assertEqual(s, {1, 2, 3})
+        set_remove(s, 2)
+        self.assertEqual(s, {1, 3})
+        set_remove(s, 1)
+        self.assertEqual(s, {3})
+        set_remove(s, 3)
+        self.assertEqual(s, set())
+        set_discard(s, 4)
+        self.assertEqual(s, set())
+
+        s = Set(str)({'aa', 'bb', 'cc'})
+        set_discard(s, 'dd')
+        self.assertEqual(s, {'aa', 'bb', 'cc'})
+        set_remove(s, 'bb')
+        self.assertEqual(s, {'aa', 'cc'})
+        set_remove(s, 'aa')
+        self.assertEqual(s, {'cc'})
+        set_remove(s, 'cc')
+        self.assertEqual(s, set())
+        set_discard(s, 'dd')
+        self.assertEqual(s, set())
+
+    def test_set_clear(self):
+        @Entrypoint
+        def set_clear(s):
+            s.clear()
+
+        s1 = Set(int)()
+        for i in range(1000):
+            s1.add(i * i)
+        self.assertEqual(len(s1), 1000)
+        set_clear(s1)
+        self.assertEqual(len(s1), 0)
+
+        s2 = Set(str)()
+        for i in range(1000, 2000):
+            s2.add(str(i))
+        self.assertEqual(len(s2), 1000)
+        set_clear(s2)
+        self.assertEqual(len(s2), 0)
+
+    def test_set_assign_and_copy(self):
+        s = Set(str)(set("abc"))
+
+        @Entrypoint
+        def set_assign_and_modify_original(s, x, y):
+            s2 = s
+            s.add(x)
+            s.remove(y)
+            return s2
+
+        @Entrypoint
+        def set_copy_and_modify_original(s, x, y):
+            s2 = s.copy()
+            s.add(x)
+            s.remove(y)
+            return s2
+
+        s = Set(str)(set("abc"))
+        self.assertEqual(set_assign_and_modify_original(s, 'q', 'b'), set("acq"))
+        s = Set(str)(set("abc"))
+        self.assertEqual(set_copy_and_modify_original(s, 'q', 'b'), set("abc"))
+
+    def test_adding_to_sets(self):
+
+        @Entrypoint
+        def f(count):
+            for salt in range(count):
+                for count in range(10):
+                    d = Set(str)()
+
+                    for i in range(count):
+                        d.add(str(salt) + "hi" + str(i))
+
+                        for j in range(i):
+                            if str(salt) + "hi" + str(j) not in d:
+                                return False
+
+            return True
+
+        self.assertTrue(f(20000))
+
+    def test_set_destructors(self):
+        @Entrypoint
+        def f():
+            x = Set(str)({'h', 'i'})
+            y = Set(int)({1, 2, 3})
+            x.add('a')
+            y.add(4)
+            return "OK"
+
+        f()
+
+    def test_set_pop(self):
+        @Entrypoint
+        def set_pop(s):
+            return s.pop()
+
+        s = Set(str)()
+        s.add('a')
+        s.add('b')
+
+        self.assertEqual(set_pop(s), 'a')
+        self.assertEqual(s, {'b'})
+        self.assertEqual(set_pop(s), 'b')
+        self.assertEqual(s, set())
+        with self.assertRaises(KeyError):
+            set_pop(s)
+
+        @Compiled
+        def set_to_list(s: Set(int)) -> ListOf(int):
+            result = ListOf(int)()
+            try:
+                while (True):
+                    result.append(s.pop())
+            except KeyError:
+                return result
+            return result
+
+        original_set = Set(int)()
+        for _ in range(10000):
+            original_set.add(numpy.random.choice(1000000))
+        temp_set = original_set.copy()
+        new_set = Set(int)(set_to_list(temp_set))
+        self.assertEqual(temp_set, set())
+        self.assertEqual(original_set, new_set)
+
+    def test_set_perf(self):
+        def set_copy_discard(s: Set(int), count: int):
+            for i in range(2, count):
+                s.add(i)
+            for i in s.copy():
+                for j in range(2, count):
+                    s.discard(i * j)
+
+        compiled_set_copy_discard = Compiled(set_copy_discard)
+
+        t0 = time.time()
+        aSet = Set(int)()
+        set_copy_discard(aSet, 1000)
+
+        t1 = time.time()
+        aSet2 = Set(int)()
+        compiled_set_copy_discard(aSet2, 1000)
+        t2 = time.time()
+
+        self.assertEqual(aSet, aSet2)
+
+        ratio = (t1 - t0) / (t2 - t1)
+
+        self.assertGreater(ratio, 6)
+
+        print("Speedup was ", ratio)
+
+    def test_set_binop(self):
+        S = Set(int)
+
+        sets = []
+        bits = 4
+        for s in range(1<<bits):
+            one_set = set()
+            for i in range(bits):
+                if s & 1<<i:
+                    one_set.add(i)
+            sets.append(one_set)
+
+        def union(x: S, y: S):
+            return x.union(y)
+
+        def intersection(x: S, y: S):
+            return x.intersection(y)
+
+        def difference(x: S, y: S):
+            return x.difference(y)
+
+        def symmetric_difference(x: S, y: S):
+            return x.symmetric_difference(y)
+
+        def op_union(x: S, y: S):
+            return x | y
+
+        def op_intersection(x: S, y: S):
+            return x & y
+
+        def op_difference(x: S, y: S):
+            return x - y
+
+        def op_symmetric_difference(x: S, y: S):
+            return x ^ y
+
+        fns = [union, op_union, intersection, op_intersection,
+               difference, op_difference, symmetric_difference, op_symmetric_difference]
+        for f in fns:
+            for left in sets:
+                for right in sets:
+                    r1 = f(left, right)
+                    r2 = f(S(left), S(right))  # retesting interpreter here
+                    r3 = Compiled(f)(S(left), S(right))  # testing compiled code
+                    self.assertEqual(r1, r2, (f, left, right))
+                    self.assertEqual(r2, r3, (f, left, right))
+
+        def equal(x: S, y: S):
+            return x == y
+
+        def notequal(x: S, y: S):
+            return x != y
+
+        def subset(x: S, y: S):
+            return x.issubset(y)
+
+        def superset(x: S, y: S):
+            return x.issuperset(y)
+
+        def op_subset(x: S, y: S):
+            return x <= y
+
+        def op_superset(x: S, y: S):
+            return x >= y
+
+        def isdisjoint(x: S, y: S):
+            return x.isdisjoint(y)
+
+        comparison_fns = [equal, notequal, subset, superset, op_subset, op_superset, isdisjoint]
+        for f in comparison_fns:
+            for left in sets:
+                for right in sets:
+                    r1 = f(left, right)
+                    r2 = f(S(left), S(right))  # retesting interpreter here
+                    r3 = Compiled(f)(S(left), S(right))  # testing compiled code
+                    self.assertEqual(r1, r2)
+                    self.assertEqual(r2, r3)
+
+        def union0(x: S):
+            return x.union()
+
+        def intersection0(x: S):
+            return x.intersection()
+
+        def difference0(x: S):
+            return x.difference()
+
+        def symmetric_difference0(x: S):
+            return x.symmetric_difference()
+
+        for left in sets:
+            for f in [union0, intersection0, difference0]:
+                r1 = f(left)
+                r2 = f(S(left))  # retesting interpreter here
+                r3 = Compiled(f)(S(left))  # testing method with 0 arguments
+                self.assertEqual(r1, r2)
+                self.assertEqual(r2, r3)
+            with self.assertRaises(TypeError):
+                Compiled(symmetric_difference0)(S(left))
+
+        def union2(x: S, y: S, z: S):
+            return x.union(y, z)
+
+        def intersection2(x: S, y: S, z: S):
+            return x.intersection(y, z)
+
+        def difference2(x: S, y: S, z: S):
+            return x.difference(y, z)
+
+        def symmetric_difference2(x: S, y: S, z: S):
+            return x.symmetric_difference(y, z)
+
+        for x in sets:
+            for y in sets:
+                for z in sets:
+                    for f in [union2, intersection2, difference2]:
+                        r1 = f(x, y, z)
+                        r2 = f(S(x), S(y), S(z))  # retesting interpreter here
+                        r3 = Compiled(f)(S(x), S(y), S(z))  # testing method with 2 arguments
+                        self.assertEqual(r1, r2)
+                        self.assertEqual(r2, r3)
+                    with self.assertRaises(TypeError):
+                        Compiled(symmetric_difference2)(S(x), S(y), S(z))
+
+    def test_set_binop_perf(self):
+        for T in [int, str]:
+            S = Set(T)
+
+            sets = []
+            bits = 6
+            for s in range(1 << bits):
+                one_set = set()
+                for i in range(bits):
+                    if s & 1 << i:
+                        one_set.add(T(i))
+                sets.append(one_set)
+
+            def union(x: S, y: S):
+                return x.union(y)
+
+            def intersection(x: S, y: S):
+                return x.intersection(y)
+
+            def difference(x: S, y: S):
+                return x.difference(y)
+
+            def symmetric_difference(x: S, y: S):
+                return x.symmetric_difference(y)
+
+            sets.append({T(x) for x in range(99)})
+            sets.append({T(x) for x in range(100)})
+            sets.append({T(x) for x in range(0, 100, 2)})
+            sets.append({T(x) for x in range(1, 100, 2)})
+            sets.append({T(x) for x in range(9999)})
+            sets.append({T(x) for x in range(10000)})
+            sets.append({T(x) for x in range(0, 10000, 2)})
+            sets.append({T(x) for x in range(1, 10000, 2)})
+            ourSets = [S(s) for s in sets]
+            for f, threshold in [(union, 0.8), (intersection, 0.2), (difference, 0.5), (symmetric_difference, 1.0)]:
+                repeat = 2
+                a1 = 0
+                a2 = 0
+                c_f = Compiled(f)
+
+                t0 = time.time()
+                for _ in range(repeat):
+                    for x in sets:
+                        for y in sets:
+                            result = f(x, y)
+                            a1 += len(result)
+
+                t1 = time.time()
+                for _ in range(repeat):
+                    for x in ourSets:
+                        for y in ourSets:
+                            result = c_f(x, y)
+                            a2 += len(result)
+
+                t2 = time.time()
+                ratio = (t1 - t0) / (t2 - t1)
+
+                self.assertEqual(a1, a2, (f, S))
+
+                print("Speedup was", ratio, "for", f, "on", S)
+
+                # performance could be improved
+                self.assertGreater(ratio, threshold)
+
+    def test_set_iteration(self):
+        def set_to_list(s: Set(str)) -> ListOf(str):
+            result = ListOf(str)()
+            for i in s:
+                result.append(i)
+            return result
+
+        s = Set(str)("iteration")
+        r1 = set_to_list(s)
+        r2 = Compiled(set_to_list)(s)
+        self.assertEqual(r1, r2)
+
+    def test_set_refcounting(self):
+        TOI = TupleOf(int)
+        aTup = TOI((1, 2, 3))
+        aTup2 = TOI((1, 2, 3, 4))
+        aTup3 = TOI((1, 2, 3, 4, 5))
+
+        x = Set(TOI)()
+        x.add(aTup2)
+        x.add(aTup)
+        x.add(aTup3)
+
+        @Entrypoint
+        def addItem(s, k):
+            s.add(k)
+
+        @Entrypoint
+        def removeItem(s, k):
+            s.remove(k)
+
+        @Entrypoint
+        def getItem(s, k):
+            return k in s
+
+        self.assertTrue(getItem(x, aTup))
+
+        addItem(x, aTup)
+
+        self.assertTrue(getItem(x, aTup))
+        removeItem(x, aTup2)
+        self.assertFalse(getItem(x, aTup2))
+
+        self.assertEqual(_types.refcount(aTup), 2)
+        self.assertEqual(_types.refcount(aTup2), 1)
+        self.assertEqual(_types.refcount(aTup3), 2)
+
+        x = None
+
+        self.assertEqual(_types.refcount(aTup), 1)
+        self.assertEqual(_types.refcount(aTup2), 1)
+        self.assertEqual(_types.refcount(aTup3), 1)
+
+    def test_set_pop_many(self):
+        @Entrypoint
+        def f(x: Set(str)):
+            keys = ListOf(str)()
+
+            for key in x:
+                keys.append(key)
+
+            for _ in keys:
+                x.pop()
+
+        x = Set(str)()
+
+        for i in range(1000):
+            x.add(str(i))
+        self.assertEqual(len(x), 1000)
+
+        f(x)
+
+        self.assertEqual(len(x), 0)
+
+    def test_set_up_and_down(self):
+        @Entrypoint
+        def f(targets):
+            x = Set(int)()
+
+            for target in targets:
+                for i in range(len(x), target):
+                    assert i not in x
+                    x.add(i)
+                    assert i in x
+                    assert i + 1 not in x
+
+                for i in range(target, len(x)):
+                    assert i in x
+                    x.remove(i)
+                    assert i not in x
+
+                assert len(x) == target
+
+        C = 10
+        for i1 in range(C):
+            for i2 in range(C):
+                for i3 in range(C):
+                    for i4 in range(C):
+                        for i5 in range(C):
+                            f(ListOf(int)([i1, i2, i3, i4, i5]))
+
+    def test_set_fuzz(self):
+        # try adding and removing items repeatedly, in an effort to fill the table up
+        @Entrypoint
+        def f(actions: ListOf(Tuple(bool, int))):
+            x = Set(int)()
+
+            for thing in actions:
+                if thing[0]:
+                    x.add(thing[1])
+                else:
+                    x.discard(thing[1])
+
+        f([(True, 3), (False, 17), (False, 3), (True, 34), (True, 36), (True, 0), (False, 0),
+           (False, 38), (False, 34), (True, 11), (True, 37), (True, 33), (False, 4), (True, 16)])
+
+        for length in range(5, 15):
+            print("Trying length ", length)
+            for trials in range(10000):
+                actions = []
+
+                for i in range(length):
+                    actions.append((numpy.random.uniform() > .5, numpy.random.choice(40)))
+
+                try:
+                    f(actions)
+                except Exception:
+                    print(actions)
+                    raise
+
+    def test_set_with_neg_one(self):
+        # negative one is special because it hashes to -1. Python
+        # treats a -1 as an error code (indicating there was
+        # an exception). We don't do the same thing, so lets make
+        # sure we handle things that hash to -1 correctly
+        s = Set(int)()
+
+        @Entrypoint
+        def set_add(s, x):
+            s.add(x)
+
+        @Entrypoint
+        def set_remove(s, x):
+            s.remove(x)
+
+        @Entrypoint
+        def set_in(x, s):
+            return x in s
+
+        self.assertFalse(set_in(-1, s))
+        set_add(s, -1)
+        self.assertTrue(set_in(-1, s))
+        set_remove(s, -1)
+        self.assertFalse(set_in(-1, s))

--- a/typed_python/compiler/type_wrappers/dict_wrapper.py
+++ b/typed_python/compiler/type_wrappers/dict_wrapper.py
@@ -17,7 +17,8 @@ from typed_python.compiler.typed_expression import TypedExpression
 import typed_python.compiler.type_wrappers.runtime_functions as runtime_functions
 from typed_python.compiler.type_wrappers.bound_method_wrapper import BoundMethodWrapper
 from typed_python.compiler.type_wrappers.wrapper import Wrapper
-from typed_python.compiler.type_wrappers.compilable_builtin import CompilableBuiltin
+from typed_python.compiler.type_wrappers.native_hash import NativeHash, table_add_slot, table_slot_for_key, \
+    table_next_slot, table_remove_key, table_clear, table_contains, table_contains_not
 from typed_python import NoneType, Tuple, PointerTo, Int32, Int64, UInt8
 
 import typed_python.compiler.native_ast as native_ast
@@ -25,190 +26,6 @@ import typed_python.compiler
 
 
 typeWrapper = lambda t: typed_python.compiler.python_object_representation.typedPythonTypeToTypeWrapper(t)
-
-EMPTY = -1
-DELETED = -2
-
-
-class NativeHash(CompilableBuiltin):
-    """A function for directly hashing a typed python value.
-
-    Note that this is not the same as calling 'hash' from compiled code,
-    which will produce different answers from python right now, and which
-    is attempting at some level to mimic python's standard hash functionality.
-
-    That functionality is not used internally to our datastructures (we
-    allow things to hash to -1) so you can't just use 'hash' when implementing
-    wrappers for tp internals.
-    """
-    def __eq__(self, other):
-        return isinstance(other, NativeHash)
-
-    def __hash__(self):
-        return hash("NativeHash")
-
-    def convert_call(self, context, instance, args, kwargs):
-        if len(args) == 1:
-            return args[0].convert_hash()
-
-        return super().convert_call(context, instance, args, kwargs)
-
-
-class CPlusPlusStyleMod(CompilableBuiltin):
-    def __eq__(self, other):
-        return isinstance(other, CPlusPlusStyleMod)
-
-    def __hash__(self):
-        return hash("CPlusPlusStyleMod")
-
-    def convert_call(self, context, instance, args, kwargs):
-        if len(args) == 2 and args[0].expr_type.typeRepresentation == Int32 and args[1].expr_type.typeRepresentation == Int64:
-            return context.pushPod(
-                int,
-                args[0].nonref_expr.cast(native_ast.Int64).mod(args[1].nonref_expr)
-            )
-
-        if len(args) == 2 and args[0].expr_type.typeRepresentation == Int64 and args[1].expr_type.typeRepresentation == Int64:
-            return context.pushPod(
-                int,
-                args[0].nonref_expr.mod(args[1].nonref_expr)
-            )
-
-        return super().convert_call(context, instance, args, kwargs)
-
-
-def dict_add_slot(instance, itemHash, slot):
-    if (instance._hash_table_count * 2 + 1 > instance._hash_table_size or
-            instance._hash_table_empty_slots < (instance._hash_table_size >> 2) + 1):
-        instance._resizeTableUnsafe()
-
-    if itemHash < 0:
-        itemHash = -itemHash
-
-    offset = CPlusPlusStyleMod()(itemHash, instance._hash_table_size)
-
-    while True:
-        if instance._hash_table_slots[offset] == EMPTY or instance._hash_table_slots[offset] == DELETED:
-            if instance._hash_table_slots[offset] == EMPTY:
-                instance._hash_table_empty_slots -= 1
-
-            instance._hash_table_slots[offset] = slot
-            instance._hash_table_hashes[offset] = itemHash
-            instance._items_populated[slot] = 1
-            instance._hash_table_count += 1
-
-            return
-
-        offset += 1
-
-        if offset >= instance._hash_table_size:
-            offset = 0
-
-
-def dict_slot_for_key(instance, itemHash, item):
-    slots = instance._hash_table_slots
-
-    if not slots:
-        return -1
-
-    if itemHash < 0:
-        itemHash = -itemHash
-
-    modFun = CPlusPlusStyleMod()
-
-    offset = modFun(itemHash, instance._hash_table_size)
-
-    assert instance._hash_table_empty_slots > 0
-
-    while True:
-        slotIndex = int((slots + offset).get())
-
-        if slotIndex == EMPTY:
-            return -1
-
-        if slotIndex != DELETED and (instance._hash_table_hashes + offset).get() == itemHash:
-            if instance.getKeyByIndexUnsafe(slotIndex) == item:
-                return slotIndex
-
-        offset += 1
-        if offset >= instance._hash_table_size:
-            offset = 0
-
-    # not necessary, but currently we don't realize that the while loop
-    # never exits, and so we think there's a possibility we return None
-    return 0
-
-
-def dict_next_slot(instance, slotIx):
-    slotIx += 1
-
-    while slotIx < instance._items_reserved:
-        if instance._items_populated[slotIx]:
-            return slotIx
-        slotIx += 1
-
-    return -1
-
-
-def dict_remove_key(instance, item, itemHash):
-    if instance._items_reserved > (instance._hash_table_count + 2) * 4:
-        instance._compressItemTableUnsafe()
-
-    if instance._hash_table_count < instance._hash_table_size >> 3:
-        instance._resizeTableUnsafe()
-
-    slots = instance._hash_table_slots
-
-    if not slots:
-        raise KeyError(item)
-
-    if itemHash < 0:
-        itemHash = -itemHash
-
-    offset = CPlusPlusStyleMod()(itemHash, instance._hash_table_size)
-
-    while True:
-        slotIndex = int((slots + offset).get())
-
-        if slotIndex == EMPTY:
-            raise KeyError(item)
-
-        if slotIndex != DELETED and (instance._hash_table_hashes + offset).get() == itemHash:
-            if instance.getKeyByIndexUnsafe(slotIndex) == item:
-                instance._hash_table_hashes[offset] = -1
-                instance._hash_table_slots[offset] = DELETED
-                instance._hash_table_count -= 1
-                instance._items_populated[slotIndex] = 0
-
-                instance.deleteItemByIndexUnsafe(slotIndex)
-                return
-
-        offset += 1
-        if offset >= instance._hash_table_size:
-            offset = 0
-
-    # not necessary, but currently we don't currently realize that the while loop
-    # never exits, and so we think there's a possibility we return None
-    return 0
-
-
-def dict_clear(instance):
-    slotIx = 0
-
-    while slotIx < instance._items_reserved:
-        if instance._items_populated[slotIx]:
-            instance.deleteItemByIndexUnsafe(slotIx)
-            instance._items_populated[slotIx] = 0
-
-        slotIx += 1
-
-    for i in range(instance._hash_table_size):
-        instance._hash_table_hashes[i] = EMPTY
-        instance._hash_table_slots[i] = -1
-
-    instance._hash_table_count = 0
-    instance._hash_table_empty_slots = instance._hash_table_size
-    instance._top_item_slot = 0
 
 
 def dict_update(instance, other):
@@ -219,13 +36,13 @@ def dict_update(instance, other):
 def dict_delitem(instance, item):
     itemHash = NativeHash()(item)
 
-    dict_remove_key(instance, item, itemHash)
+    table_remove_key(instance, item, itemHash, True)
 
 
 def dict_getitem(instance, item):
     itemHash = NativeHash()(item)
 
-    slot = dict_slot_for_key(instance, itemHash, item)
+    slot = table_slot_for_key(instance, itemHash, item)
 
     if slot == -1:
         raise KeyError(item)
@@ -236,7 +53,7 @@ def dict_getitem(instance, item):
 def dict_get(instance, item, default):
     itemHash = NativeHash()(item)
 
-    slot = dict_slot_for_key(instance, itemHash, item)
+    slot = table_slot_for_key(instance, itemHash, item)
 
     if slot == -1:
         return default
@@ -244,22 +61,14 @@ def dict_get(instance, item, default):
     return instance.getValueByIndexUnsafe(slot)
 
 
-def dict_contains(instance, item):
-    itemHash = NativeHash()(item)
-
-    slot = dict_slot_for_key(instance, itemHash, item)
-
-    return slot != -1
-
-
 def dict_setitem(instance, key, value):
     itemHash = NativeHash()(key)
 
-    slot = dict_slot_for_key(instance, itemHash, key)
+    slot = table_slot_for_key(instance, itemHash, key)
 
     if slot == -1:
         newSlot = instance._allocateNewSlotUnsafe()
-        dict_add_slot(instance, itemHash, newSlot)
+        table_add_slot(instance, itemHash, newSlot)
         instance.initializeKeyByIndexUnsafe(newSlot, key)
         instance.initializeValueByIndexUnsafe(newSlot, value)
     else:
@@ -355,7 +164,7 @@ class DictWrapper(DictWrapperBase):
     def convert_default_initialize(self, context, instance):
         context.pushEffect(
             instance.expr.store(
-                runtime_functions.dict_create.call().cast(self.layoutType)
+                runtime_functions.table_create.call().cast(self.layoutType)
             )
         )
 
@@ -484,7 +293,7 @@ class DictWrapper(DictWrapperBase):
         if len(args) == 0:
             if methodname == "_compressItemTableUnsafe":
                 context.pushEffect(
-                    runtime_functions.dict_compressItemTable.call(
+                    runtime_functions.table_compress.call(
                         instance.nonref_expr.cast(native_ast.VoidPtr),
                         context.constant(self.kvBytecount)
                     )
@@ -493,7 +302,7 @@ class DictWrapper(DictWrapperBase):
 
             if methodname == "_resizeTableUnsafe":
                 context.pushEffect(
-                    runtime_functions.dict_resizeTable.call(
+                    runtime_functions.table_resize.call(
                         instance.nonref_expr.cast(native_ast.VoidPtr)
                     )
                 )
@@ -502,7 +311,7 @@ class DictWrapper(DictWrapperBase):
             if methodname == "_allocateNewSlotUnsafe":
                 return context.pushPod(
                     Int32,
-                    runtime_functions.dict_allocateNewSlot.call(
+                    runtime_functions.table_allocate_new_slot.call(
                         instance.nonref_expr.cast(native_ast.VoidPtr),
                         context.constant(self.kvBytecount)
                     )
@@ -522,7 +331,7 @@ class DictWrapper(DictWrapperBase):
 
         if methodname == "clear":
             if len(args) == 0:
-                return context.call_py_function(dict_clear, (instance,), {})
+                return context.call_py_function(table_clear, (instance,), {})
 
         if methodname == "update":
             if len(args) == 1:
@@ -670,13 +479,13 @@ class DictWrapper(DictWrapperBase):
         return context.pushPod(int, self.convert_len_native(expr))
 
     def convert_bin_op_reverse(self, context, left, op, right, inplace):
-        if op.matches.In:
+        if op.matches.In or op.matches.NotIn:
             right = right.convert_to_type(self.keyType)
             if right is None:
                 return None
 
             return context.call_py_function(
-                dict_contains,
+                table_contains if op.matches.In else table_contains_not,
                 (left, right),
                 {}
             )
@@ -734,7 +543,7 @@ class DictMakeIteratorWrapper(DictWrapperBase):
         if methodname == "__iter__" and not args and not kwargs:
             res = context.push(
                 # self.iteratorType is inherited from our specialized children
-                # who pick whether we're an interator over keys, values, items, etc.
+                # who pick whether we're an iterator over keys, values, items, etc.
                 self.iteratorType,
                 lambda instance:
                     instance.expr.ElementPtrIntegers(0, 0).store(-1)
@@ -785,7 +594,7 @@ class DictIteratorWrapper(Wrapper):
         )
 
     def convert_next(self, context, expr):
-        nextSlotIx = context.call_py_function(dict_next_slot, (self.refAs(context, expr, 1), self.refAs(context, expr, 0)), {})
+        nextSlotIx = context.call_py_function(table_next_slot, (self.refAs(context, expr, 1), self.refAs(context, expr, 0)), {})
 
         if nextSlotIx is None:
             return None, None

--- a/typed_python/compiler/type_wrappers/native_hash.py
+++ b/typed_python/compiler/type_wrappers/native_hash.py
@@ -1,0 +1,223 @@
+#   Copyright 2020 Braxton Mckee
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+from typed_python import Int32, Int64
+from typed_python.compiler.type_wrappers.compilable_builtin import CompilableBuiltin
+import typed_python.compiler.native_ast as native_ast
+
+EMPTY = -1
+DELETED = -2
+
+
+class NativeHash(CompilableBuiltin):
+    """A function for directly hashing a typed python value.
+
+    Note that this is not the same as calling 'hash' from compiled code,
+    which will produce different answers from python right now, and which
+    is attempting at some level to mimic python's standard hash functionality.
+
+    That functionality is not used internally to our datastructures (we
+    allow things to hash to -1) so you can't just use 'hash' when implementing
+    wrappers for tp internals.
+    """
+    def __eq__(self, other):
+        return isinstance(other, NativeHash)
+
+    def __hash__(self):
+        return hash("NativeHash")
+
+    def convert_call(self, context, instance, args, kwargs):
+        if len(args) == 1:
+            return args[0].convert_hash()
+
+        return super().convert_call(context, instance, args, kwargs)
+
+
+class CPlusPlusStyleMod(CompilableBuiltin):
+    def __eq__(self, other):
+        return isinstance(other, CPlusPlusStyleMod)
+
+    def __hash__(self):
+        return hash("CPlusPlusStyleMod")
+
+    def convert_call(self, context, instance, args, kwargs):
+        if len(args) == 2 and args[0].expr_type.typeRepresentation == Int32 and args[1].expr_type.typeRepresentation == Int64:
+            return context.pushPod(
+                int,
+                args[0].nonref_expr.cast(native_ast.Int64).mod(args[1].nonref_expr)
+            )
+
+        if len(args) == 2 and args[0].expr_type.typeRepresentation == Int64 and args[1].expr_type.typeRepresentation == Int64:
+            return context.pushPod(
+                int,
+                args[0].nonref_expr.mod(args[1].nonref_expr)
+            )
+
+        return super().convert_call(context, instance, args, kwargs)
+
+
+def table_add_slot(instance, itemHash, slot):
+    if (instance._hash_table_count * 2 + 1 > instance._hash_table_size or
+            instance._hash_table_empty_slots < (instance._hash_table_size >> 2) + 1):
+        instance._resizeTableUnsafe()
+
+    if itemHash < 0:
+        itemHash = -itemHash
+
+    offset = CPlusPlusStyleMod()(itemHash, instance._hash_table_size)
+
+    while True:
+        if instance._hash_table_slots[offset] == EMPTY or instance._hash_table_slots[offset] == DELETED:
+            if instance._hash_table_slots[offset] == EMPTY:
+                instance._hash_table_empty_slots -= 1
+
+            instance._hash_table_slots[offset] = slot
+            instance._hash_table_hashes[offset] = itemHash
+            instance._items_populated[slot] = 1
+            instance._hash_table_count += 1
+
+            return
+
+        offset += 1
+
+        if offset >= instance._hash_table_size:
+            offset = 0
+
+
+def table_slot_for_key(instance, itemHash, item):
+    slots = instance._hash_table_slots
+
+    if not slots:
+        return -1
+
+    if itemHash < 0:
+        itemHash = -itemHash
+
+    modFun = CPlusPlusStyleMod()
+
+    offset = modFun(itemHash, instance._hash_table_size)
+
+    assert instance._hash_table_empty_slots > 0
+
+    while True:
+        slotIndex = int((slots + offset).get())
+
+        if slotIndex == EMPTY:
+            return -1
+
+        if slotIndex != DELETED and (instance._hash_table_hashes + offset).get() == itemHash:
+            if instance.getKeyByIndexUnsafe(slotIndex) == item:
+                return slotIndex
+
+        offset += 1
+        if offset >= instance._hash_table_size:
+            offset = 0
+
+    # not necessary, but currently we don't realize that the while loop
+    # never exits, and so we think there's a possibility we return None
+    return 0
+
+
+def table_next_slot(instance, slotIx):
+    slotIx += 1
+
+    while slotIx < instance._items_reserved:
+        if instance._items_populated[slotIx]:
+            return slotIx
+        slotIx += 1
+
+    return -1
+
+
+def table_remove_key(instance, item, itemHash, raises):
+    if instance._items_reserved > (instance._hash_table_count + 2) * 4:
+        instance._compressItemTableUnsafe()
+
+    if instance._hash_table_count < instance._hash_table_size >> 3:
+        instance._resizeTableUnsafe()
+
+    slots = instance._hash_table_slots
+
+    if not slots:
+        if raises:
+            raise KeyError(item)
+        else:
+            return 0
+
+    if itemHash < 0:
+        itemHash = -itemHash
+
+    offset = CPlusPlusStyleMod()(itemHash, instance._hash_table_size)
+
+    while True:
+        slotIndex = int((slots + offset).get())
+
+        if slotIndex == EMPTY:
+            if raises:
+                raise KeyError(item)
+            else:
+                return 0
+
+        if slotIndex != DELETED and (instance._hash_table_hashes + offset).get() == itemHash:
+            if instance.getKeyByIndexUnsafe(slotIndex) == item:
+                instance._hash_table_hashes[offset] = -1
+                instance._hash_table_slots[offset] = DELETED
+                instance._hash_table_count -= 1
+                instance._items_populated[slotIndex] = 0
+
+                instance.deleteItemByIndexUnsafe(slotIndex)
+                return
+
+        offset += 1
+        if offset >= instance._hash_table_size:
+            offset = 0
+
+    # not necessary, but currently we don't currently realize that the while loop
+    # never exits, and so we think there's a possibility we return None
+    return 0
+
+
+def table_clear(instance):
+    slotIx = 0
+
+    while slotIx < instance._items_reserved:
+        if instance._items_populated[slotIx]:
+            instance.deleteItemByIndexUnsafe(slotIx)
+            instance._items_populated[slotIx] = 0
+
+        slotIx += 1
+
+    for i in range(instance._hash_table_size):
+        instance._hash_table_hashes[i] = EMPTY
+        instance._hash_table_slots[i] = -1
+
+    instance._hash_table_count = 0
+    instance._hash_table_empty_slots = instance._hash_table_size
+    instance._top_item_slot = 0
+
+
+def table_contains(instance, item):
+    itemHash = NativeHash()(item)
+
+    slot = table_slot_for_key(instance, itemHash, item)
+
+    return slot != -1
+
+
+def table_contains_not(instance, item):
+    itemHash = NativeHash()(item)
+
+    slot = table_slot_for_key(instance, itemHash, item)
+
+    return slot == -1

--- a/typed_python/compiler/type_wrappers/runtime_functions.py
+++ b/typed_python/compiler/type_wrappers/runtime_functions.py
@@ -1,4 +1,4 @@
-#   Copyright 2017-2019 typed_python Authors
+#   Copyright 2017-2020 typed_python Authors
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
@@ -610,25 +610,32 @@ bool_to_string = externalCallTarget(
     Bool
 )
 
-dict_create = externalCallTarget(
-    "nativepython_dict_create",
+table_create = externalCallTarget(
+    "nativepython_tableCreate",
     Void.pointer()
 )
 
-dict_allocateNewSlot = externalCallTarget(
-    "nativepython_dict_allocateNewSlot",
+table_allocate_new_slot = externalCallTarget(
+    "nativepython_tableAllocateNewSlot",
     Int32,
     Void.pointer(), Int64
 )
 
-dict_resizeTable = externalCallTarget(
-    "nativepython_dict_resizeTable",
+table_copy = externalCallTarget(
+    "nativepython_tableCopy",
+    Void.pointer(),
+    Void.pointer(),
+    UInt64
+)
+
+table_resize = externalCallTarget(
+    "nativepython_tableResize",
     Void,
     Void.pointer()
 )
 
-dict_compressItemTable = externalCallTarget(
-    "nativepython_dict_compressItemTable",
+table_compress = externalCallTarget(
+    "nativepython_tableCompress",
     Void,
     Void.pointer(), Int64
 )

--- a/typed_python/compiler/type_wrappers/set_wrapper.py
+++ b/typed_python/compiler/type_wrappers/set_wrapper.py
@@ -1,4 +1,4 @@
-#   Copyright 2018 Braxton Mckee
+#   Copyright 2020 Braxton Mckee
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
@@ -15,13 +15,229 @@
 from typed_python.compiler.type_wrappers.refcounted_wrapper import RefcountedWrapper
 from typed_python.compiler.typed_expression import TypedExpression
 import typed_python.compiler.type_wrappers.runtime_functions as runtime_functions
-from typed_python import NoneType
+from typed_python.compiler.type_wrappers.bound_method_wrapper import BoundMethodWrapper
+from typed_python.compiler.type_wrappers.wrapper import Wrapper
+from typed_python.compiler.type_wrappers.native_hash import NativeHash, table_add_slot, table_slot_for_key, \
+    table_next_slot, table_remove_key, table_clear, table_contains, table_contains_not
+from typed_python import NoneType, PointerTo, Int32, Int64, UInt8
 
 import typed_python.compiler.native_ast as native_ast
 import typed_python.compiler
 
 
 typeWrapper = lambda t: typed_python.compiler.python_object_representation.typedPythonTypeToTypeWrapper(t)
+
+
+def set_add(instance, key):
+    itemHash = NativeHash()(key)
+
+    slot = table_slot_for_key(instance, itemHash, key)
+
+    if slot == -1:
+        newSlot = instance._allocateNewSlotUnsafe()
+        table_add_slot(instance, itemHash, newSlot)
+        instance.initializeKeyByIndexUnsafe(newSlot, key)
+
+
+def set_add_or_remove(instance, key):
+    itemHash = NativeHash()(key)
+
+    slot = table_slot_for_key(instance, itemHash, key)
+
+    if slot == -1:
+        newSlot = instance._allocateNewSlotUnsafe()
+        table_add_slot(instance, itemHash, newSlot)
+        instance.initializeKeyByIndexUnsafe(newSlot, key)
+    else:
+        table_remove_key(instance, key, itemHash, False)
+
+
+def set_remove(instance, key):
+    itemHash = NativeHash()(key)
+
+    table_remove_key(instance, key, itemHash, True)
+
+
+def set_discard(instance, key):
+    itemHash = NativeHash()(key)
+
+    table_remove_key(instance, key, itemHash, False)
+
+
+def set_pop(instance):
+    slotIx = 0
+
+    while slotIx < instance._items_reserved:
+        if instance._items_populated[slotIx]:
+            res = instance.getKeyByIndexUnsafe(slotIx)
+            set_remove(instance, res)
+            return res
+
+        slotIx += 1
+    raise KeyError(instance)
+
+
+# this set_copy has been replaced by more performant code in hash_table_layout
+# def set_copy(instance):
+#     result = type(instance)()
+#     for i in instance:
+#         result.add(i)
+#     return result
+
+
+def set_union(left, right):
+    if len(left) >= len(right):
+        result = left.copy()
+        for i in right:
+            result.add(i)
+    else:
+        result = right.copy()
+        for i in left:
+            result.add(i)
+    return result
+
+
+# alternate way to do set_union; not as performant as above
+def set_union1(left, right):
+    result = type(left)()
+    for i in left:
+        result.add(i)
+    for i in right:
+        result.add(i)
+    return result
+
+
+def set_intersection(left, right):
+    if len(left) > len(right):
+        result = right.copy()
+        for i in right:
+            if i not in left:
+                result.discard(i)
+    else:
+        result = left.copy()
+        for i in left:
+            if i not in right:
+                result.discard(i)
+    return result
+
+
+# alternate way to do set_intersection; not as performant
+def set_intersection1(left, right):
+    result = type(left)()
+    if len(left) > len(right):
+        for i in right:
+            if i in left:
+                result.add(i)
+    else:
+        for i in left:
+            if i in right:
+                result.add(i)
+    return result
+
+
+# alternate way to do set_intersection; primitive loop is not measurably faster than "for" iterator
+def set_intersection2(left, right):
+    result = type(left)()
+    if len(left) > len(right):
+        slotIx = 0
+        while slotIx < right._items_reserved:
+            if right._items_populated[slotIx]:
+                i = right.getKeyByIndexUnsafe(slotIx)
+                if i in left:
+                    result.add(i)
+            slotIx += 1
+    else:
+        slotIx = 0
+        while slotIx < left._items_reserved:
+            if left._items_populated[slotIx]:
+                i = left.getKeyByIndexUnsafe(slotIx)
+                if i in right:
+                    result.add(i)
+            slotIx += 1
+    return result
+
+
+def set_difference(left, right):
+    if len(left) / 4 > len(right):
+        result = left.copy()
+        for i in right:
+            result.discard(i)
+    else:
+        result = type(left)()
+        for i in left:
+            if i not in right:
+                result.add(i)
+    return result
+
+
+def set_symmetric_difference(left, right):
+    if len(left) / 2 > len(right):
+        result = left.copy()
+        for i in right:
+            set_add_or_remove(result, i)
+    elif len(right) / 2 > len(left):
+        result = right.copy()
+        for i in left:
+            set_add_or_remove(result, i)
+    else:
+        result = type(left)()
+        for i in left:
+            if i not in right:
+                result.add(i)
+        for i in right:
+            if i not in left:
+                result.add(i)
+    return result
+
+
+def set_union_multiple(left, *others):
+    result = left
+    for o in others:
+        result |= o
+    return result
+
+
+def set_intersection_multiple(left, *others):
+    result = left
+    for o in others:
+        result &= o
+    return result
+
+
+def set_difference_multiple(left, *others):
+    result = left
+    for o in others:
+        result -= o
+    return result
+
+
+def set_disjoint(left, right):
+    for i in left:
+        if i in right:
+            return False
+    return True
+
+
+def set_subset(left, right):
+    for i in left:
+        if i not in right:
+            return False
+    return True
+
+
+def set_proper_subset(left, right):
+    for i in left:
+        if i not in right:
+            return False
+    return len(left) < len(right)
+
+
+def set_equal(left, right):
+    return len(left) == len(right) and set_subset(left, right)
+
+
+def set_not_equal(left, right):
+    return len(left) != len(right) or not set_subset(right, left)
 
 
 class SetWrapperBase(RefcountedWrapper):
@@ -49,8 +265,8 @@ class SetWrapperBase(RefcountedWrapper):
             ('hash_table_size', native_ast.Int64),
             ('hash_table_count', native_ast.Int64),
             ('hash_table_empty_slots', native_ast.Int64),
-            ('setdefault', native_ast.Int64)
-        ), name="DictWrapper").pointer()
+            ('reserved', native_ast.Int64)  # not used
+        ), name="SetWrapper").pointer()
 
     def on_refcount_zero(self, context, instance):
         assert instance.isReference
@@ -70,8 +286,285 @@ class SetWrapperBase(RefcountedWrapper):
 
 
 class SetWrapper(SetWrapperBase):
-    def __init__(self, dictType):
-        super().__init__(dictType, None)
+    def __init__(self, setType):
+        super().__init__(setType, None)
+
+    def convert_default_initialize(self, context, instance):
+        context.pushEffect(
+            instance.expr.store(
+                runtime_functions.table_create.call().cast(self.layoutType)
+            )
+        )
+
+    def convert_attribute(self, context, expr, attr):
+        if attr in (
+                "getKeyByIndexUnsafe", "deleteItemByIndexUnsafe",
+                "initializeKeyByIndexUnsafe", "_allocateNewSlotUnsafe", "_resizeTableUnsafe",
+                "_compressItemTableUnsafe",
+                "add", "remove", "discard", "pop", "clear", "copy", "log",
+                "union", "intersection", "difference", "symmetric_difference",
+                "issubset", "issuperset", "isdisjoint"):
+            return expr.changeType(BoundMethodWrapper.Make(self, attr))
+
+        if attr == '_items':
+            return context.pushPod(
+                PointerTo(UInt8),
+                expr.nonref_expr.ElementPtrIntegers(0, 1).load()
+            )
+
+        if attr == '_items_populated':
+            return context.pushPod(
+                PointerTo(UInt8),
+                expr.nonref_expr.ElementPtrIntegers(0, 2).load()
+            )
+
+        if attr == '_items_reserved':
+            return context.pushPod(
+                Int64,
+                expr.nonref_expr.ElementPtrIntegers(0, 3).load()
+            )
+
+        if attr == '_top_item_slot':
+            return context.pushPod(
+                Int64,
+                expr.nonref_expr.ElementPtrIntegers(0, 4).load()
+            )
+
+        if attr == '_hash_table_slots':
+            return context.pushPod(
+                PointerTo(Int32),
+                expr.nonref_expr.ElementPtrIntegers(0, 5).load()
+            )
+
+        if attr == '_hash_table_hashes':
+            return context.pushPod(
+                PointerTo(Int32),
+                expr.nonref_expr.ElementPtrIntegers(0, 6).load()
+            )
+
+        if attr == '_hash_table_size':
+            return context.pushPod(
+                int,
+                expr.nonref_expr.ElementPtrIntegers(0, 7).load()
+            )
+
+        if attr == '_hash_table_count':
+            return context.pushPod(
+                int,
+                expr.nonref_expr.ElementPtrIntegers(0, 8).load()
+            )
+
+        if attr == '_hash_table_empty_slots':
+            return context.pushPod(
+                int,
+                expr.nonref_expr.ElementPtrIntegers(0, 9).load()
+            )
+
+        return super().convert_attribute(context, expr, attr)
+
+    def convert_set_attribute(self, context, instance, attr, expr):
+        if attr == '_items_reserved':
+            val = expr.convert_to_type(int)
+            if val is None:
+                return None
+            context.pushEffect(
+                instance.nonref_expr.ElementPtrIntegers(0, 3).store(val.nonref_expr)
+            )
+
+            return context.pushVoid()
+
+        if attr == '_top_item_slot':
+            val = expr.convert_to_type(int)
+            if val is None:
+                return None
+            context.pushEffect(
+                instance.nonref_expr.ElementPtrIntegers(0, 4).store(val.nonref_expr)
+            )
+
+            return context.pushVoid()
+
+        if attr == '_hash_table_size':
+            val = expr.convert_to_type(int)
+            if val is None:
+                return None
+            context.pushEffect(
+                instance.nonref_expr.ElementPtrIntegers(0, 7).store(val.nonref_expr)
+            )
+
+            return context.pushVoid()
+
+        if attr == '_hash_table_count':
+            val = expr.convert_to_type(int)
+            if val is None:
+                return None
+            context.pushEffect(
+                instance.nonref_expr.ElementPtrIntegers(0, 8).store(val.nonref_expr)
+            )
+
+            return context.pushVoid()
+
+        if attr == '_hash_table_empty_slots':
+            val = expr.convert_to_type(int)
+            if val is None:
+                return None
+            context.pushEffect(
+                instance.nonref_expr.ElementPtrIntegers(0, 9).store(val.nonref_expr)
+            )
+
+            return context.pushVoid()
+
+        return super().convert_set_attribute(context, instance, attr, expr)
+
+    def convert_method_call(self, context, instance, methodname, args, kwargs):
+        if kwargs:
+            return super().convert_method_call(context, instance, methodname, args, kwargs)
+
+        if methodname == "__iter__" and not args and not kwargs:
+            res = context.push(
+                SetKeysIteratorWrapper(self.setType),
+                lambda instance:
+                instance.expr.ElementPtrIntegers(0, 0).store(-1)
+                # we initialize the set pointer below, so technically
+                # if that were to throw, this would leak a bad value.
+            )
+
+            context.pushReference(
+                self,
+                res.expr.ElementPtrIntegers(0, 1)
+            ).convert_copy_initialize(instance)
+
+            return res
+
+        if methodname == 'union':
+            return context.call_py_function(set_union_multiple, (instance, *args), {})
+
+        if methodname == 'intersection':
+            return context.call_py_function(set_intersection_multiple, (instance, *args), {})
+
+        if methodname == 'difference':
+            return context.call_py_function(set_difference_multiple, (instance, *args), {})
+
+        if methodname == 'symmetric_difference':
+            if len(args) != 1:
+                return context.pushException(TypeError, f"symmetric_difference() takes exactly one argument ({len(args)} given)")
+            return context.call_py_function(set_symmetric_difference, (instance, args[0]), {})
+
+        if len(args) == 0:
+            if methodname == "pop":
+                return context.call_py_function(set_pop, (instance,), {})
+            if methodname == "clear":
+                return context.call_py_function(table_clear, (instance,), {})
+            if methodname == "_compressItemTableUnsafe":
+                context.pushEffect(
+                    runtime_functions.table_compress.call(
+                        instance.nonref_expr.cast(native_ast.VoidPtr),
+                        context.constant(self.keyBytecount)
+                    )
+                )
+                return context.pushVoid()
+
+            if methodname == "_resizeTableUnsafe":
+                context.pushEffect(
+                    runtime_functions.table_resize.call(
+                        instance.nonref_expr.cast(native_ast.VoidPtr)
+                    )
+                )
+                return context.pushVoid()
+
+            if methodname == "copy":
+                # alternate way, but less performant:
+                # return context.call_py_function(set_copy, (instance,), {})
+
+                tp = context.getTypePointer(self.setType)
+                if tp:
+                    return context.push(
+                        typeWrapper(self.setType),
+                        lambda ref: ref.expr.store(
+                            runtime_functions.table_copy.call(
+                                instance.nonref_expr.cast(native_ast.VoidPtr),
+                                tp
+                            ).cast(self.layoutType)
+                        )
+                    )
+
+            if methodname == "_allocateNewSlotUnsafe":
+                return context.pushPod(
+                    Int32,
+                    runtime_functions.table_allocate_new_slot.call(
+                        instance.nonref_expr.cast(native_ast.VoidPtr),
+                        context.constant(self.keyBytecount)
+                    )
+                )
+
+        if len(args) == 1:
+            if methodname == "isdisjoint":
+                return context.call_py_function(set_disjoint, (instance, args[0]), {})
+            if methodname == "issubset":
+                return context.call_py_function(set_subset, (instance, args[0]), {})
+            if methodname == "issuperset":
+                return context.call_py_function(set_subset, (args[0], instance), {})
+
+            if methodname == "add":
+                key = args[0].convert_to_type(self.keyType, explicit=False)
+                if key is None:
+                    return None
+
+                return context.call_py_function(set_add, (instance, key), {})
+
+            if methodname == "remove":
+                key = args[0].convert_to_type(self.keyType, explicit=False)
+                if key is None:
+                    return None
+
+                return context.call_py_function(set_remove, (instance, key), {})
+
+            if methodname == "discard":
+                key = args[0].convert_to_type(self.keyType, explicit=False)
+                if key is None:
+                    return None
+
+                return context.call_py_function(set_discard, (instance, key), {})
+
+            if methodname in ("getKeyByIndexUnsafe", "deleteItemByIndexUnsafe"):
+                index = args[0].convert_to_type(int)
+                if index is None:
+                    return None
+
+                key = context.pushReference(
+                    self.keyType,
+                    instance.nonref_expr.ElementPtrIntegers(0, 1).load().cast(
+                        self.keyType.getNativeLayoutType().pointer()
+                    ).elemPtr(index.toInt64().nonref_expr)
+                )
+
+                if methodname == "getKeyByIndexUnsafe":
+                    return key
+                elif methodname == "deleteItemByIndexUnsafe":
+                    key.convert_destroy()
+                    return context.pushVoid()
+
+        if len(args) == 2:
+            if methodname == "initializeKeyByIndexUnsafe":
+                index = args[0].convert_to_type(int)
+                if index is None:
+                    return None
+
+            key = args[1].convert_to_type(self.keyType)
+            if key is None:
+                return None
+
+            item = context.pushReference(
+                self.keyType,
+                instance.nonref_expr.ElementPtrIntegers(0, 1).load().cast(
+                    self.keyType.getNativeLayoutType().pointer()
+                ).elemPtr(index.toInt64().nonref_expr)
+            )
+
+            item.convert_copy_initialize(key)
+
+            return context.pushVoid()
+
+        return super().convert_method_call(context, instance, methodname, args, kwargs)
 
     def convert_len_native(self, expr):
         if isinstance(expr, TypedExpression):
@@ -94,12 +587,51 @@ class SetWrapper(SetWrapperBase):
     def convert_len(self, context, expr):
         return context.pushPod(int, self.convert_len_native(expr))
 
+    def convert_bin_op(self, context, left, op, right, inplace):
+        if right.expr_type == left.expr_type:
+            if op.matches.BitOr:
+                return context.call_py_function(set_union, (left, right), {})
+            if op.matches.BitAnd:
+                return context.call_py_function(set_intersection, (left, right), {})
+            if op.matches.Sub:
+                return context.call_py_function(set_difference, (left, right), {})
+            if op.matches.BitXor:
+                return context.call_py_function(set_symmetric_difference, (left, right), {})
+            if op.matches.Eq:
+                return context.call_py_function(set_equal, (left, right), {})
+            if op.matches.NotEq:
+                return context.call_py_function(set_not_equal, (left, right), {})
+            if op.matches.Lt:
+                return context.call_py_function(set_proper_subset, (left, right), {})
+            if op.matches.LtE:
+                return context.call_py_function(set_subset, (left, right), {})
+            if op.matches.Gt:
+                return context.call_py_function(set_proper_subset, (right, left), {})
+            if op.matches.GtE:
+                return context.call_py_function(set_subset, (right, left), {})
+
+        return super().convert_bin_op(context, left, op, right, inplace)
+
+    def convert_bin_op_reverse(self, context, right, op, left, inplace):
+        if op.matches.In or op.matches.NotIn:
+            left = left.convert_to_type(self.keyType, False)
+            if left is None:
+                return None
+
+            return context.call_py_function(
+                table_contains if op.matches.In else table_contains_not,
+                (right, left),
+                {}
+            )
+
+        return super().convert_bin_op_reverse(context, right, op, left, inplace)
+
     def convert_getkey_by_index_unsafe(self, context, expr, item):
         return context.pushReference(
             self.keyType,
             expr.nonref_expr.ElementPtrIntegers(0, 1)
             .elemPtr(item.nonref_expr.mul(native_ast.const_int_expr(self.keyBytecount)))
-            .cast(self.keyType.getNativeLayoutType().pointer())
+            .cast(self.keyType.getNativeLayoutType())
         )
 
     def generateNativeDestructorFunction(self, context, out, inst):
@@ -116,5 +648,119 @@ class SetWrapper(SetWrapperBase):
             runtime_functions.free.call(inst.nonref_expr.cast(native_ast.UInt8Ptr))
         )
 
+    def convert_type_call(self, context, typeInst, args, kwargs):
+        if len(args) == 0 and not kwargs:
+            return context.push(self, lambda x: x.convert_default_initialize())
+
+        if len(args) == 1 and not kwargs:
+            return args[0].convert_to_type(self, True)
+
+        return super().convert_type_call(context, typeInst, args, kwargs)
+
     def convert_bool_cast(self, context, expr):
         return context.pushPod(bool, self.convert_len_native(expr.nonref_expr).neq(0))
+
+
+class SetMakeIteratorWrapper(SetWrapperBase):
+    def convert_method_call(self, context, expr, methodname, args, kwargs):
+        if methodname == "__iter__" and not args and not kwargs:
+            res = context.push(
+                # self.iteratorType is inherited from our specialized children
+                # who pick whether we're an iterator over keys, values, items, etc.
+                self.iteratorType,
+                lambda instance:
+                    instance.expr.ElementPtrIntegers(0, 0).store(-1)
+            )
+
+            context.pushReference(
+                self,
+                res.expr.ElementPtrIntegers(0, 1)
+            ).convert_copy_initialize(expr)
+
+            return res
+
+        return super().convert_method_call(context, expr, methodname, args, kwargs)
+
+
+class SetKeysWrapper(SetMakeIteratorWrapper):
+    def __init__(self, setType):
+        super().__init__(setType, "keys")
+        self.iteratorType = SetKeysIteratorWrapper(setType)
+
+
+class SetIteratorWrapper(Wrapper):
+    is_pod = False
+    is_empty = False
+    is_pass_by_ref = True
+
+    def __init__(self, setType, iteratorType):
+        self.setType = setType
+        self.iteratorType = iteratorType
+        super().__init__((setType, "iterator", iteratorType))
+
+    def getNativeLayoutType(self):
+        return native_ast.Type.Struct(
+            element_types=(("pos", native_ast.Int64), ("set", SetWrapper(self.setType).getNativeLayoutType())),
+            name="const_set_iterator"
+        )
+
+    def convert_next(self, context, expr):
+        nextSlotIx = context.call_py_function(table_next_slot, (self.refAs(context, expr, 1), self.refAs(context, expr, 0)), {})
+
+        if nextSlotIx is None:
+            return None, None
+
+        context.pushEffect(
+            expr.expr.ElementPtrIntegers(0, 0).store(
+                nextSlotIx.nonref_expr
+            )
+        )
+        canContinue = context.pushPod(
+            bool,
+            nextSlotIx.nonref_expr.gte(0)
+        )
+
+        nextIx = context.pushReference(int, expr.expr.ElementPtrIntegers(0, 0))
+
+        return self.iteratedItemForReference(context, expr, nextIx), canContinue
+
+    def refAs(self, context, expr, which):
+        assert expr.expr_type == self
+
+        if which == 0:
+            return context.pushReference(int, expr.expr.ElementPtrIntegers(0, 0))
+
+        if which == 1:
+            return context.pushReference(
+                self.setType,
+                expr.expr
+                    .ElementPtrIntegers(0, 1)
+                    .cast(SetWrapper(self.setType).getNativeLayoutType().pointer())
+            )
+
+    def convert_assign(self, context, expr, other):
+        assert expr.isReference
+
+        for i in range(2):
+            self.refAs(context, expr, i).convert_assign(self.refAs(context, other, i))
+
+    def convert_copy_initialize(self, context, expr, other):
+        for i in range(2):
+            self.refAs(context, expr, i).convert_copy_initialize(self.refAs(context, other, i))
+
+    def convert_destroy(self, context, expr):
+        self.refAs(context, expr, 1).convert_destroy()
+
+
+class SetKeysIteratorWrapper(SetIteratorWrapper):
+    def __init__(self, setType):
+        super().__init__(setType, "keys")
+
+    def iteratedItemForReference(self, context, expr, ixExpr):
+        return SetWrapper(self.setType).convert_method_call(
+            context,
+            self.refAs(context, expr, 1),
+            "getKeyByIndexUnsafe",
+            (ixExpr,),
+            {}
+        )


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Motivation and Context
The Set type was missing some functionality and couldn't be compiled.

## Approach
Rearranged some of the code for Dict compilation to share with Set.
Set and Dict share the same layout (native hash table).

## How Has This Been Tested?
Tried to duplicate applicable tests from Dict, and added new tests for Set operations.
Compiled Set operations have reasonable performance, except for intersection.



## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.