### PR TITLE
Compile certain operations on OneOf types.  Refs #316.

### DIFF
--- a/typed_python/compiler/tests/one_of_compilation_test.py
+++ b/typed_python/compiler/tests/one_of_compilation_test.py
@@ -63,7 +63,7 @@ class ClassB(Class, Final):
         return self.x - y
 
 
-class TestOneOfOfCompilation(unittest.TestCase):
+class TestOneOfCompilation(unittest.TestCase):
     def test_one_of_basic(self):
         @Compiled
         def f(x: OneOf(int, float)) -> OneOf(int, float):
@@ -331,3 +331,43 @@ class TestOneOfOfCompilation(unittest.TestCase):
 
         self.assertEqual(f(1), "1")
         self.assertEqual(f(2), 2.0)
+
+    def test_operations_on_oneof_values(self):
+        @Entrypoint
+        def oneof_concat(x: OneOf('A', 'B')):
+            return x + x
+
+        @Entrypoint
+        def oneof_getitem(x: OneOf('AB', 'CD'), i: int):
+            return x[i]
+
+        @Entrypoint
+        def oneof_ord(x: OneOf('A', 'B')):
+            return ord(x[0])
+
+        @Entrypoint
+        def oneof_isalpha(x: OneOf('A', '1')):
+            return x.isalpha()
+
+        @Entrypoint
+        def oneof_abs(x: OneOf(123.4, -234.5)):
+            return abs(x)
+
+        @Entrypoint
+        def oneof_not(x: OneOf(0, 1)):
+            return not x
+
+        self.assertEqual(oneof_concat('A'), 'AA')
+        self.assertEqual(oneof_concat('B'), 'BB')
+        self.assertEqual(oneof_getitem('AB', 0), 'A')
+        self.assertEqual(oneof_getitem('AB', 1), 'B')
+        self.assertEqual(oneof_getitem('CD', 0), 'C')
+        self.assertEqual(oneof_getitem('CD', 1), 'D')
+        self.assertEqual(oneof_ord('A'), 65)
+        self.assertEqual(oneof_ord('B'), 66)
+        self.assertEqual(oneof_isalpha('A'), True)
+        self.assertEqual(oneof_isalpha('1'), False)
+        self.assertEqual(oneof_abs(123.4), 123.4)
+        self.assertEqual(oneof_abs(-234.5), 234.5)
+        self.assertEqual(oneof_not(0), True)
+        self.assertEqual(oneof_not(1), False)

--- a/typed_python/compiler/type_wrappers/arithmetic_wrapper.py
+++ b/typed_python/compiler/type_wrappers/arithmetic_wrapper.py
@@ -301,7 +301,7 @@ class IntWrapper(ArithmeticTypeWrapper):
 
     def convert_unary_op(self, context, left, op):
         if op.matches.Not:
-            return context.pushPod(self, left.nonref_expr.logical_not())
+            return context.pushPod(bool, left.nonref_expr.eq(self.getNativeLayoutType().zero()))
         if op.matches.Invert:
             return context.pushPod(self, left.nonref_expr.bitwise_not())
         if op.matches.USub:

--- a/typed_python/compiler/type_wrappers/one_of_wrapper.py
+++ b/typed_python/compiler/type_wrappers/one_of_wrapper.py
@@ -163,6 +163,30 @@ class OneOfWrapper(Wrapper):
         # just unwrap us
         return self.unwrap(context, expr, lambda realInstance: realInstance.convert_getitem(index))
 
+    def convert_abs(self, context, expr):
+        return context.expressionAsFunctionCall(
+            "oneof_abs",
+            (expr,),
+            lambda expr: self.unwrap(
+                expr.context,
+                expr,
+                lambda exprUnwrapped: exprUnwrapped.convert_abs()
+            ),
+            ("oneof", self, "abs")
+        )
+
+    def convert_unary_op(self, context, left, op):
+        return context.expressionAsFunctionCall(
+            "oneof_unaryop",
+            (left,),
+            lambda left: self.unwrap(
+                left.context,
+                left,
+                lambda leftUnwrapped: leftUnwrapped.convert_unary_op(op)
+            ),
+            ("oneof", self, "unaryop", op)
+        )
+
     def convert_bin_op(self, context, left, op, right, inplace):
         return context.expressionAsFunctionCall(
             "oneof_binop",

--- a/typed_python/compiler/type_wrappers/value_wrapper.py
+++ b/typed_python/compiler/type_wrappers/value_wrapper.py
@@ -64,9 +64,21 @@ class ValueWrapper(Wrapper):
     def convert_destroy(self, context, instance):
         pass
 
+    def convert_unary_op(self, context, left, op):
+        return context.constant(self.typeRepresentation.Value).convert_unary_op(op)
+
     def convert_bin_op(self, context, left, op, right, inplace):
         """Apply a binary operator to a Value and something else."""
         return context.constant(self.typeRepresentation.Value).convert_bin_op(op, right)
 
     def convert_bin_op_reverse(self, context, left, op, right, inplace):
         return right.convert_bin_op(op, context.constant(self.typeRepresentation.Value))
+
+    def convert_getitem(self, context, expr, item):
+        return context.constant(self.typeRepresentation.Value).convert_getitem(item)
+
+    def convert_attribute(self, context, instance, attribute):
+        return context.constant(self.typeRepresentation.Value).convert_attribute(attribute)
+
+    def convert_abs(self, context, expr):
+        return context.constant(self.typeRepresentation.Value).convert_abs()


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->

## Motivation and Context
Motivating issue described in #316: ord(x[0]) was not compilable when x is a OneOf type of several constant string values.  
<!-- Why is this change required? -->
<!-- What problem does it solve? -->
<!--  If it fixes an open issue, please link to the issue here.-->

## Approach
Determined that the getitem (subscript) conversion was missing from the Value wrapper, as well as conversions for attribute access, abs, and unary operators.   Support for unwrapping and applying these operations needed to be added to the OneOf wrapper.

Incidentally, fixed compilation of logical not on integer types.
<!-- Describe your changes in reasonable detail -->

## How Has This Been Tested?
Test cases added to one_of_compilation_test.py.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.