### PR TITLE
Fix Set initialization from ListOf or TupleOf.  Refs #332.

### DIFF
--- a/typed_python/PySetInstance.cpp
+++ b/typed_python/PySetInstance.cpp
@@ -989,7 +989,11 @@ void PySetInstance::copyConstructFromPythonInstanceConcrete(SetType* setType, in
                 setIsInitialized = true;
 
                 for (long k = 0; k < tupType->count(argDataPtr); k++) {
-                    setType->insertKey(tgt, tupType->eltPtr(argDataPtr, k));
+                    instance_ptr data = tupType->eltPtr(argDataPtr, k);
+                    instance_ptr found = setType->lookupKey(tgt, data);
+                    if (!found) {
+                        setType->insertKey(tgt, data);
+                    }
                 }
 
                 return;
@@ -1004,7 +1008,11 @@ void PySetInstance::copyConstructFromPythonInstanceConcrete(SetType* setType, in
                 setIsInitialized = true;
 
                 for (long k = 0; k < listType->count(argDataPtr); k++) {
-                    setType->insertKey(tgt, listType->eltPtr(argDataPtr, k));
+                    instance_ptr data = listType->eltPtr(argDataPtr, k);
+                    instance_ptr found = setType->lookupKey(tgt, data);
+                    if (!found) {
+                         setType->insertKey(tgt, data);
+                    }
                 }
 
                 return;

--- a/typed_python/compiler/tests/set_compilation_test.py
+++ b/typed_python/compiler/tests/set_compilation_test.py
@@ -22,6 +22,7 @@ import typed_python._types as _types
 import time
 import numpy
 import unittest
+import pytest
 
 
 class TestSetCompilation(unittest.TestCase):
@@ -789,3 +790,14 @@ class TestSetCompilation(unittest.TestCase):
         set_update(s1, s2)
         set_intersection_update(s1, s1)
         set_difference_update(s1, [9, 11])
+
+    @pytest.mark.skip(reason="not addressed yet")
+    def test_compiled_set_constructors(self):
+        @Entrypoint
+        def f(x):
+            return Set(int)(x)
+
+        r1 = f(ListOf(int)([1, 1]))
+        self.assertEqual(len(r1), 1)
+        r2 = f(TupleOf(int)([1, 1]))
+        self.assertEqual(len(r2), 1)

--- a/typed_python/types_test.py
+++ b/typed_python/types_test.py
@@ -2968,6 +2968,13 @@ class NativeTypesTests(unittest.TestCase):
         self.assertEqual(s1, Set(str)(word1))
         self.assertEqual(type(i), Set(str))
 
+    def test_set_listof_tupleof_constructors(self):
+        s1 = Set(int)(ListOf(int)([1, 1]))
+        self.assertEqual(len(s1), 1)
+
+        s2 = Set(int)(TupleOf(int)((1, 1)))
+        self.assertEqual(len(s2), 1)
+
     def test_list_of_tuples_transpose(self):
         listOfTuples = ListOf(NamedTuple(x=int, y=str, z=bool))()
         listOfTuples.append(dict(x=1, y="hi", z=False))


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Motivation and Context
When a Set type was initialized with a ListOf or TupleOf type, each element was inserted, without checking for duplicates.  So the constructed Set was invalid.

## Approach
Changed ListOf and TupleOf initialization for a Set instance to match initialization from an iterable.

## How Has This Been Tested?
Check len after initializing with duplicate elements.


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.