### PR TITLE
Brax memleak

### DIFF
--- a/typed_python/FunctionType.hpp
+++ b/typed_python/FunctionType.hpp
@@ -506,6 +506,13 @@ public:
             return mArgTypes;
         }
 
+        bool operator==(const CompiledSpecialization& other) const {
+            return mFuncPtr == other.mFuncPtr
+                && mReturnType == other.mReturnType
+                && mArgTypes == other.mArgTypes
+                ;
+        }
+
     private:
         compiled_code_entrypoint mFuncPtr;
         Type* mReturnType;
@@ -747,7 +754,15 @@ public:
         }
 
         void addCompiledSpecialization(compiled_code_entrypoint e, Type* returnType, const std::vector<Type*>& argTypes) {
-            mCompiledSpecializations.push_back(CompiledSpecialization(e,returnType,argTypes));
+            CompiledSpecialization newSpec = CompiledSpecialization(e,returnType,argTypes);
+
+            for (auto& spec: mCompiledSpecializations) {
+                if (spec == newSpec) {
+                    return;
+                }
+            }
+
+            mCompiledSpecializations.push_back(newSpec);
         }
 
         void touchCompiledSpecializations() {

--- a/typed_python/TypedClosureBuilder.hpp
+++ b/typed_python/TypedClosureBuilder.hpp
@@ -89,6 +89,10 @@ public:
 
             Function* funcType = PyFunctionInstance::convertPythonObjectToFunctionType(name, o, false, true);
 
+            if (!funcType) {
+                throw PythonExceptionSet();
+            }
+
             Instance funcAsInstance = Instance::createAndInitialize(
                 funcType,
                 [&](instance_ptr ptr) {
@@ -96,7 +100,7 @@ public:
                 }
             );
 
-            result.set(PyInstance::extractPythonObject(funcAsInstance));
+            result.steal(PyInstance::extractPythonObject(funcAsInstance));
         }
 
         return result;

--- a/typed_python/compiler/runtime.py
+++ b/typed_python/compiler/runtime.py
@@ -323,7 +323,6 @@ def NotCompiled(pyFunc, returnTypeOverride=None):
     pyFunc = Function(
         pyFunc,
         returnTypeOverride=returnTypeOverride,
-        assumeClosuresGlobal=True
     ).withNocompile(True)
 
     return pyFunc

--- a/typed_python/compiler/type_wrappers/runtime_functions.py
+++ b/typed_python/compiler/type_wrappers/runtime_functions.py
@@ -355,6 +355,13 @@ call_pyobj = externalCallTarget(
     varargs=True
 )
 
+call_func_as_pyobj = externalCallTarget(
+    "nativepython_runtime_call_func_as_pyobj",
+    Void.pointer(),
+    Void.pointer(),
+    varargs=True
+)
+
 get_pyobj_None = externalCallTarget(
     "nativepython_runtime_get_pyobj_None",
     Void.pointer()


### PR DESCRIPTION
Braxton wrote that code by I'm writing the PR 

## Motivation and Context
Compiling closures was leaking memory.

## Approach
A few different memory leaks were fixed. 

For closures, before adding a compiled function specialization, we check if we already had it in the set of compiled specializations. 

## How Has This Been Tested?
Added unit tests and also the bespoke examples in our application code that were leaking memory are no longer leaking.
