### PR TITLE
Produce a useful error when we fail to deserialize a name

### DIFF
--- a/typed_python/PythonSerializationContext.cpp
+++ b/typed_python/PythonSerializationContext.cpp
@@ -513,6 +513,9 @@ PyObject* PythonSerializationContext::deserializePythonObjectFromName(Deserializ
     if (!result) {
         throw PythonExceptionSet();
     }
+    if (result == Py_None){
+        throw std::runtime_error("Failed to deserialize Type '" + name + "'");
+    }
 
     if (memo != -1) {
         b.addCachedPyObj(memo, incref(result));


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Motivation and Context
Produce a useful error when we fail to deserialize a name. Previously we would get:
```
TypeError: Expected a type object. Got NoneType instead
```

## Approach
Check the return value of the `objectFromName` call, and if it's `None` raise an exception:
```
TypeError: Failed to deserialize Type '<type_name>'
```
