### PR TITLE
Compile list, set, and dict comprehensions.  Refs #287, 342, 344.

### DIFF
--- a/typed_python/PyDictInstance.hpp
+++ b/typed_python/PyDictInstance.hpp
@@ -56,6 +56,8 @@ public:
 
     static PyObject* dictClear(PyObject* o);
 
+    static PyObject* dictCopy(PyObject* o, PyObject* args);
+
     static PyMethodDef* typeMethodsConcrete(Type* t);
 
     static void mirrorTypeInformationIntoPyTypeConcrete(DictType* dictT, PyTypeObject* pyType);

--- a/typed_python/StringType.cpp
+++ b/typed_python/StringType.cpp
@@ -550,6 +550,30 @@ uint32_t StringType::getord(layout* lhs) {
     return 0;
 }
 
+
+StringType::layout* StringType::mult(layout* lhs, int64_t rhs) {
+    if (!lhs) {
+        return lhs;
+    }
+    if (rhs <= 0)
+        return 0;
+    int64_t new_length = lhs->pointcount * rhs;
+    int64_t new_byteCount = sizeof(layout) + new_length * lhs->bytes_per_codepoint;
+
+    layout* new_layout = (layout*)malloc(new_byteCount);
+    new_layout->refcount = 1;
+    new_layout->hash_cache = -1;
+    new_layout->bytes_per_codepoint = lhs->bytes_per_codepoint;
+    new_layout->pointcount = new_length;
+
+    int64_t old_size = lhs->pointcount * lhs->bytes_per_codepoint;
+    for (size_t i = 0; i < rhs; i++) {
+        memcpy(new_layout->data + i * old_size, lhs->data, old_size);
+    }
+
+    return new_layout;
+}
+
 StringType::layout* StringType::getitem(layout* lhs, int64_t offset) {
     if (!lhs) {
         return lhs;

--- a/typed_python/StringType.hpp
+++ b/typed_python/StringType.hpp
@@ -98,6 +98,8 @@ public:
     //return an increffed string containing the data from the utf-encoded string
     static layout* createFromUtf8(const char* utfEncodedString, int64_t len);
 
+    static layout* mult(layout* lhs, int64_t rhs);
+
     bool isBinaryCompatibleWithConcrete(Type* other) {
         if (other->getTypeCategory() != m_typeCategory) {
             return false;

--- a/typed_python/_runtime.cpp
+++ b/typed_python/_runtime.cpp
@@ -579,6 +579,10 @@ extern "C" {
         return StringType::getitem(lhs, index);
     }
 
+    StringType::layout* nativepython_runtime_string_mult(StringType::layout* lhs, int64_t rhs) {
+        return StringType::mult(lhs, rhs);
+    }
+
     StringType::layout* nativepython_runtime_string_chr(int64_t code) {
         if (code < 0 || code > 0x10ffff) {
             PyEnsureGilAcquired getTheGil;
@@ -2014,7 +2018,7 @@ extern "C" {
      PyIter_Next returns NULL if there are no remaining items, but can also throw an exception.
 
      This function retains the convention that upon exhausting the container we return 'nullptr',
-     but raises the exception if its present.
+     but raises the exception if it's present.
     ******/
     PythonObjectOfType::layout_type* np_pyobj_iter_next(PythonObjectOfType::layout_type* toIterate) {
         PyEnsureGilAcquired getTheGil;

--- a/typed_python/compiler/python_ast_util.py
+++ b/typed_python/compiler/python_ast_util.py
@@ -1,4 +1,4 @@
-#   Copyright 2017-2019 typed_python Authors
+#   Copyright 2017-2020 typed_python Authors
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
@@ -71,7 +71,7 @@ def pyAstForCode(codeObject):
     if len(defs) == 0:
         raise Exception(
             f"Error: can't convert {codeObject} back to code because when we"
-            f" look, there are no defs or lambas at "
+            f" look, there are no defs or lambdas at "
             f"{codeObject.co_filename}:{codeObject.co_firstlineno}"
         )
 

--- a/typed_python/compiler/tests/dict_compilation_test.py
+++ b/typed_python/compiler/tests/dict_compilation_test.py
@@ -690,3 +690,45 @@ class TestDictCompilation(unittest.TestCase):
         self.assertEqual(dict_assign_and_modify_original(d, 'q', 'b'), {'a': 1, 'c': 5, 'q': 7})
         d = Dict(str, int)({'a': 1, 'b': 3, 'c': 5})
         self.assertEqual(dict_copy_and_modify_original(d, 'q', 'b'), {'a': 1, 'b': 3, 'c': 5})
+
+    def test_dict_setitem_mm(self):
+        def f(d, k, v):
+            d1 = d.copy()
+            d1.__setitem__(k, v)
+            return d1
+
+        d = Dict(int, str)({2: "z", 3: "y"})
+        k = 4
+        v = "hello"
+        r1 = f(d, k, v)
+        r2 = Entrypoint(f)(d, k, v)
+        self.assertEqual(r1, r2)
+
+    def test_dict_comprehensions(self):
+        def f1(i):
+            return {x: x+1 for x in i}
+
+        def f2(i, k):
+            return {2*x: 2*x+1 for x in i if x % k}
+
+        def f3(i, k):
+            return {10*x: 0.1*x for x in i if x % k if x % 5}
+
+        def f4(i, k):
+            return {x*7+y: (x, y) for x in i for y in range(7) if x % k if y % (x + 2)}
+
+        def f5(i, k):
+            return {x*7+y: (x, y) for x in i if x % k for y in range(7) if y % (x + 2)}
+
+        for i in [range(10), range(100), []]:
+            r1 = f1(i)
+            r2 = Entrypoint(f1)(i)
+            self.assertTrue(type(r2) is dict)
+            self.assertEqual(r1, r2)
+
+            for f in [f2, f3, f4, f5]:
+                for k in [1, 2, 3]:
+                    r1 = f(i, k)
+                    r2 = Entrypoint(f)(i, k)
+                    self.assertTrue(type(r2) is dict)
+                    self.assertEqual(r1, r2)

--- a/typed_python/compiler/tests/set_compilation_test.py
+++ b/typed_python/compiler/tests/set_compilation_test.py
@@ -1061,3 +1061,35 @@ class TestSetCompilation(unittest.TestCase):
             f_set_t({t1, t2, t4})
         with self.assertRaises(TypeError):
             Entrypoint(f_set_t)({t1, t2, t4})
+
+    def test_set_comprehensions(self):
+        def f1(s):
+            return {x for x in s}
+
+        def f2(s, k):
+            return {x * 2 + 1 for x in s if x % k}
+
+        def f3(s, k):
+            return {0.01 * x for x in s if x % k if x % 5}
+
+        def f4(s, k):
+            return {(x, y) for x in s for y in range(7) if x % k if y % (x+2)}
+
+        def f5(s, k):
+            return {(x, y) for x in s if x % k for y in range(7) if y % (x+2)}
+
+        def f6(s, k):
+            return {Tuple(int, int)((x, y)) for x in s if x % k for y in range(7) if y % (x+2)}
+
+        for s in [range(10), range(100), set()]:
+            r1 = f1(s)
+            r2 = Entrypoint(f1)(s)
+            self.assertTrue(type(r2) is set)
+            self.assertEqual(r1, r2)
+
+            for f in [f2, f3, f4, f5, f6]:
+                for k in [1, 2, 3]:
+                    r1 = f(s, k)
+                    r2 = Entrypoint(f)(s, k)
+                    self.assertTrue(type(r2) is set)
+                    self.assertEqual(r1, r2)

--- a/typed_python/compiler/tests/string_compilation_test.py
+++ b/typed_python/compiler/tests/string_compilation_test.py
@@ -760,3 +760,38 @@ class TestStringCompilation(unittest.TestCase):
             return x["bd"]
 
         doIt({'bd': 'yes'})
+
+    def test_string_iteration(self):
+        def iter(x: str):
+            r = ListOf(str)()
+            for a in x:
+                r.append(a)
+            return r
+
+        def iter_constant():
+            r = ListOf(str)()
+            for a in "constant":
+                r.append(a)
+            return r
+
+        def contains_space(x: str):
+            for c in x:
+                if c == ' ':
+                    return True
+            return False
+
+        r1 = iter_constant()
+        r2 = Compiled(iter_constant)()
+        self.assertEqual(type(r1), type(r2))
+        self.assertEqual(r1, r2)
+
+        for v in ['whatever', 'o', '']:
+            r1 = iter(v)
+            r2 = Compiled(iter)(v)
+            self.assertEqual(type(r1), type(r2))
+            self.assertEqual(r1, r2)
+
+        for v in ['', 'a', ' ', 'abc ', 'x'*1000+' '+'x'*1000, 'y'*1000]:
+            r1 = contains_space(v)
+            r2 = Compiled(contains_space)(v)
+            self.assertEqual(r1, r2)

--- a/typed_python/compiler/type_wrappers/dict_wrapper.py
+++ b/typed_python/compiler/type_wrappers/dict_wrapper.py
@@ -132,7 +132,7 @@ class DictWrapper(DictWrapperBase):
                 "initializeValueByIndexUnsafe", "assignValueByIndexUnsafe",
                 "initializeKeyByIndexUnsafe", "_allocateNewSlotUnsafe", "_resizeTableUnsafe",
                 "_top_item_slot", "_compressItemTableUnsafe", "get", "items", "keys", "values", "setdefault",
-                "pop", "clear", "copy", "update"):
+                "pop", "clear", "copy", "update", "__setitem__"):
             return expr.changeType(BoundMethodWrapper.Make(self, attr))
 
         if attr == '_items_populated':
@@ -304,6 +304,10 @@ class DictWrapper(DictWrapperBase):
         if methodname == "update":
             if len(args) == 1:
                 return context.call_py_function(dict_update, (instance, args[0]), {})
+
+        if methodname == "__setitem__":
+            if len(args) == 2:
+                return context.call_py_function(dict_setitem, (instance, args[0], args[1]), {})
 
         if len(args) == 1:
             if methodname == "get":
@@ -645,3 +649,27 @@ class DictValuesIteratorWrapper(DictIteratorWrapper):
             (ixExpr,),
             {}
         )
+
+
+class MasqueradingDictWrapper(DictWrapper):
+    # A 'Dict' that's masquerading as a regular 'dict'
+    def __str__(self):
+        return "Masquerading" + super().__str__()
+
+    @property
+    def interpreterTypeRepresentation(self):
+        return dict
+
+    def convert_mutable_masquerade_to_untyped_type(self):
+        return typeWrapper(dict)
+
+    def convert_mutable_masquerade_to_untyped(self, context, instance):
+        return context.constant(dict).convert_call([instance], {}).changeType(
+            typeWrapper(dict)
+        )
+
+    def convert_to_type_with_target(self, context, e, targetVal, explicit):
+        # Allow the typed form of the object to perform the conversion
+        e = e.changeType(typeWrapper(self.typeRepresentation))
+
+        return e.convert_to_type_with_target(targetVal, explicit)

--- a/typed_python/compiler/type_wrappers/list_of_wrapper.py
+++ b/typed_python/compiler/type_wrappers/list_of_wrapper.py
@@ -529,3 +529,6 @@ class MasqueradingListOfWrapper(ListOfWrapper):
         e = e.changeType(typeWrapper(self.typeRepresentation))
 
         return e.convert_to_type_with_target(targetVal, explicit)
+
+    def get_iteration_elt_wrapper(self):
+        return self.underlyingWrapperType

--- a/typed_python/compiler/type_wrappers/range_wrapper.py
+++ b/typed_python/compiler/type_wrappers/range_wrapper.py
@@ -13,6 +13,7 @@
 #   limitations under the License.
 
 from typed_python.compiler.type_wrappers.wrapper import Wrapper
+from typed_python.compiler.type_wrappers.arithmetic_wrapper import IntWrapper
 import typed_python.compiler.native_ast as native_ast
 
 
@@ -81,6 +82,9 @@ class RangeInstanceWrapper(Wrapper):
                     instance.expr.store(expr.nonref_expr)
             )
         return super().convert_method_call(context, expr, methodname, args, kwargs)
+
+    def get_iteration_elt_wrapper(self):
+        return IntWrapper(int)
 
 
 class RangeIteratorWrapper(Wrapper):

--- a/typed_python/compiler/type_wrappers/runtime_functions.py
+++ b/typed_python/compiler/type_wrappers/runtime_functions.py
@@ -515,6 +515,12 @@ string_getitem_int64 = externalCallTarget(
     Void.pointer(), Int64
 )
 
+string_mult = externalCallTarget(
+    "nativepython_runtime_string_mult",
+    Void.pointer(),
+    Void.pointer(), Int64
+)
+
 string_from_utf8_and_len = externalCallTarget(
     "nativepython_runtime_string_from_utf8_and_len",
     Void.pointer(),

--- a/typed_python/compiler/type_wrappers/set_wrapper.py
+++ b/typed_python/compiler/type_wrappers/set_wrapper.py
@@ -827,6 +827,9 @@ class SetIteratorWrapper(Wrapper):
     def convert_destroy(self, context, expr):
         self.refAs(context, expr, 1).convert_destroy()
 
+    def get_iteration_elt_wrapper(self):
+        return self.keyType
+
 
 class SetKeysIteratorWrapper(SetIteratorWrapper):
     def __init__(self, setType):
@@ -840,3 +843,27 @@ class SetKeysIteratorWrapper(SetIteratorWrapper):
             (ixExpr,),
             {}
         )
+
+
+class MasqueradingSetWrapper(SetWrapper):
+    # A 'Set' that's masquerading as a regular 'set'
+    def __str__(self):
+        return "Masquerading" + super().__str__()
+
+    @property
+    def interpreterTypeRepresentation(self):
+        return set
+
+    def convert_mutable_masquerade_to_untyped_type(self):
+        return typeWrapper(set)
+
+    def convert_mutable_masquerade_to_untyped(self, context, instance):
+        return context.constant(set).convert_call([instance], {}).changeType(
+            typeWrapper(set)
+        )
+
+    def convert_to_type_with_target(self, context, e, targetVal, explicit):
+        # Allow the typed form of the object to perform the conversion
+        e = e.changeType(typeWrapper(self.typeRepresentation))
+
+        return e.convert_to_type_with_target(targetVal, explicit)

--- a/typed_python/compiler/type_wrappers/string_wrapper.py
+++ b/typed_python/compiler/type_wrappers/string_wrapper.py
@@ -14,6 +14,7 @@
 
 from typed_python import sha_hash
 from typed_python.compiler.global_variable_definition import GlobalVariableMetadata
+from typed_python.compiler.type_wrappers.wrapper import Wrapper
 from typed_python.compiler.type_wrappers.refcounted_wrapper import RefcountedWrapper
 from typed_python import Int32, Float32
 from typed_python.type_promotion import isInteger
@@ -136,6 +137,20 @@ class StringWrapper(RefcountedWrapper):
         return False
 
     def convert_bin_op(self, context, left, op, right, inplace):
+        if op.matches.Mult and isInteger(right.expr_type.typeRepresentation):
+            if left.isConstant and right.isConstant:
+                return context.constant(left.constantValue * right.constantValue)
+
+            return context.push(
+                str,
+                lambda strRef: strRef.expr.store(
+                    runtime_functions.string_mult.call(
+                        left.nonref_expr.cast(VoidPtr),
+                        right.nonref_expr
+                    ).cast(self.layoutType)
+                )
+            )
+
         if right.expr_type == left.expr_type:
             if op.matches.Eq or op.matches.NotEq or op.matches.Lt or op.matches.LtE or op.matches.GtE or op.matches.Gt:
                 if op.matches.Eq:
@@ -312,6 +327,16 @@ class StringWrapper(RefcountedWrapper):
             )
         )
 
+    def convert_getitem_unsafe(self, context, expr, item):
+        return context.push(
+            str,
+            lambda strRef: strRef.expr.store(
+                runtime_functions.string_getitem_int64.call(
+                    expr.nonref_expr.cast(native_ast.VoidPtr), item.nonref_expr
+                ).cast(self.layoutType)
+            )
+        )
+
     def convert_len_native(self, expr):
         return native_ast.Expression.Branch(
             cond=expr,
@@ -370,12 +395,26 @@ class StringWrapper(RefcountedWrapper):
         return super().convert_attribute(context, instance, attr)
 
     def convert_method_call(self, context, instance, methodname, args, kwargs):
-        if not (methodname in ("find", "split", "join", 'strip', 'rstrip', 'lstrip', "startswith", "endswith", "replace")
+        if not (methodname in ("find", "split", "join", 'strip', 'rstrip', 'lstrip', "startswith", "endswith", "replace", "__iter__")
                 or methodname in self._str_methods or methodname in self._bool_methods):
             return context.pushException(AttributeError, methodname)
 
         if kwargs:
             return super().convert_method_call(context, instance, methodname, args, kwargs)
+
+        if methodname == "__iter__" and not args and not kwargs:
+            res = context.push(
+                _StringIteratorWrapper,
+                lambda instance:
+                instance.expr.ElementPtrIntegers(0, 0).store(-1)
+            )
+
+            context.pushReference(
+                self,
+                res.expr.ElementPtrIntegers(0, 1)
+            ).convert_copy_initialize(instance)
+
+            return res
 
         if methodname in ['strip', 'lstrip', 'rstrip']:
             fromLeft = methodname in ['strip', 'lstrip']
@@ -583,3 +622,79 @@ class StringWrapper(RefcountedWrapper):
                 return context.pushException(type(e), *e.args)
 
         return context.pushPod(float, runtime_functions.str_to_float64.call(expr.nonref_expr.cast(VoidPtr)))
+
+    def get_iteration_elt_wrapper(self):
+        return typeWrapper(str)
+
+    def get_iteration_expressions(self, context, expr):
+        if expr.isConstant:
+            return [context.constant(expr.constantValue[i]) for i in range(len(expr.constantValue))]
+        else:
+            return None
+
+
+class StringIteratorWrapper(Wrapper):
+    is_pod = False
+    is_empty = False
+    is_pass_by_ref = True
+
+    def __init__(self):
+        super().__init__((str, "iterator"))
+
+    def getNativeLayoutType(self):
+        return native_ast.Type.Struct(
+            element_types=(("pos", native_ast.Int64), ("str", typeWrapper(str).getNativeLayoutType())),
+            name="tuple_or_list_iterator"
+        )
+
+    def convert_next(self, context, inst):
+        context.pushEffect(
+            inst.expr.ElementPtrIntegers(0, 0).store(
+                inst.expr.ElementPtrIntegers(0, 0).load().add(1)
+            )
+        )
+        self_len = self.refAs(context, inst, 1).convert_len()
+        canContinue = context.pushPod(
+            bool,
+            inst.expr.ElementPtrIntegers(0, 0).load().lt(self_len.nonref_expr)
+        )
+
+        nextIx = context.pushReference(int, inst.expr.ElementPtrIntegers(0, 0))
+        return self.iteratedItemForReference(context, inst, nextIx), canContinue
+
+    def refAs(self, context, expr, which):
+        assert expr.expr_type == self
+
+        if which == 0:
+            return context.pushReference(int, expr.expr.ElementPtrIntegers(0, 0))
+
+        if which == 1:
+            return context.pushReference(
+                str,
+                expr.expr
+                    .ElementPtrIntegers(0, 1)
+                    .cast(typeWrapper(str).getNativeLayoutType().pointer())
+            )
+
+    def iteratedItemForReference(self, context, expr, ixExpr):
+        return typeWrapper(typeWrapper(str)).convert_getitem_unsafe(
+            context,
+            self.refAs(context, expr, 1),
+            ixExpr
+        ).heldToRef()
+
+    def convert_assign(self, context, expr, other):
+        assert expr.isReference
+
+        for i in range(2):
+            self.refAs(context, expr, i).convert_assign(self.refAs(context, other, i))
+
+    def convert_copy_initialize(self, context, expr, other):
+        for i in range(2):
+            self.refAs(context, expr, i).convert_copy_initialize(self.refAs(context, other, i))
+
+    def convert_destroy(self, context, expr):
+        self.refAs(context, expr, 1).convert_destroy()
+
+
+_StringIteratorWrapper = StringIteratorWrapper()

--- a/typed_python/compiler/type_wrappers/tuple_of_wrapper.py
+++ b/typed_python/compiler/type_wrappers/tuple_of_wrapper.py
@@ -509,6 +509,9 @@ class TupleOrListOfWrapper(RefcountedWrapper):
     def convert_bool_cast(self, context, expr):
         return context.pushPod(bool, self.convert_len_native(expr.nonref_expr).neq(0))
 
+    def get_iteration_elt_wrapper(self):
+        return self.underlyingWrapperType
+
 
 class TupleOrListOfIteratorWrapper(Wrapper):
     is_pod = False

--- a/typed_python/compiler/type_wrappers/wrapper.py
+++ b/typed_python/compiler/type_wrappers/wrapper.py
@@ -603,6 +603,13 @@ class Wrapper(object):
         """
         return None
 
+    def get_iteration_elt_wrapper(self):
+        """Return the wrapper of the elements of this type.
+        By 'elements' I mean the objects you would get if you iterated this type.
+        e.g. typeWrapper(ListOf(T)).get_iteration_elt_wrapper()) = typeWrapper(T)
+        """
+        return None
+
     def convert_context_manager_enter(self, context, instance):
         return instance.convert_method_call("__enter__", (), {})
 

--- a/typed_python/types_test.py
+++ b/typed_python/types_test.py
@@ -863,6 +863,21 @@ class NativeTypesTests(unittest.TestCase):
             d["1"] = "1"
             self.assertTrue("1" in d)
 
+    def test_dict_copy(self):
+        T = Dict(str, Tuple(int, str))
+
+        d = T({chr(i): (i, chr(i+1)) for i in range(96, 128)})
+        self.assertEqual(d['a'], (97, 'b'))
+        d1 = d.copy()
+        self.assertEqual(d1['a'], (97, 'b'))
+        d['a'] = (0, 'x')
+        d['A'] = (65, 'B')
+        self.assertEqual(d['a'], (0, 'x'))
+        self.assertEqual(d['A'], (65, 'B'))
+        self.assertEqual(d1['a'], (97, 'b'))
+        with self.assertRaises(KeyError):
+            d1['A']
+
     def test_deserialize_primitive(self):
         x = deserialize(str, serialize(str, "a"))
         self.assertTrue(isinstance(x, str))


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Motivation and Context
This was missing functionality.
Please note: nested comprehensions are not supported yet.
Please note: This PR is built on top of PR #341 (i.e. it includes all the changes of PR #341)

## Approach
Comprehensions are compiled by transforming the ast into a form that uses more elementary operations, which are then compiled as usual.  This transform requires knowing the element type of an iterator, so some out-of-band (not via compilation) determination of the element type was implemented in the wrapper.  For example, code was added so that we know if we iterate over:
* a ListOf(T), we get a T.
* a PythonObjectOfType(range), we get an int.
* etc.

The type of a comprehension is a ListOf, Set, or Dict, masqueraded to list, set, or dict, respectively.

Along the way, some fixes were done to Dict operations (Refs #344), and to str operations (Refs #342).
Also, str*int multiplication is now compilable.
These changes made some test cases easier to write.

## How Has This Been Tested?
* multiple iterators are supported
* multiple conditions are supported
* different expression types
* result type is just 'list', 'set', or 'dict'

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.