### PR TITLE
Fixes for Set.clear(), conversions, methods, on iterables.  Refs #334, #335, #339.

### DIFF
--- a/typed_python/PyCompositeTypeInstance.hpp
+++ b/typed_python/PyCompositeTypeInstance.hpp
@@ -37,7 +37,7 @@ public:
     static bool compare_to_python_concrete(CompositeType* tupT, instance_ptr self, PyObject* other, bool exact, int pyComparisonOp);
 
     static bool pyValCouldBeOfTypeConcrete(modeled_type* type, PyObject* pyRepresentation, bool isExplicit) {
-        return PyTuple_Check(pyRepresentation) || PyList_Check(pyRepresentation) || PyDict_Check(pyRepresentation);
+        return PyTuple_Check(pyRepresentation) || PyList_Check(pyRepresentation) || PySet_Check(pyRepresentation) || PyDict_Check(pyRepresentation);
     }
 
     int pyInquiryConcrete(const char* op, const char* opErrRep);

--- a/typed_python/PyConstDictInstance.cpp
+++ b/typed_python/PyConstDictInstance.cpp
@@ -1,5 +1,5 @@
 /******************************************************************************
-   Copyright 2017-2019 typed_python Authors
+   Copyright 2017-2020 typed_python Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -422,11 +422,12 @@ PyMethodDef* PyConstDictInstance::typeMethodsConcrete(Type* t) {
 }
 
 void PyConstDictInstance::mirrorTypeInformationIntoPyTypeConcrete(ConstDictType* constDictT, PyTypeObject* pyType) {
-    //expose 'ElementType' as a member of the type object
     PyDict_SetItemString(pyType->tp_dict, "KeyType",
         typePtrToPyTypeRepresentation(constDictT->keyType())
     );
-
+    PyDict_SetItemString(pyType->tp_dict, "ElementType",  // ElementType is what you get if you iterate
+        typePtrToPyTypeRepresentation(constDictT->keyType())
+    );
     PyDict_SetItemString(pyType->tp_dict, "ValueType",
         typePtrToPyTypeRepresentation(constDictT->valueType())
     );
@@ -473,7 +474,7 @@ bool PyConstDictInstance::compare_to_python_concrete(ConstDictType* dictType, in
         } catch(PythonExceptionSet&) {
             PyErr_Clear();
         } catch(...) {
-            //if we can't convert to KeyType, we're not equal
+            //if we can't convert to keyType, we're not equal
             return false;
         }
 

--- a/typed_python/PyDictInstance.cpp
+++ b/typed_python/PyDictInstance.cpp
@@ -1,5 +1,5 @@
 /******************************************************************************
-   Copyright 2017-2019 typed_python Authors
+   Copyright 2017-2020 typed_python Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -457,13 +457,15 @@ PyMethodDef* PyDictInstance::typeMethodsConcrete(Type* t) {
 }
 
 void PyDictInstance::mirrorTypeInformationIntoPyTypeConcrete(DictType* dictT, PyTypeObject* pyType) {
-    //expose 'ElementType' as a member of the type object
     PyDict_SetItemString(pyType->tp_dict, "KeyType",
-            typePtrToPyTypeRepresentation(dictT->keyType())
-            );
+        typePtrToPyTypeRepresentation(dictT->keyType())
+    );
+    PyDict_SetItemString(pyType->tp_dict, "ElementType",  // ElementType is what you get if you iterate
+        typePtrToPyTypeRepresentation(dictT->keyType())
+    );
     PyDict_SetItemString(pyType->tp_dict, "ValueType",
-            typePtrToPyTypeRepresentation(dictT->valueType())
-            );
+        typePtrToPyTypeRepresentation(dictT->valueType())
+    );
 }
 
 
@@ -546,7 +548,7 @@ bool PyDictInstance::compare_to_python_concrete(DictType* dictType, instance_ptr
             PyErr_Clear();
             return false;
         } catch(...) {
-            //if we can't convert to KeyType, we're not equal
+            //if we can't convert to keyType, we're not equal
             return false;
         }
 

--- a/typed_python/PySetInstance.hpp
+++ b/typed_python/PySetInstance.hpp
@@ -1,5 +1,5 @@
 /******************************************************************************
-   Copyright 2017-2019 typed_python Authors
+   Copyright 2017-2020 typed_python Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -51,10 +51,7 @@ class PySetInstance : public PyInstance {
                                                         PyObject* pyRepresentation,
                                                         bool isExplicit);
     static void mirrorTypeInformationIntoPyTypeConcrete(SetType* setType, PyTypeObject* pyType);
-    static bool pyValCouldBeOfTypeConcrete(modeled_type* type, PyObject* pyRepresentation,
-                                           bool isExplicit) {
-        return true;
-    }
+    static bool pyValCouldBeOfTypeConcrete(modeled_type* type, PyObject* pyRepresentation, bool isExplicit);
     static bool compare_to_python_concrete(SetType* setT, instance_ptr self, PyObject* other, bool exact, int pyComparisonOp);
     int pyInquiryConcrete(const char* op, const char* opErrRep);
     PyObject* pyOperatorConcrete(PyObject* rhs, const char* op, const char* opErr);
@@ -75,9 +72,9 @@ class PySetInstance : public PyInstance {
     static int set_difference_update(PyObject* o, PyObject* other);
     static PyObject* set_symmetric_difference(PyObject* o, PyObject* other);
     static int set_symmetric_difference_update(PyObject* o, PyObject* other);
-    static bool set_is_subset(PyObject* o, PyObject* other);
-    static bool set_is_superset(PyObject* o, PyObject* other);
-    static bool set_is_disjoint(PyObject* o, PyObject* other);
+    static int set_is_subset(PyObject* o, PyObject* other);
+    static int set_is_superset(PyObject* o, PyObject* other);
+    static int set_is_disjoint(PyObject* o, PyObject* other);
     SetType* type();
     static void getDataFromNative(PySetInstance* src, std::function<void(instance_ptr)> func);
     static void getDataFromNative(PyTupleOrListOfInstance* src,

--- a/typed_python/PyTupleOrListOfInstance.cpp
+++ b/typed_python/PyTupleOrListOfInstance.cpp
@@ -1,5 +1,5 @@
 /******************************************************************************
-   Copyright 2017-2019 typed_python Authors
+   Copyright 2017-2020 typed_python Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -37,6 +37,8 @@ bool PyTupleOrListOfInstance::pyValCouldBeOfTypeConcrete(modeled_type* type, PyO
         PyTuple_Check(pyRepresentation) ||
         PyList_Check(pyRepresentation) ||
         PyDict_Check(pyRepresentation) ||
+        PySet_Check(pyRepresentation) ||
+        PySequence_Check(pyRepresentation) ||
         PyIter_Check(pyRepresentation) ||
         PyArray_Check(pyRepresentation)
         ;

--- a/typed_python/SetType.cpp
+++ b/typed_python/SetType.cpp
@@ -36,9 +36,10 @@ void SetType::clear(instance_ptr self) {
     hash_table_layout& record = **(hash_table_layout**)self;
     for (long k = 0; k < record.items_reserved; k++) {
         if (record.items_populated[k]) {
-            discard(self, keyAtSlot(self, k));
+            m_key_type->destroy(record.items + m_bytes_per_el * k);
         }
     }
+    record.allItemsHaveBeenRemoved();
 }
 
 instance_ptr SetType::insertKey(instance_ptr self, instance_ptr key) {

--- a/typed_python/_runtime.cpp
+++ b/typed_python/_runtime.cpp
@@ -1259,6 +1259,30 @@ extern "C" {
         return np_pyobj_compare(lhs, rhs, Py_GE);
     }
 
+    PythonObjectOfType::layout_type* np_pyobj_In(PythonObjectOfType::layout_type* lhs, PythonObjectOfType::layout_type* rhs) {
+        PyEnsureGilAcquired acquireTheGil;
+
+        int res = PySequence_Contains(rhs->pyObj, lhs->pyObj);
+
+        if (res == -1) {
+            throw PythonExceptionSet();
+        }
+
+        return PythonObjectOfType::createLayout(res == 1 ? Py_True : Py_False);
+    }
+
+    PythonObjectOfType::layout_type* np_pyobj_NotIn(PythonObjectOfType::layout_type* lhs, PythonObjectOfType::layout_type* rhs) {
+        PyEnsureGilAcquired acquireTheGil;
+
+        int res = PySequence_Contains(rhs->pyObj, lhs->pyObj);
+
+        if (res == -1) {
+            throw PythonExceptionSet();
+        }
+
+        return PythonObjectOfType::createLayout(res == 1 ? Py_False : Py_True);
+    }
+
     PythonObjectOfType::layout_type* np_pyobj_Invert(PythonObjectOfType::layout_type* lhs) {
         PyEnsureGilAcquired acquireTheGil;
 

--- a/typed_python/compiler/expression_conversion_context.py
+++ b/typed_python/compiler/expression_conversion_context.py
@@ -1,4 +1,4 @@
-#   Copyright 2017-2019 typed_python Authors
+#   Copyright 2017-2020 typed_python Authors
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
@@ -1687,28 +1687,30 @@ class ExpressionConversionContext(object):
             return aList
 
         if ast.matches.Tuple:
-            aList = self.constant(list).convert_call([], {})
+            # While constructing, it is a list, so we can append to it.
+            aTuple = self.constant(list).convert_call([], {})
 
             for e in ast.elts:
                 eVal = self.convert_expression_ast(e)
                 if eVal is None:
                     return None
 
-                aList.convert_method_call("append", (eVal,), {})
+                aTuple.convert_method_call("append", (eVal,), {})
 
-            return self.constant(tuple).convert_call([aList], {})
+            # Now it becomes a tuple.
+            return self.constant(tuple).convert_call([aTuple], {})
 
         if ast.matches.Set:
-            aList = self.constant(set).convert_call([], {})
+            aSet = self.constant(set).convert_call([], {})
 
             for e in ast.elts:
                 eVal = self.convert_expression_ast(e)
                 if eVal is None:
                     return None
 
-                aList.convert_method_call("add", (eVal,), {})
+                aSet.convert_method_call("add", (eVal,), {})
 
-            return aList
+            return aSet
 
         if ast.matches.Dict:
             aList = self.constant(dict).convert_call([], {})

--- a/typed_python/compiler/tests/range_compilation_test.py
+++ b/typed_python/compiler/tests/range_compilation_test.py
@@ -1,4 +1,4 @@
-#   Copyright 2017-2019 typed_python Authors
+#   Copyright 2017-2020 typed_python Authors
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-from typed_python import ListOf, Compiled
+from typed_python import ListOf, Compiled, Entrypoint
 import unittest
 
 
@@ -65,3 +65,13 @@ class TestRangeCompilation(unittest.TestCase):
         self.assertEqual(repeat(aList, 1), aList)
         self.assertEqual(repeat(aList, 2), aList + aList)
         self.assertEqual(repeat(aList, 3), aList + aList + aList)
+
+    def test_range_type_str(self):
+        def f(x):
+            return str(type(x))
+
+        x = range(10)
+
+        r1 = f(x)
+        r2 = Entrypoint(f)(x)
+        self.assertEqual(r1, r2)

--- a/typed_python/compiler/tests/set_compilation_test.py
+++ b/typed_python/compiler/tests/set_compilation_test.py
@@ -12,17 +12,31 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-from typed_python import Set, ListOf, Entrypoint, Compiled, Tuple, TupleOf, NamedTuple
+from typed_python import Set, ListOf, Entrypoint, Compiled, Tuple, TupleOf, NamedTuple, Dict, ConstDict, OneOf
 from typed_python.compiler.type_wrappers.set_wrapper import set_union, set_intersection, set_difference, \
     set_symmetric_difference, set_union_multiple, set_intersection_multiple, set_difference_multiple, \
-    set_disjoint, set_subset, set_proper_subset, set_equal, set_not_equal, \
+    set_disjoint, set_subset, set_subset_iterable, set_proper_subset, set_equal, set_not_equal, \
     set_update, set_intersection_update, set_difference_update
 from flaky import flaky
 import typed_python._types as _types
 import time
 import numpy
 import unittest
-import pytest
+
+
+def result_or_exception(f, *p):
+    try:
+        return f(*p)
+    except Exception as e:
+        return str(e)
+
+
+def some_fibs():
+    a = 0
+    b = 1
+    while b < 100:
+        yield b
+        a, b = b, a + b
 
 
 class TestSetCompilation(unittest.TestCase):
@@ -422,8 +436,8 @@ class TestSetCompilation(unittest.TestCase):
                     r1 = f(left, right)
                     r2 = f(S(left), S(right))  # retesting interpreter here
                     r3 = Compiled(f)(S(left), S(right))  # testing compiled code
-                    self.assertEqual(r1, r2)
-                    self.assertEqual(r2, r3)
+                    self.assertEqual(r1, r2, (f, left, right))
+                    self.assertEqual(r2, r3, (f, left, right))
 
         def union0(x: S):
             return x.union()
@@ -506,7 +520,7 @@ class TestSetCompilation(unittest.TestCase):
             x.difference_update(y, z)
 
         def symmetric_difference_update2(x: S, y: S, z: S):
-            return x.symmetric_difference_update(y, z)
+            x.symmetric_difference_update(y, z)
 
         for x in sets:
             for y in sets:
@@ -522,6 +536,170 @@ class TestSetCompilation(unittest.TestCase):
                         self.assertEqual(x1, x3)
                     with self.assertRaises(TypeError):
                         Compiled(symmetric_difference_update2)(S(x), S(y), S(z))
+
+    def test_set_iterable_comparisons(self):
+        S = Set(int)
+
+        def issubset(x, y):
+            return x.issubset(y)
+
+        def issuperset(x, y):
+            return x.issuperset(y)
+
+        def isdisjoint(x, y):
+            return x.isdisjoint(y)
+
+        test_cases = [
+            {1, 2, 3, 5, 8, 13, 21, 34, 55, 89},
+            {1, 2, 3, 5, 13, 21, 34, 55, 89},
+            {1, 2, 3, 5, 9, 8, 13, 21, 34, 55, 89},
+            {1, 2, 3, 5, 9, 13, 21, 34, 55, 89},
+            {2, 3, 5, 8, 13, 21, 34, 55, 89},
+            {1, 2, 3, 5, 8, 13, 21, 34, 55},
+            {1, 2, 3, 5, 8, 13, 21, 34, 55, 89, 90},
+            {0, 1, 2, 3, 5, 8, 13, 21, 34, 55, 89},
+            {},
+        ]
+        for f in [issubset, issuperset, isdisjoint]:
+            for s in test_cases:
+                r1 = f(S(s), some_fibs())
+                r2 = Entrypoint(f)(S(s), some_fibs())
+                self.assertEqual(r1, r2)
+
+                r1 = f(S(s), range(3))
+                r2 = Entrypoint(f)(S(s), range(3))
+                self.assertEqual(r1, r2)
+
+                r1 = f(S(s), range(10))
+                r2 = Entrypoint(f)(S(s), range(10))
+                self.assertEqual(r1, r2)
+
+        fail_cases = [
+            Set(str)("abc"),
+            ListOf(str)("abc"),
+            TupleOf(str)("abc"),
+            Dict(str, int)({}.fromkeys("xyz", 1)),
+            ConstDict(str, int)({}.fromkeys("xyz", 1)),
+        ]
+        for f in [issubset, issuperset, isdisjoint]:
+            s = S({1, 2, 3})
+            for v in fail_cases:
+                with self.assertRaises(TypeError):
+                    f(s, v)
+                with self.assertRaises(TypeError):
+                    Entrypoint(f)(s, v)
+
+    def test_set_iterable_updates(self):
+        S = Set(int)
+
+        def update(x, y):
+            x.update(y)
+            return x
+
+        def intersection_update(x, y):
+            x.intersection_update(y)
+            return x
+
+        def difference_update(x, y):
+            x.difference_update(y)
+            return x
+
+        def symmetric_difference_update(x, y):
+            x.symmetric_difference_update(y)
+            return x
+
+        def is_subset(x, y):
+            return x.issubset(y)
+
+        def is_superset(x, y):
+            return x.issuperset(y)
+
+        def is_disjoint(x, y):
+            return x.isdisjoint(y)
+
+        test_sets = [
+            {-1, -2},
+            set(range(20)),
+            {1, 3, 5},
+            {-1, 3, 5},
+            set(range(20)),
+            set(some_fibs()),
+            set(some_fibs()) | {0},
+            set(some_fibs()).difference({5}),
+        ]
+        test_iterables = [
+            [1, 2, 2, 3],
+            [-1, -1, 2, 2, 3],
+            (89, 4, 89),
+            ListOf(int)([1, 4, 4, 5, 5]),
+            TupleOf(int)(some_fibs()),
+            Dict(int, int)({}.fromkeys(range(20), 1)),
+            ConstDict(int, int)({}.fromkeys(range(20), 1)),
+        ]
+        for f in [update, intersection_update, difference_update, symmetric_difference_update, is_subset, is_superset, is_disjoint]:
+            for s in test_sets:
+                for v in test_iterables:
+                    s0 = s.copy()
+                    r0 = f(s0, v)
+
+                    s1 = S(s)
+                    r1 = f(s1, v)
+                    self.assertEqual(s0, s1)  # test interpreted side effect
+                    self.assertEqual(r0, r1)  # test interpreted return value
+
+                    s2 = S(s)
+                    r2 = Entrypoint(f)(s2, v)
+                    self.assertEqual(s0, s2)  # test compiled side effect
+                    self.assertEqual(r0, r2)  # test compiled return value
+
+                # now test range() and some_fibs() separately
+                s0 = s.copy()
+                r0 = f(s0, range(10))
+
+                s1 = S(s)
+                r1 = f(s1, range(10))
+                self.assertEqual(s0, s1, (f, s, "range()"))  # test interpreted result
+                self.assertEqual(r0, r1, (f, s, "range()"))  # test interpreted result
+
+                s2 = S(s)
+                r2 = Entrypoint(f)(s2, range(10))
+                self.assertEqual(s0, s2, (f, s, "range()"))  # test compiled result
+                self.assertEqual(r0, r2, (f, s, "range()"))  # test compiled result
+
+                s0 = s.copy()
+                r0 = f(s0, some_fibs())
+
+                s1 = S(s)
+                r1 = f(s1, some_fibs())
+                self.assertEqual(s0, s1, (f, s, "some_fibs()"))  # test interpreted result
+                self.assertEqual(r0, r1, (f, s, "some_fibs()"))  # test interpreted result
+
+                s2 = S(s)
+                r2 = Entrypoint(f)(s2, some_fibs())
+                self.assertEqual(s0, s2, (f, s, "some_fibs()"))  # test compiled result
+                self.assertEqual(r0, r2, (f, s, "some_fibs()"))  # test compiled result
+
+        fail_iterables = [
+            [[]],
+            ['a', 1, 2, 3],
+            ['x', -1, -1, 2, 3],
+            ('b', 2, 'b'),
+            ListOf(OneOf(int, str))(['q', 1, 4, 4, 5]),
+            TupleOf(OneOf(int, str))(('a', 1, 2, 3)),
+            Dict(str, int)({'a': 1, 'b': 2, 'c': 3}),
+            ConstDict(str, int)({'a': 1, 'b': 2, 'c': 3}),
+        ]
+        for f in [update, intersection_update, difference_update, symmetric_difference_update, is_subset, is_superset, is_disjoint]:
+            s = {1, 2, 3}
+            for v in fail_iterables:
+                print("TEST", v)
+                s1 = S(s)
+                with self.assertRaises(TypeError):
+                    f(s1, v)
+
+                s2 = S(s)
+                with self.assertRaises(TypeError):
+                    Entrypoint(f)(s2, v)
 
     @flaky(max_runs=3, min_passes=1)
     def test_set_binop_perf(self):
@@ -783,6 +961,7 @@ class TestSetCompilation(unittest.TestCase):
         s4 = {2, 3}
         self.assertEqual(set_disjoint(s3, s4), s3.isdisjoint(s4))
         self.assertEqual(set_subset(s3, s4), s3 <= s4)
+        self.assertEqual(set_subset_iterable(s3, s4), s3 <= s4)
         self.assertEqual(set_proper_subset(s3, s4), s3 < s4)
         self.assertEqual(set_equal(s3, s4), s3 == s4)
         self.assertEqual(set_not_equal(s3, s4), s3 != s4)
@@ -791,13 +970,79 @@ class TestSetCompilation(unittest.TestCase):
         set_intersection_update(s1, s1)
         set_difference_update(s1, [9, 11])
 
-    @pytest.mark.skip(reason="not addressed yet")
     def test_compiled_set_constructors(self):
-        @Entrypoint
-        def f(x):
+        def f_set(x):
             return Set(int)(x)
 
-        r1 = f(ListOf(int)([1, 1]))
-        self.assertEqual(len(r1), 1)
-        r2 = f(TupleOf(int)([1, 1]))
-        self.assertEqual(len(r2), 1)
+        def f_listof(x):
+            return ListOf(int)(x)
+
+        def f_tupleof(x):
+            return TupleOf(int)(x)
+
+        test_values = [
+            range(10),
+            {1, 2},
+            [3, 3, 4, 4],
+            (5, 6, 5, 6),
+            {101: 1, 202: 2},
+            Set(int)({1, 2}),
+            ListOf(int)([3, 3, 4, 4]),
+            TupleOf(int)((5, 6, 5, 6)),
+            Tuple(int, int, int, int)((7, 8, 8, 7)),
+            Dict(int, int)({101: 1, 202: 2}),
+            ConstDict(int, int)({101: 1, 202: 2}),
+            Set(float)({1.0, 2.0}),
+            ListOf(float)([3.0, 3.0, 4.0, 4.0]),
+            TupleOf(float)((5.0, 6.0, 5.0, 6.0)),
+            Tuple(float, float, float, float)((7.0, 8.0, 8.0, 7.0)),
+            Dict(float, int)({101.0: 1, 102.0: 2}),
+        ]
+
+        test_values_mismatch = [
+            Set(str)({"a", "b"}),
+            ListOf(str)(["c", "c", "d", "d"]),
+            TupleOf(str)(("e", "f", "e", "f")),
+            Tuple(str, int, int, int)(("g", 8, 8, 7)),
+            Dict(str, int)({"x": 1, "y": 2}),
+        ]
+
+        # let's test all these types, not just Set
+        for f in [f_set, f_listof, f_tupleof]:
+            for v in test_values:
+                r1 = f(v)
+                r2 = Entrypoint(f)(v)
+                self.assertEqual(r1, r2)
+
+            r1 = f(some_fibs())
+            r2 = Entrypoint(f)(some_fibs())
+            self.assertEqual(r1, r2)
+
+            for v in test_values_mismatch:
+                with self.assertRaises(TypeError):
+                    f(v)
+                with self.assertRaises(TypeError):
+                    Entrypoint(f)(v)
+
+        S = Set(TupleOf(TupleOf(int)))
+
+        def f_set_t(x):
+            return S(x)
+
+        t1 = TupleOf(TupleOf(int))(((1, 2), (3, 0)))
+        t2 = TupleOf(TupleOf(int))(((4, 5, 5), (6,)))
+
+        r1 = f_set_t({t1, t2})
+        r2 = Entrypoint(f_set_t)({t1, t2})
+        self.assertEqual(r1, r2)
+
+        t3 = TupleOf(TupleOf(OneOf(int, str)))(((7, 7, 7), (8, 9)))
+        r1 = f_set_t({t1, t2, t3})
+        r2 = Entrypoint(f_set_t)({t1, t2, t3})
+        self.assertEqual(r1, r2)
+
+        t4 = TupleOf(TupleOf(OneOf(int, str)))(((7, 7, 7), (8, "x")))
+        with self.assertRaises(TypeError):
+            f_set_t({t1, t2, t4})
+        with self.assertRaises(TypeError):
+            Entrypoint(f_set_t)({t1, t2, t4})

--- a/typed_python/compiler/tests/set_compilation_test.py
+++ b/typed_python/compiler/tests/set_compilation_test.py
@@ -15,8 +15,9 @@
 from typed_python import Set, ListOf, Entrypoint, Compiled, Tuple, TupleOf, NamedTuple, Dict, ConstDict, OneOf
 from typed_python.compiler.type_wrappers.set_wrapper import set_union, set_intersection, set_difference, \
     set_symmetric_difference, set_union_multiple, set_intersection_multiple, set_difference_multiple, \
-    set_disjoint, set_subset, set_subset_iterable, set_proper_subset, set_equal, set_not_equal, \
-    set_update, set_intersection_update, set_difference_update
+    set_disjoint, set_subset, set_subset_iterable, set_superset, set_proper_subset, set_equal, set_not_equal, \
+    set_update, set_intersection_update, set_difference_update, set_symmetric_difference_update, \
+    initialize_set_from_other
 from flaky import flaky
 import typed_python._types as _types
 import time
@@ -960,15 +961,29 @@ class TestSetCompilation(unittest.TestCase):
 
         s4 = {2, 3}
         self.assertEqual(set_disjoint(s3, s4), s3.isdisjoint(s4))
+        self.assertEqual(set_disjoint(s3, s3), s3.isdisjoint(s3))
         self.assertEqual(set_subset(s3, s4), s3 <= s4)
+        self.assertEqual(set_subset(s3, s3), s3 <= s3)
+        self.assertEqual(set_superset(s4, s3), s4 >= s3)
+        self.assertEqual(set_superset(s3, s3), s3 >= s3)
         self.assertEqual(set_subset_iterable(s3, s4), s3 <= s4)
         self.assertEqual(set_proper_subset(s3, s4), s3 < s4)
         self.assertEqual(set_equal(s3, s4), s3 == s4)
         self.assertEqual(set_not_equal(s3, s4), s3 != s4)
 
         set_update(s1, s2)
-        set_intersection_update(s1, s1)
-        set_difference_update(s1, [9, 11])
+        set_intersection_update(s1, [5, 6])
+        set_difference_update(s1, [3, 7])
+        set_symmetric_difference_update(s1, [2, 8])
+
+        class P_mock:
+            ElementType = Set(int)
+
+            def initialize(self, src):
+                pass
+
+        p1 = P_mock()
+        initialize_set_from_other(p1, [1, 2])
 
     def test_compiled_set_constructors(self):
         def f_set(x):

--- a/typed_python/compiler/type_wrappers/const_dict_wrapper.py
+++ b/typed_python/compiler/type_wrappers/const_dict_wrapper.py
@@ -1,4 +1,4 @@
-#   Copyright 2017-2019 typed_python Authors
+#   Copyright 2017-2020 typed_python Authors
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
@@ -147,6 +147,10 @@ def const_dict_contains(constDict, key):
             return True
 
     return False
+
+
+def const_dict_contains_not(constDict, key):
+    return not const_dict_contains(constDict, key)
 
 
 class ConstDictWrapperBase(RefcountedWrapper):
@@ -315,13 +319,13 @@ class ConstDictWrapper(ConstDictWrapperBase):
         return super().convert_bin_op(context, left, op, right, inplace)
 
     def convert_bin_op_reverse(self, context, left, op, right, inplace):
-        if op.matches.In:
+        if op.matches.In or op.matches.NotIn:
             right = right.convert_to_type(self.keyType)
             if right is None:
                 return None
 
             return context.call_py_function(
-                const_dict_contains,
+                const_dict_contains if op.matches.In else const_dict_contains_not,
                 (left, right),
                 {}
             )

--- a/typed_python/compiler/type_wrappers/const_dict_wrapper.py
+++ b/typed_python/compiler/type_wrappers/const_dict_wrapper.py
@@ -149,10 +149,6 @@ def const_dict_contains(constDict, key):
     return False
 
 
-def const_dict_contains_not(constDict, key):
-    return not const_dict_contains(constDict, key)
-
-
 class ConstDictWrapperBase(RefcountedWrapper):
     """Common method wrappers for all ConstDicts.
 
@@ -319,16 +315,12 @@ class ConstDictWrapper(ConstDictWrapperBase):
         return super().convert_bin_op(context, left, op, right, inplace)
 
     def convert_bin_op_reverse(self, context, left, op, right, inplace):
-        if op.matches.In or op.matches.NotIn:
+        if op.matches.In:
             right = right.convert_to_type(self.keyType)
             if right is None:
                 return None
 
-            return context.call_py_function(
-                const_dict_contains if op.matches.In else const_dict_contains_not,
-                (left, right),
-                {}
-            )
+            return context.call_py_function(const_dict_contains, (left, right), {})
 
         return super().convert_bin_op_reverse(context, left, op, right, inplace)
 

--- a/typed_python/compiler/type_wrappers/dict_wrapper.py
+++ b/typed_python/compiler/type_wrappers/dict_wrapper.py
@@ -1,4 +1,4 @@
-#   Copyright 2018 Braxton Mckee
+#   Copyright 2017-2020 typed_python Authors
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@ import typed_python.compiler.type_wrappers.runtime_functions as runtime_function
 from typed_python.compiler.type_wrappers.bound_method_wrapper import BoundMethodWrapper
 from typed_python.compiler.type_wrappers.wrapper import Wrapper
 from typed_python.compiler.type_wrappers.native_hash import table_next_slot, table_clear, table_contains, \
-    table_contains_not, dict_delitem, dict_getitem, dict_get, dict_setitem
+    dict_delitem, dict_getitem, dict_get, dict_setitem
 from typed_python import Tuple, PointerTo, Int32, UInt8
 
 import typed_python.compiler.native_ast as native_ast
@@ -449,16 +449,12 @@ class DictWrapper(DictWrapperBase):
         return context.pushPod(int, self.convert_len_native(expr))
 
     def convert_bin_op_reverse(self, context, left, op, right, inplace):
-        if op.matches.In or op.matches.NotIn:
+        if op.matches.In:
             right = right.convert_to_type(self.keyType)
             if right is None:
                 return None
 
-            return context.call_py_function(
-                table_contains if op.matches.In else table_contains_not,
-                (left, right),
-                {}
-            )
+            return context.call_py_function(table_contains, (left, right), {})
 
         return super().convert_bin_op_reverse(context, left, op, right, inplace)
 

--- a/typed_python/compiler/type_wrappers/native_hash.py
+++ b/typed_python/compiler/type_wrappers/native_hash.py
@@ -215,14 +215,6 @@ def table_contains(instance, item):
     return slot != -1
 
 
-def table_contains_not(instance, item):
-    itemHash = NativeHash()(item)
-
-    slot = table_slot_for_key(instance, itemHash, item)
-
-    return slot == -1
-
-
 # Operations specific to dicts that manipulate the fields directly:
 
 

--- a/typed_python/compiler/type_wrappers/one_of_wrapper.py
+++ b/typed_python/compiler/type_wrappers/one_of_wrapper.py
@@ -254,7 +254,15 @@ class OneOfWrapper(Wrapper):
                     with subcontext:
                         self.refAs(context, expr, ix).convert_destroy()
 
+    def _can_convert_to_type(self, otherType, explicit) -> OneOf(False, True, "Maybe"):  # noqa
+        if otherType == self:
+            return True
+
+        return "Maybe"
+
     def _can_convert_from_type(self, targetType, explicit):
+        if targetType == self:
+            return True
         if targetType.typeRepresentation in self.typeRepresentation.Types:
             return True
         return "Maybe"

--- a/typed_python/compiler/type_wrappers/range_wrapper.py
+++ b/typed_python/compiler/type_wrappers/range_wrapper.py
@@ -1,4 +1,4 @@
-#   Copyright 2017-2019 typed_python Authors
+#   Copyright 2017-2020 typed_python Authors
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
@@ -55,6 +55,11 @@ class RangeWrapper(Wrapper):
                     >> newInstance.expr.ElementPtrIntegers(0, 1).store(arg1.nonref_expr)
             )
         return super().convert_call(context, expr, args, kwargs)
+
+    def convert_str_cast(self, context, instance):
+        # need this to be able to print(type(r)) if r is a range, in compiled code
+        # otherwise the tuple confuses 'print'
+        return context.constant(str(self.typeRepresentation[0]))
 
 
 class RangeInstanceWrapper(Wrapper):

--- a/typed_python/compiler/type_wrappers/runtime_functions.py
+++ b/typed_python/compiler/type_wrappers/runtime_functions.py
@@ -82,6 +82,8 @@ pyOpToBinaryCallTarget = {
     python_ast.ComparisonOp.Gt(): binaryPyobjCallTarget("np_pyobj_GT"),
     python_ast.ComparisonOp.LtE(): binaryPyobjCallTarget("np_pyobj_LE"),
     python_ast.ComparisonOp.GtE(): binaryPyobjCallTarget("np_pyobj_GE"),
+    python_ast.ComparisonOp.In(): binaryPyobjCallTarget("np_pyobj_In"),
+    python_ast.ComparisonOp.NotIn(): binaryPyobjCallTarget("np_pyobj_NotIn"),
 }
 
 pyOpToUnaryCallTarget = {

--- a/typed_python/compiler/type_wrappers/set_wrapper.py
+++ b/typed_python/compiler/type_wrappers/set_wrapper.py
@@ -16,6 +16,10 @@ from typed_python.compiler.type_wrappers.refcounted_wrapper import RefcountedWra
 from typed_python.compiler.typed_expression import TypedExpression
 import typed_python.compiler.type_wrappers.runtime_functions as runtime_functions
 from typed_python.compiler.type_wrappers.bound_method_wrapper import BoundMethodWrapper
+from typed_python.compiler.type_wrappers.tuple_wrapper import TupleWrapper
+from typed_python.compiler.type_wrappers.tuple_of_wrapper import TupleOrListOfWrapper
+from typed_python.compiler.type_wrappers.const_dict_wrapper import ConstDictWrapper
+from typed_python.compiler.type_wrappers.dict_wrapper import DictWrapper
 from typed_python.compiler.type_wrappers.wrapper import Wrapper
 from typed_python.compiler.type_wrappers.native_hash import table_next_slot, table_clear, \
     table_contains, table_contains_not, set_add, set_add_or_remove, set_remove, set_discard, set_pop
@@ -26,6 +30,19 @@ import typed_python.compiler
 
 
 typeWrapper = lambda t: typed_python.compiler.python_object_representation.typedPythonTypeToTypeWrapper(t)
+
+
+def initialize_set_from_other(targetPtr, src):
+    # TODO: Maybe could do this directly with unsafe calls, like we do for ListOf and TupleOf.
+    target = type(targetPtr).ElementType()
+
+    for item in src:
+        converted_item = type(targetPtr).ElementType.ElementType(item)
+        target.add(converted_item)
+
+    targetPtr.initialize(target)
+
+    return True
 
 
 def set_union(left, right):
@@ -88,8 +105,16 @@ def set_symmetric_difference(left, right):
 
 
 def set_symmetric_difference_update(left, right):
+    to_remove = type(left)()
+    to_add = type(left)()
     for i in right:
-        set_add_or_remove(left, i)
+        if i in left:
+            to_remove.add(i)
+        else:
+            to_add.add(i)
+            left.add(i)
+    left.difference_update(to_remove)
+    left.update(to_add)
 
 
 def set_union_multiple(left, *others):
@@ -112,11 +137,21 @@ def set_intersection_multiple(left, *others):
     return result
 
 
+# for *others that have __contains__:
+# def set_intersection_update0(left, *others):
+#    for i in left:
+#        for o in others:
+#            if i not in o:
+#                left.discard(i)
+
+# for generic iterable *others
 def set_intersection_update(left, *others):
-    for i in left:
-        for o in others:
-            if i not in o:
-                left.discard(i)
+    for o in others:
+        temp = left.copy()
+        left.clear()
+        for i in o:
+            if i in temp:
+                left.add(i)
 
 
 def set_difference_multiple(left, *others):
@@ -127,22 +162,42 @@ def set_difference_multiple(left, *others):
 
 
 def set_difference_update(left, *others):
-    for i in left:
-        for o in others:
-            if i in o:
-                left.discard(i)
+    for o in others:
+        for e in o:
+            left.discard(e)
 
 
 def set_disjoint(left, right):
-    for i in left:
-        if i in right:
+    for i in right:
+        if i in left:
             return False
     return True
 
 
+# for types that support "not in":
 def set_subset(left, right):
     for i in left:
         if i not in right:
+            return False
+    return True
+
+
+# for generic iterables:
+def set_subset_iterable(left, right):
+    if len(left) == 0:
+        return True
+    shadow = type(left)()
+    for i in right:
+        if i in left:
+            shadow.add(i)
+            if len(shadow) == len(left):
+                return True
+    return False
+
+
+def set_superset(left, right):
+    for i in right:
+        if i not in left:
             return False
     return True
 
@@ -171,7 +226,7 @@ class SetWrapperBase(RefcountedWrapper):
         assert hasattr(t, '__typed_python_category__')
         super().__init__(t if behavior is None else (t, behavior))
 
-        self.keyType = typeWrapper(t.KeyType)
+        self.keyType = typeWrapper(t.ElementType)
         self.setType = t
 
         self.keyBytecount = self.keyType.getBytecount()
@@ -434,9 +489,14 @@ class SetWrapper(SetWrapperBase):
             if methodname == "isdisjoint":
                 return context.call_py_function(set_disjoint, (instance, args[0]), {})
             if methodname == "issubset":
-                return context.call_py_function(set_subset, (instance, args[0]), {})
+                argType = args[0].expr_type.typeRepresentation
+                argCat = getattr(argType, "__typed_python_category__", None)
+                if argCat in ('Set', 'Dict', 'ConstDict'):  # types that have fast "in" operator
+                    return context.call_py_function(set_subset, (instance, args[0]), {})
+                else:  # generic iterable type
+                    return context.call_py_function(set_subset_iterable, (instance, args[0]), {})
             if methodname == "issuperset":
-                return context.call_py_function(set_subset, (args[0], instance), {})
+                return context.call_py_function(set_superset, (instance, args[0]), {})
 
             if methodname == "add":
                 key = args[0].convert_to_type(self.keyType, explicit=False)
@@ -582,6 +642,23 @@ class SetWrapper(SetWrapperBase):
             runtime_functions.free.call(inst.nonref_expr.cast(native_ast.UInt8Ptr))
         )
 
+    def convert_type_call_on_container_expression(self, context, typeInst, argExpr):
+        if not (argExpr.matches.Set or argExpr.matches.List or argExpr.matches.Tuple):
+            return super().convert_type_call_on_container_expression(context, typeInst, argExpr)
+
+        # we're calling Set(T) with an expression like {1, 2, 3, ...}
+        # TODO: construct directly with unsafe calls, like we do for ListOf and TupleOf
+
+        aSet = self.convert_type_call(context, None, [], {})
+
+        for i in range(len(argExpr.elts)):
+            val = context.convert_expression_ast(argExpr.elts[i])
+            if val is None:
+                return None
+            aSet.convert_method_call("add", (val,), {})
+
+        return aSet
+
     def convert_type_call(self, context, typeInst, args, kwargs):
         if len(args) == 0 and not kwargs:
             return context.push(self, lambda x: x.convert_default_initialize())
@@ -590,6 +667,77 @@ class SetWrapper(SetWrapperBase):
             return args[0].convert_to_type(self, True)
 
         return super().convert_type_call(context, typeInst, args, kwargs)
+
+    def _can_convert_to_type(self, otherType, explicit):
+        convertible = (
+            TupleOrListOfWrapper,
+            typed_python.compiler.type_wrappers.set_wrapper.SetWrapper,
+            DictWrapper,
+            ConstDictWrapper,
+            TupleWrapper  # doesn't have .ElementType, length must match
+        )
+        if explicit and isinstance(otherType, convertible):
+            if isinstance(otherType, TupleWrapper):
+                destEltType = typeWrapper(otherType.unionType)
+            else:
+                destEltType = typeWrapper(otherType.typeRepresentation.ElementType)
+            sourceEltType = typeWrapper(self.typeRepresentation.ElementType)
+
+            ret = sourceEltType.can_convert_to_type(destEltType, True)
+            if isinstance(otherType, TupleWrapper) and ret:
+                return "Maybe"  # since length might not match
+            return ret
+
+        return super()._can_convert_to_type(otherType, explicit)
+
+    def _can_convert_from_type(self, otherType, explicit):
+        convertible = (
+            TupleOrListOfWrapper,
+            typed_python.compiler.type_wrappers.set_wrapper.SetWrapper,
+            DictWrapper,
+            ConstDictWrapper,
+            TupleWrapper  # doesn't have .ElementType
+        )
+        if explicit and isinstance(otherType, convertible):
+            if isinstance(otherType, TupleWrapper):
+                minimum = True
+                destEltType = typeWrapper(self.typeRepresentation.ElementType)
+                for one_src in otherType.typeRepresentation.ElementTypes:
+                    sourceEltType = typeWrapper(one_src)
+                    cvt_one = sourceEltType.can_convert_to_type(destEltType, True)
+                    if cvt_one is False:
+                        return False
+                    if cvt_one == "Maybe":
+                        minimum = "Maybe"
+                return minimum
+            else:
+                sourceEltType = typeWrapper(otherType.typeRepresentation.ElementType)
+            destEltType = typeWrapper(self.typeRepresentation.ElementType)
+
+            return sourceEltType.can_convert_to_type(destEltType, True)
+
+        return super()._can_convert_from_type(otherType, explicit)
+
+    def convert_to_self_with_target(self, context, targetVal, sourceVal, explicit):
+        convertible = (SetWrapper, TupleWrapper, TupleOrListOfWrapper, DictWrapper, ConstDictWrapper)
+        if explicit and isinstance(sourceVal.expr_type, convertible):
+            canConvert = self._can_convert_from_type(sourceVal.expr_type, True)
+
+            if canConvert is False:
+                return context.constant(False)
+
+            res = context.call_py_function(
+                initialize_set_from_other,
+                (targetVal.asPointer(), sourceVal),
+                {}
+            )
+
+            if canConvert is True:
+                return context.constant(True)
+
+            return res
+
+        return super().convert_to_self_with_target(context, targetVal, sourceVal, explicit)
 
     def convert_bool_cast(self, context, expr):
         return context.pushPod(bool, self.convert_len_native(expr.nonref_expr).neq(0))

--- a/typed_python/compiler/type_wrappers/set_wrapper.py
+++ b/typed_python/compiler/type_wrappers/set_wrapper.py
@@ -22,7 +22,7 @@ from typed_python.compiler.type_wrappers.const_dict_wrapper import ConstDictWrap
 from typed_python.compiler.type_wrappers.dict_wrapper import DictWrapper
 from typed_python.compiler.type_wrappers.wrapper import Wrapper
 from typed_python.compiler.type_wrappers.native_hash import table_next_slot, table_clear, \
-    table_contains, table_contains_not, set_add, set_add_or_remove, set_remove, set_discard, set_pop
+    table_contains, set_add, set_add_or_remove, set_remove, set_discard, set_pop
 from typed_python import PointerTo, Int32, UInt8
 
 import typed_python.compiler.native_ast as native_ast
@@ -607,16 +607,12 @@ class SetWrapper(SetWrapperBase):
         return super().convert_bin_op(context, left, op, right, inplace)
 
     def convert_bin_op_reverse(self, context, right, op, left, inplace):
-        if op.matches.In or op.matches.NotIn:
+        if op.matches.In:
             left = left.convert_to_type(self.keyType, False)
             if left is None:
                 return None
 
-            return context.call_py_function(
-                table_contains if op.matches.In else table_contains_not,
-                (right, left),
-                {}
-            )
+            return context.call_py_function(table_contains, (right, left), {})
 
         return super().convert_bin_op_reverse(context, right, op, left, inplace)
 

--- a/typed_python/compiler/type_wrappers/string_wrapper.py
+++ b/typed_python/compiler/type_wrappers/string_wrapper.py
@@ -1,4 +1,4 @@
-#   Copyright 2017-2019 typed_python Authors
+#   Copyright 2017-2020 typed_python Authors
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
@@ -243,8 +243,6 @@ class StringWrapper(RefcountedWrapper):
                     expr.nonref_expr.cast(native_ast.VoidPtr)
                 )
             )
-
-        print(a1, f)
 
         return super().convert_builtin(f, context, expr, a1)
 

--- a/typed_python/compiler/type_wrappers/wrapper.py
+++ b/typed_python/compiler/type_wrappers/wrapper.py
@@ -1,4 +1,4 @@
-#   Copyright 2017-2019 typed_python Authors
+#   Copyright 2017-2020 typed_python Authors
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
@@ -449,7 +449,7 @@ class Wrapper(object):
                 context.markUninitializedSlotInitialized(targetVal)
 
             with ifFalse:
-                context.pushException(TypeError, "Can't convert from type %s to type %s" % (self, target_type))
+                context.pushException(TypeError, f"Can't convert from type {self} to type {target_type}")
 
         return targetVal
 

--- a/typed_python/hash_table_layout.hpp
+++ b/typed_python/hash_table_layout.hpp
@@ -1,5 +1,5 @@
 /******************************************************************************
-   Copyright 2017-2019 typed_python Authors
+   Copyright 2017-2020 typed_python Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -290,6 +290,7 @@ class hash_table_layout {
 
         setTo(hash_table_slots, EMPTY, hash_table_size);
         setTo(hash_table_hashes, EMPTY, hash_table_size);
+        std::memset(items_populated, 0, items_reserved);
     }
 
     template <class copy_constructor_type>

--- a/typed_python/util.hpp
+++ b/typed_python/util.hpp
@@ -1,5 +1,5 @@
 /******************************************************************************
-   Copyright 2017-2019 typed_python Authors
+   Copyright 2017-2020 typed_python Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -284,7 +284,7 @@ void iterate(PyObject* o, func_type f) {
 /********
 Iterate over 'o' calling 'f' with each PyObject encountered.
 
-if 'f' return false, exit eraly.
+if 'f' return false, exit early.
 
 May throw, so use in conjunction with 'translateExceptionToPyObject'
 ********/


### PR DESCRIPTION



<!-- Provide a general summary of your changes in the Title above -->

## Motivation and Context
* Discovered various bugs in the first implementation of Set methods, and especially with conversions and Set method arguments that could be iterables.
<!-- Why is this change required? -->
<!-- What problem does it solve? -->
<!--  If it fixes an open issue, please link to the issue here.-->

## Approach
* Fixed bugs for interpreted Set operations and for compiled Set operations.
* Made exceptions more consistent: when conversion fails, produce same exception in interpreted and compiled code.
* Fix involving iterables, and error conditions
* Handle element type conversion exceptions for all Set methods.
* Fix Set.clear().  
<!-- Describe your changes in reasonable detail -->

## How Has This Been Tested?
* Interesting test case: the various "update" methods on sets can take sequences or iterables
* Consider sequences with duplicate elements (this breaks some algorithms that would work on sets)
* Consider iterables with duplicate elements
* Consider iterables that do not support the 'in' operator.
<!-- Describe in reasonable detail how you tested your changes. -->
<!-- If appropriate, include details of your testing environment, -->
<!-- tests ran to see how your change affects other areas of the code, etc. -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.