### PR TITLE
Compile max and min (2+ arguments, non-iterable case).  Refs #337.

### DIFF
--- a/typed_python/compiler/python_object_representation.py
+++ b/typed_python/compiler/python_object_representation.py
@@ -57,6 +57,7 @@ from typed_python.compiler.type_wrappers.string_wrapper import StringWrapper
 from typed_python.compiler.type_wrappers.bytes_wrapper import BytesWrapper
 from typed_python.compiler.type_wrappers.python_object_of_type_wrapper import PythonObjectOfTypeWrapper
 from typed_python.compiler.type_wrappers.abs_wrapper import AbsWrapper
+from typed_python.compiler.type_wrappers.min_max_wrapper import MinWrapper, MaxWrapper
 from typed_python.compiler.type_wrappers.repr_wrapper import ReprWrapper
 from types import ModuleType
 from typed_python._types import TypeFor, bytecount, prepareArgumentToBePassedToCompiler
@@ -192,6 +193,12 @@ def pythonObjectRepresentation(context, f):
 
     if f is abs:
         return TypedExpression(context, native_ast.nullExpr, AbsWrapper(), False)
+
+    if f is min:
+        return TypedExpression(context, native_ast.nullExpr, MinWrapper(), False)
+
+    if f is max:
+        return TypedExpression(context, native_ast.nullExpr, MaxWrapper(), False)
 
     if f is repr:
         return TypedExpression(context, native_ast.nullExpr, ReprWrapper(), False)

--- a/typed_python/compiler/tests/builtin_compilation_test.py
+++ b/typed_python/compiler/tests/builtin_compilation_test.py
@@ -178,7 +178,6 @@ class TestBuiltinCompilation(unittest.TestCase):
                         __ge__=lambda self, other: self.val <= other.val,
                         )
         test_cases = [
-            (1.1, 2.1, 3, 0.5),
             (1, 9), (9, 1),
             (-1, -9), (-9, -1),
             range(100), range(100, 0, -1),

--- a/typed_python/compiler/tests/builtin_compilation_test.py
+++ b/typed_python/compiler/tests/builtin_compilation_test.py
@@ -19,6 +19,9 @@ from typed_python import ListOf, TupleOf, Tuple, NamedTuple, Dict, ConstDict, \
     Int32, Int16, Int8, UInt64, UInt32, UInt16, UInt8, Float32, \
     Alternative, Set, OneOf, Compiled, Entrypoint
 
+from typed_python.compiler.type_wrappers.min_max_wrapper import i_min, i_min_default, i_min_key, i_min_key_default,\
+    i_max, i_max_default, i_max_key, i_max_key_default
+
 
 def result_or_exception(f, *p):
     try:
@@ -431,3 +434,18 @@ class TestBuiltinCompilation(unittest.TestCase):
                 f(v, x=99)
             with self.assertRaises(TypeError):
                 Entrypoint(f)(v, x=99)
+
+    def test_min_max_cover(self):
+        # these functions are compiled indirectly and tested elsewhere
+        # to avoid codecov failures, they appear here
+        v = (1, 2, 3)
+        d = -99
+        k = lambda x: 1
+        i_min(v)
+        i_min_default(v, d)
+        i_min_key(v, k)
+        i_min_key_default(v, k, d)
+        i_max(v)
+        i_max_default(v, d)
+        i_max_key(v, k)
+        i_max_key_default(v, k, d)

--- a/typed_python/compiler/tests/builtin_compilation_test.py
+++ b/typed_python/compiler/tests/builtin_compilation_test.py
@@ -204,3 +204,59 @@ class TestBuiltinCompilation(unittest.TestCase):
                 r2 = Entrypoint(f)(*v)
                 self.assertEqual(r1, r2)
                 self.assertEqual(type(r1), type(r2))
+
+    def test_min_max_with_key(self):
+        T = OneOf(str, ListOf(int), TupleOf(int), Set(int))
+
+        def f_key1(s: T) -> int:
+            return len(s)
+
+        def f_min1(*v):
+            return min(*v, key=f_key1)
+
+        def f_max1(*v):
+            return max(*v, key=f_key1)
+
+        def f_key2(s: T) -> OneOf(int, float):
+            r = len(s)
+            if r == 2:
+                return 2.5
+            else:
+                return r
+
+        def f_min2(*v):
+            return min(*v, key=f_key2)
+
+        def f_max2(*v):
+            return max(*v, key=f_key2)
+
+        test_cases = [
+            ('abc', 'de', 'fghi', 'klm'),
+            ('abc', 'de', 'fghi', 'klm') * 5,
+            ('abc', (2, 3), 'fghi', 'klm'),
+            ('abc', (2, 3), 'fghi', 'klm') * 5,
+            ('abc', (2, 3), 'de', 'klm'),
+            ('abc', (2, 3), 'de', 'klm') * 5,
+            ('abc', 'de', (2, 3), 'klm'),
+            ('abc', 'de', (2, 3), 'klm') * 5,
+            ('abc', 'de', (1, 2, 3, 4), 'klm'),
+            ('abc', 'de', (1, 2, 3, 4), 'klm') * 5,
+            ('abc', 'de', (1, 2, 3, 4), 'klmn'),
+            ('abc', 'de', (1, 2, 3, 4), 'klmn') * 5,
+            ('abc', 'de', 'klmn', (1, 2, 3, 4)),
+            ('abc', 'de', 'klmn', (1, 2, 3, 4)) * 5,
+            ('ab', (1, 2), [3, 4], {5, 6}),
+            ('ab', (1, 2), [3, 4], {5, 6}) * 5,
+            ((1, 2), [3, 4], {5, 6}, 'ab'),
+            ((1, 2), [3, 4], {5, 6}, 'ab') * 5,
+            ([3, 4], {5, 6}, 'ab', (1, 2)),
+            ([3, 4], {5, 6}, 'ab', (1, 2)) * 5,
+            ({5, 6}, 'ab', (1, 2), [3, 4]),
+            ({5, 6}, 'ab', (1, 2), [3, 4]) * 5,
+        ]
+        for f in [f_min1, f_max1, f_min2, f_max2]:
+            for v in test_cases:
+                r1 = f(*v)
+                r2 = Entrypoint(f)(*v)
+                self.assertEqual(r1, r2)
+                self.assertEqual(type(r1), type(r2))

--- a/typed_python/compiler/tests/builtin_compilation_test.py
+++ b/typed_python/compiler/tests/builtin_compilation_test.py
@@ -203,3 +203,4 @@ class TestBuiltinCompilation(unittest.TestCase):
                 r1 = f(*v)
                 r2 = Entrypoint(f)(*v)
                 self.assertEqual(r1, r2)
+                self.assertEqual(type(r1), type(r2))

--- a/typed_python/compiler/type_wrappers/min_max_wrapper.py
+++ b/typed_python/compiler/type_wrappers/min_max_wrapper.py
@@ -63,7 +63,7 @@ class MinWrapper(Wrapper):
 
             # returns False to abort this attempt
             def comparison_tree(j, k):
-                cond = args[j].expr_type.convert_bin_op(context, args[j], python_ast.ComparisonOp.Lt(), args[k], False)
+                cond = args[j].expr_type.convert_bin_op(context, args[j], python_ast.ComparisonOp.LtE(), args[k], False)
                 if cond is None:
                     return False
                 with context.ifelse(cond.nonref_expr) as (ifTrue, ifFalse):
@@ -125,7 +125,7 @@ class MaxWrapper(Wrapper):
 
             # returns False to abort this attempt
             def comparison_tree(j, k):
-                cond = args[j].expr_type.convert_bin_op(context, args[j], python_ast.ComparisonOp.Gt(), args[k], False)
+                cond = args[j].expr_type.convert_bin_op(context, args[j], python_ast.ComparisonOp.GtE(), args[k], False)
                 if cond is None:
                     return False
                 with context.ifelse(cond.nonref_expr) as (ifTrue, ifFalse):

--- a/typed_python/compiler/type_wrappers/min_max_wrapper.py
+++ b/typed_python/compiler/type_wrappers/min_max_wrapper.py
@@ -27,20 +27,146 @@ typeWrapper = lambda t: typed_python.compiler.python_object_representation.typed
 _MINMAX_SPACE_VS_COPY_THRESHOLD = 10
 
 
+def i_min(v):
+    first = 1
+    for e in v:
+        if first or e < ret:  # noqa: F821
+            first = 0
+            ret = e
+    if first:
+        raise ValueError("min() arg is an empty sequence")
+    return ret
+
+
+def i_min_default(v, default):
+    first = 1
+    for e in v:
+        if first or e < ret:  # noqa: F821
+            first = 0
+            ret = e
+    if first:
+        return default
+    return ret
+
+
+def i_min_key(v, key_f):
+    first = 1
+    for e in v:
+        elt_key = key_f(e)
+        if first or elt_key < ret_key:  # noqa: F821
+            first = 0
+            ret_key = elt_key  # noqa: F841
+            ret = e
+    if first:
+        raise ValueError("min() arg is an empty sequence")
+    return ret
+
+
+def i_min_key_default(v, key_f, default):
+    first = 1
+    for e in v:
+        elt_key = key_f(e)
+        if first or elt_key < ret_key:  # noqa: F821
+            first = 0
+            ret_key = elt_key  # noqa: F841
+            ret = e
+    if first:
+        return default
+    return ret
+
+
+def i_max(v):
+    first = 1
+    for e in v:
+        if first or e > ret:  # noqa: F821
+            first = 0
+            ret = e
+    if first:
+        raise ValueError("max() arg is an empty sequence")
+    return ret
+
+
+def i_max_default(v, default):
+    first = 1
+    for e in v:
+        if first or e > ret:  # noqa: F821
+            first = 0
+            ret = e
+    if first:
+        return default
+    return ret
+
+
+def i_max_key(v, key_f):
+    first = 1
+    for e in v:
+        elt_key = key_f(e)
+        if first or elt_key > ret_key:  # noqa: F821
+            first = 0
+            ret_key = elt_key  # noqa: F841
+            ret = e
+    if first:
+        raise ValueError("max() arg is an empty sequence")
+    return ret
+
+
+def i_max_key_default(v, key_f, default):
+    first = 1
+    for e in v:
+        elt_key = key_f(e)
+        if first or elt_key > ret_key:  # noqa: F821
+            first = 0
+            ret_key = elt_key  # noqa: F841
+            ret = e
+    if first:
+        return default
+    return ret
+
+
+def no_more_kwargs(**kwargs):
+    for e in kwargs:
+        raise TypeError(f"'{e}' is an invalid keyword argument for this function")
+
+
 class MinMaxWrapper(Wrapper):
     is_pod = True
     is_empty = False
     is_pass_by_ref = False
 
-    def __init__(self, comparison1, comparison2, builtin):
+    def __init__(self, comparison1, comparison2, i_call, i_default_call, i_key_call, i_key_default_call, builtin):
         self.comparison_op1 = comparison1
         self.comparison_op2 = comparison2
+        self.i_call = i_call
+        self.i_default_call = i_default_call
+        self.i_key_call = i_key_call
+        self.i_key_default_call = i_key_default_call
         super().__init__(builtin)
 
     def getNativeLayoutType(self):
         return native_ast.Type.Void()
 
     def convert_call(self, context, expr, args, kwargs):
+        # iterable case
+        if len(args) == 1:
+            if 'key' in kwargs:
+                key_f = kwargs['key']
+                del kwargs['key']
+                if 'default' in kwargs:
+                    default = kwargs['default']
+                    del kwargs['default']
+                    no_more_kwargs(**kwargs)
+                    return context.call_py_function(self.i_key_default_call, (args[0], key_f, default), {})
+                else:
+                    no_more_kwargs(**kwargs)
+                    return context.call_py_function(self.i_key_call, (args[0], key_f), {})
+            if 'default' in kwargs:
+                default = kwargs['default']
+                del kwargs['default']
+                no_more_kwargs(**kwargs)
+                return context.call_py_function(self.i_default_call, (args[0], default), {})
+            no_more_kwargs(**kwargs)
+            return context.call_py_function(self.i_call, (args[0],), {})
+
         # this algorithm generates O(n) in code size and does O(n) copies
         if len(args) >= 2 and len(args) > _MINMAX_SPACE_VS_COPY_THRESHOLD and 'key' in kwargs:
             outT = OneOfWrapper.mergeTypes([a.expr_type.typeRepresentation for a in args]).typeRepresentation
@@ -49,6 +175,8 @@ class MinMaxWrapper(Wrapper):
             context.markUninitializedSlotInitialized(selected)
 
             key_f = kwargs['key']
+            del kwargs['key']
+            no_more_kwargs(**kwargs)
 
             # determine key type
             keyT = None
@@ -105,6 +233,8 @@ class MinMaxWrapper(Wrapper):
             selected = context.allocateUninitializedSlot(outT)
 
             key_f = kwargs['key']
+            del kwargs['key']
+            no_more_kwargs(**kwargs)
 
             # determine key type
             keyT = None
@@ -184,9 +314,25 @@ class MinMaxWrapper(Wrapper):
 
 class MinWrapper(MinMaxWrapper):
     def __init__(self):
-        super().__init__(python_ast.ComparisonOp.Gt(), python_ast.ComparisonOp.GtE(), min)
+        super().__init__(
+            python_ast.ComparisonOp.Gt(),
+            python_ast.ComparisonOp.GtE(),
+            i_min,
+            i_min_default,
+            i_min_key,
+            i_min_key_default,
+            min
+        )
 
 
 class MaxWrapper(MinMaxWrapper):
     def __init__(self):
-        super().__init__(python_ast.ComparisonOp.Lt(), python_ast.ComparisonOp.LtE(), max)
+        super().__init__(
+            python_ast.ComparisonOp.Lt(),
+            python_ast.ComparisonOp.LtE(),
+            i_max,
+            i_max_default,
+            i_max_key,
+            i_max_key_default,
+            max
+        )

--- a/typed_python/compiler/type_wrappers/min_max_wrapper.py
+++ b/typed_python/compiler/type_wrappers/min_max_wrapper.py
@@ -27,13 +27,14 @@ typeWrapper = lambda t: typed_python.compiler.python_object_representation.typed
 _MINMAX_SPACE_VS_COPY_THRESHOLD = 10
 
 
-class MinWrapper(Wrapper):
+class MinMaxWrapper(Wrapper):
     is_pod = True
     is_empty = False
     is_pass_by_ref = False
 
-    def __init__(self):
-        super().__init__(min)
+    def __init__(self, comparison, builtin):
+        self.comparison_op = comparison
+        super().__init__(builtin)
 
     def getNativeLayoutType(self):
         return native_ast.Type.Void()
@@ -47,7 +48,7 @@ class MinWrapper(Wrapper):
             context.markUninitializedSlotInitialized(selected)
 
             for i in range(1, len(args)):
-                cond = typeWrapper(outT).convert_bin_op(context, selected, python_ast.ComparisonOp.Gt(), args[i], False)
+                cond = typeWrapper(outT).convert_bin_op(context, args[i], self.comparison_op, selected, False)
                 if cond is None:
                     return None
                 with context.ifelse(cond.nonref_expr) as (ifTrue, ifFalse):
@@ -63,7 +64,7 @@ class MinWrapper(Wrapper):
 
             # returns False to abort this attempt
             def comparison_tree(j, k):
-                cond = args[j].expr_type.convert_bin_op(context, args[j], python_ast.ComparisonOp.LtE(), args[k], False)
+                cond = args[j].expr_type.convert_bin_op(context, args[j], self.comparison_op, args[k], False)
                 if cond is None:
                     return False
                 with context.ifelse(cond.nonref_expr) as (ifTrue, ifFalse):
@@ -89,63 +90,11 @@ class MinWrapper(Wrapper):
         return super().convert_call(context, expr, args, kwargs)
 
 
-class MaxWrapper(Wrapper):
-    is_pod = True
-    is_empty = False
-    is_pass_by_ref = False
-
+class MinWrapper(MinMaxWrapper):
     def __init__(self):
-        super().__init__(max)
+        super().__init__(python_ast.ComparisonOp.LtE(), min)
 
-    def getNativeLayoutType(self):
-        return native_ast.Type.Void()
 
-    def convert_call(self, context, expr, args, kwargs):
-        # this algorithm generates O(n) code and does O(n) copies
-        if len(args) > _MINMAX_SPACE_VS_COPY_THRESHOLD and not kwargs:
-            outT = OneOfWrapper.mergeTypes([a.expr_type.typeRepresentation for a in args]).typeRepresentation
-            selected = context.allocateUninitializedSlot(outT)
-            selected.convert_copy_initialize(args[0].convert_to_type(outT))
-            context.markUninitializedSlotInitialized(selected)
-
-            for i in range(1, len(args)):
-                cond = typeWrapper(outT).convert_bin_op(context, selected, python_ast.ComparisonOp.Lt(), args[i], False)
-                if cond is None:
-                    return None
-                with context.ifelse(cond.nonref_expr) as (ifTrue, ifFalse):
-                    with ifTrue:
-                        selected.convert_copy_initialize(args[i].convert_to_type(outT))
-
-            return selected
-
-        # this algorithm generates O(n^2) code and does only one copy
-        if len(args) >= 2 and not kwargs:
-            outT = OneOfWrapper.mergeTypes([a.expr_type.typeRepresentation for a in args]).typeRepresentation
-            selected = context.allocateUninitializedSlot(outT)
-
-            # returns False to abort this attempt
-            def comparison_tree(j, k):
-                cond = args[j].expr_type.convert_bin_op(context, args[j], python_ast.ComparisonOp.GtE(), args[k], False)
-                if cond is None:
-                    return False
-                with context.ifelse(cond.nonref_expr) as (ifTrue, ifFalse):
-                    if j + 1 == k:
-                        with ifTrue:
-                            selected.convert_copy_initialize(args[j].convert_to_type(outT))
-                        with ifFalse:
-                            selected.convert_copy_initialize(args[k].convert_to_type(outT))
-                    else:
-                        with ifTrue:
-                            if not comparison_tree(j, k-1):
-                                return False
-                        with ifFalse:
-                            if not comparison_tree(j+1, k):
-                                return False
-                return True
-
-            if not comparison_tree(0, len(args) - 1):
-                return None
-            context.markUninitializedSlotInitialized(selected)
-            return selected
-
-        return super().convert_call(context, expr, args, kwargs)
+class MaxWrapper(MinMaxWrapper):
+    def __init__(self):
+        super().__init__(python_ast.ComparisonOp.GtE(), max)

--- a/typed_python/compiler/type_wrappers/min_max_wrapper.py
+++ b/typed_python/compiler/type_wrappers/min_max_wrapper.py
@@ -1,0 +1,84 @@
+#   Copyright 2020-2020 typed_python Authors
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+from typed_python.compiler.type_wrappers.wrapper import Wrapper
+from typed_python.compiler.type_wrappers.one_of_wrapper import OneOfWrapper
+import typed_python.compiler.native_ast as native_ast
+import typed_python.python_ast as python_ast
+import typed_python.compiler
+
+
+typeWrapper = lambda t: typed_python.compiler.python_object_representation.typedPythonTypeToTypeWrapper(t)
+
+
+class MinWrapper(Wrapper):
+    is_pod = True
+    is_empty = False
+    is_pass_by_ref = False
+
+    def __init__(self):
+        super().__init__(min)
+
+    def getNativeLayoutType(self):
+        return native_ast.Type.Void()
+
+    def convert_call(self, context, expr, args, kwargs):
+        if len(args) >= 2 and not kwargs:
+            outT = OneOfWrapper.mergeTypes([a.expr_type.typeRepresentation for a in args]).typeRepresentation
+            selected = context.allocateUninitializedSlot(outT)
+            selected.convert_copy_initialize(args[0].convert_to_type(outT))
+            context.markUninitializedSlotInitialized(selected)
+
+            for i in range(1, len(args)):
+                cond = typeWrapper(outT).convert_bin_op(context, selected, python_ast.ComparisonOp.Gt(), args[i], False)
+                if cond is None:
+                    return None
+                with context.ifelse(cond.nonref_expr) as (ifTrue, ifFalse):
+                    with ifTrue:
+                        selected.convert_copy_initialize(args[i].convert_to_type(outT))
+
+            return selected
+
+        return super().convert_call(context, expr, args, kwargs)
+
+
+class MaxWrapper(Wrapper):
+    is_pod = True
+    is_empty = False
+    is_pass_by_ref = False
+
+    def __init__(self):
+        super().__init__(max)
+
+    def getNativeLayoutType(self):
+        return native_ast.Type.Void()
+
+    def convert_call(self, context, expr, args, kwargs):
+        if len(args) >= 2 and not kwargs:
+            outT = OneOfWrapper.mergeTypes([a.expr_type.typeRepresentation for a in args]).typeRepresentation
+            selected = context.allocateUninitializedSlot(outT)
+            selected.convert_copy_initialize(args[0].convert_to_type(outT))
+            context.markUninitializedSlotInitialized(selected)
+
+            for i in range(1, len(args)):
+                cond = typeWrapper(outT).convert_bin_op(context, selected, python_ast.ComparisonOp.Lt(), args[i], False)
+                if cond is None:
+                    return None
+                with context.ifelse(cond.nonref_expr) as (ifTrue, ifFalse):
+                    with ifTrue:
+                        selected.convert_copy_initialize(args[i].convert_to_type(outT))
+
+            return selected
+
+        return super().convert_call(context, expr, args, kwargs)


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Motivation and Context
The builtin functions min and max were not actually being compiled.

## Approach
Only handling the non-iterable case right now.
Keyword parameter 'key' is handled.

## How Has This Been Tested?
Types don't need to match - they just need to be comparable.
Tested on variety of numeric types, make sure first item is selected if equal.
e.g. min(3, 3.0) is 3 but min(3.0, 3) is 3.0.
Should work on any type that supports comparisons.


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.