### PR TITLE
wrote Macro

### DIFF
--- a/typed_python/macro.py
+++ b/typed_python/macro.py
@@ -1,0 +1,194 @@
+import threading
+
+from typed_python.type_function import ConcreteTypeFunction
+from typed_python.compiler.python_ast_util import _linesCache
+
+from keyword import iskeyword
+
+_fileNameLock = threading.RLock()
+
+
+class MacroFormatError(Exception):
+    pass
+
+
+class MacroNameError(NameError):
+    pass
+
+
+def isValidVariableName(string):
+    return isinstance(string, str) and string.isidentifier() and not iskeyword(string)
+
+
+def checkFormat(constructor):
+    keyFormat = True
+    if not isinstance(constructor, dict):
+        keyFormat = False
+    elif len(constructor) != 2:
+        keyFormat = False
+    elif "sourceText" not in constructor:
+        keyFormat = False
+    elif "locals" not in constructor:
+        keyFormat = False
+    if not keyFormat:
+        raise MacroFormatError(
+            "A macro function must return a dict with keys 'sourceText' and 'locals'"
+            " and no other keys"
+        )
+
+    textFormat = True
+    sourceText = constructor["sourceText"]
+    if not isinstance(sourceText, list):
+        textFormat = False
+    else:
+        if not len(sourceText):
+            textFormat = False
+        else:
+            returnLine = sourceText[-1]
+            if not returnLine[:7] == "return ":
+                textFormat = False
+        for line in sourceText:
+            if not isinstance(line, str):
+                textFormat = False
+    if not textFormat:
+        raise MacroFormatError(
+            "The sourceText returned by a macro function must be a list of strings, the"
+            " last being equal to f\"return {X}\" for some string X"
+        )
+
+    namespaceFormat = True
+    namespace = constructor["locals"]
+    if not isinstance(namespace, dict):
+        namespaceFormat = False
+    else:
+        for key, value in namespace.items():
+            if not isValidVariableName(key):
+                namespaceFormat = False
+    if not namespaceFormat:
+        raise MacroFormatError(
+            "The locals returned by a macro function must be a dict from valid variable "
+            "names to accessible variables"
+        )
+
+
+def getSourceText(constructor):
+    sourceText = constructor["sourceText"]
+    return [sourceText[i] + "\n" for i in range(len(sourceText) - 1)]
+
+
+def getReturnName(constructor):
+    return constructor["sourceText"][-1][7:]
+
+
+def getNamespace(constructor):
+    return constructor["locals"]
+
+
+class ConcreteMacro(ConcreteTypeFunction):
+    def __init__(self, concreteMacro):
+        self.count = 0
+        self.concreteMacro = concreteMacro
+
+        concreteTypeFunction = self.getConcreteTypeFunction()
+        super().__init__(concreteTypeFunction)
+
+    def getConcreteTypeFunction(self):
+        def concreteTypeFunction(*args, **kwargs):
+            constructor = self.concreteMacro(*args, **kwargs)
+            checkFormat(constructor)
+            sourceText = getSourceText(constructor)
+            returnName = getReturnName(constructor)
+            namespace = getNamespace(constructor)
+
+            with _fileNameLock:
+                filename = (
+                    "macro stash at"
+                    + self.concreteMacro.__code__.co_filename
+                    + ", line "
+                    + str(self.concreteMacro.__code__.co_firstlineno)
+                    + ", unique call number "
+                    + str(self.count)
+                )
+                self.count += 1
+
+            code = compile("".join(sourceText), filename, "exec")
+
+            if code.co_filename in _linesCache:
+                raise Exception(
+                    f"Filename collision on {code.co_filename}, review the macro code naming "
+                    + "logic"
+                )
+            _linesCache[code.co_filename] = sourceText
+
+            fake_globals = dict(self.concreteMacro.__globals__)
+            fake_globals.update(namespace)
+
+            try:
+                exec(code, fake_globals)
+            except NameError as e:
+                msg = e.args[0]
+                msg = msg.split(" ")
+                varname = msg[1]
+                varname = varname[1: len(varname) - 1]
+                assert varname not in fake_globals
+                raise MacroNameError(
+                    f"Macro source text contains {varname} but it's not in the namespace"
+                )
+            try:
+                return fake_globals[returnName]
+            except KeyError as e:
+                assert e.args[0] == returnName
+                raise MacroNameError(
+                    f"Macro source text tries to return {returnName} but does not define it"
+                )
+
+        return concreteTypeFunction
+
+
+def Macro(f):
+    """Decorate 'f' to be a 'Macro'.
+
+    Like a 'TypeFunction', a 'Macro' takes a set of hashable arguments and produces a type
+    object, and the result is memoized so that code in 'f' is executed only once for each
+    distinct set of arguments.
+
+    Unlike 'TypeFunction', the output of a call to 'f' is *not* the same as the output of a
+    call to 'Macro(f)'. Instead, the output of a call to 'f' is a dictionary which provides
+    string-based instructions for how to construct a type, and this type will be the output
+    of a call to 'Macro(f)'.
+
+    The format for the output of a call to 'f' is a dict with two keys, 'sourceText' and
+    'locals', and corresponding values:
+
+        'sourceText' --> a list of strings to be read as lines of source code
+        'locals' --> a dict from variable names appearing in the source text to non-global
+                variables in the namespace of f
+
+    Responsibility for getting this right is on the user.
+
+    Example:
+
+    @Macro
+    def f(T):
+        names = T.ElementNames
+
+        sourceText = []
+        sourceText.append("@Entrypoint")
+        sourceText.append("def f(x):")
+        sourceText.append("    return T(")
+        for name in names:
+            sourceText.append(f"        {name}=x.{name},")
+        sourceText.append("    )")
+        sourceText.append("f_t = type(f)")
+        sourceText.append("return f_t")
+
+        return {
+            'sourceText': sourceText,
+            'locals': {"T": T},
+        }
+
+    The 'locals' field isn't restricted to input names to 'f', it can also contain variables
+    defined in the body of f or in the scope where f is defined.
+    """
+
+    return ConcreteMacro(f)

--- a/typed_python/macro_test.py
+++ b/typed_python/macro_test.py
@@ -1,0 +1,237 @@
+from typed_python.macro import Macro
+from typed_python import TypeFunction, ListOf, Entrypoint
+from typed_python import Class, NamedTuple, Member, makeNamedTuple  # noqa: F401
+
+from typed_python.compiler.runtime import PrintNewFunctionVisitor
+
+import unittest
+
+
+class TestMacro(unittest.TestCase):
+    def test_main(self):
+        @Macro
+        def A(T):
+            output = ["class R(Class):"]
+            output.append("    x = Member(T)")
+            if T is int:
+                output.append("    def do(self) -> str:")
+                output.append("        return 'boom.'")
+            else:
+                output.append("    pass")
+            output.append("return R")
+            return {
+                "sourceText": output,
+                "locals": {"T": T},
+            }
+
+        self.assertEqual(A(int)().do(), "boom.")
+        with self.assertRaises(AttributeError):
+            A(float)().do()
+
+        self.assertIs(A(int), A(int))
+        self.assertIs(A(A(str)), A(A(str)))
+        self.assertFalse(A(str) is A(A(str)))
+        self.assertFalse(A(str) is A(float))
+
+    def test_more(self):
+        @TypeFunction
+        def F(S, T):
+            class A:
+                pass
+            return A
+
+        @Macro
+        def G(S, T):
+            output = []
+            output.append("R = F(S, T)")
+            output.append("return R")
+            return {
+                "sourceText": output,
+                "locals": {"S": S, "T": T, "F": F},
+            }
+
+        self.assertEqual(G(int, float), F(int, float))
+
+        @Macro
+        def H(S, T):
+            output = []
+            output.append("R = F(S, T)")
+            output.append("return R")
+            return {
+                "sourceText": output,
+                "locals": {"S": S, "T": T},
+            }
+
+        with self.assertRaises(NameError):
+            H(int, float)
+
+    def test_another(self):
+        @Macro
+        def A(S, T):
+            positions = []
+            for name in T.ElementNames:
+                assert name in S.ElementNames
+                positions.append(S.ElementNames.index(name))
+
+            output = []
+            output.append("class X(Class):")
+            output.append("    s = Member(S)")
+            output.append("    def __init__(self, s):")
+            output.append("        self.s = s")
+            output.append("    def do(self) -> None:")
+            for position in positions:
+                output.append(f"        print(self.s[{position}])")
+            output.append("return X")
+
+            return {
+                "sourceText": output,
+                "locals": {"S": S, "T": T},
+            }
+
+        a = A(NamedTuple(x=int, y=float), NamedTuple(y=str))
+        a = A(NamedTuple(x=int, y=float), NamedTuple(y=str))(makeNamedTuple(x=3, y=4.0))
+        print(a)
+        print(a.do())
+
+    def test_lazy_named_tuple_row(self):
+        @Macro
+        def lazyWindow(T):
+            output = []
+            output.append(f"class X(Class, __name__='LazyWindow({T.__name__})'):")
+            output.append("    table = Member(T)")
+            output.append("    window = Member(int)")
+            output.append("    def __init__(self, table, window=0):")
+            output.append("        self.table = table")
+            output.append("        self.window = window")
+            for i in range(len(T.ElementNames)):
+                output.append("    @Entrypoint")
+                output.append(f"    def {T.ElementNames[i]}(self) -> T.ElementTypes[{i}].ElementType:")
+                output.append(f"        return self.table[{i}][self.window]")
+            output.append("return X")
+
+            return {
+                "sourceText": output,
+                "locals": {"T": T},
+            }
+
+        Table = NamedTuple(a=ListOf(int), b=ListOf(str))
+        Lazy = lazyWindow(Table)
+
+        table = Table(a=[1, 2, 3, 4, 5], b=['a', 'b', 'c', 'd', 'e'])
+        lazy = Lazy(table)
+
+        @Entrypoint
+        def return_a(lazy):
+            return lazy.a()
+
+        def return_b(lazy):
+            return lazy.b()
+
+        with PrintNewFunctionVisitor():
+            self.assertEqual(return_a(lazy), 1)
+
+        with PrintNewFunctionVisitor():
+            self.assertEqual(return_b(lazy), 'a')
+
+        lazy.window += 1
+
+        with PrintNewFunctionVisitor():
+            self.assertEqual(return_a(lazy), 2)
+
+        with PrintNewFunctionVisitor():
+            self.assertEqual(return_b(lazy), 'b')
+
+    def test_exception(self):
+        @Macro
+        def f(T):
+            output = []
+            output.append("R=S")
+            output.append("Q=R")
+            output.append("return Q")
+            return {
+                "sourceText": output,
+                "locals": {"S": S}
+            }
+
+        with self.assertRaises(NameError):
+            f(int)
+
+        S = float
+
+        self.assertEqual(f(str), float)
+
+        with self.assertRaises(NameError):
+            f(int)
+
+    def test_namespace(self):
+        @Macro
+        def f(T):
+            return {
+                "sourceText": ["return A"],
+                "locals": {"T": T, "A": A},
+            }
+
+        with self.assertRaises(NameError):
+            f(int)
+
+        class A(Class):
+            pass
+
+        with self.assertRaises(NameError):
+            f(int)
+
+        self.assertEqual(f(float).__name__, 'A')
+
+        class A(Class, __name__='B'):  # noqa: F811
+            pass
+
+        with self.assertRaises(NameError):
+            f(int)
+
+        self.assertEqual(f(float).__name__, 'A')
+        self.assertEqual(f(str).__name__, 'B')
+
+        def inside():
+            @Macro
+            def f(T):
+                return {
+                    "sourceText": ["return A"],
+                    "locals": {"T": T, "A": A},
+                }
+
+            with self.assertRaises(NameError):
+                f(int)
+                # although A existed before, on compilation that A is understood to
+                # refer to an A defined in 'inside'
+
+            class A(Class, __name__='C'):
+                pass
+
+            with self.assertRaises(NameError):
+                f(int)
+
+            self.assertEqual(f(float).__name__, 'C')
+
+            class A(Class, __name__='D'):  # noqa: F811
+                pass
+
+            with self.assertRaises(NameError):
+                f(int)
+
+            self.assertEqual(f(float).__name__, 'C')
+            self.assertEqual(f(str).__name__, 'D')
+
+            return f
+
+        f = inside()
+
+        with self.assertRaises(NameError):
+            f(int)
+        self.assertEqual(f(float).__name__, 'C')
+        self.assertEqual(f(str).__name__, 'D')
+        self.assertEqual(f(bool).__name__, 'D')
+
+        class A(Class, __name__='E'):  # noqa: F811
+            pass
+
+        self.assertEqual(f(list).__name__, 'D')


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

New TypeFunction-like decorator, Macro, which allows the user to define types from source text in a controlled way. For example, the user can now do manual loop unrolling.

## Motivation and Context
<!-- Why is this change required? -->

To increase our ability to write generic named tuple operations, for example.

<!-- What problem does it solve? -->

A simple example, it's now possible to define general named tuple construction functions, which work under entrypoint (avoiding getitem), for all named tuple types at once. Previously, the only way to do this was to hard code such a function on a named tuple type-by-named tuple type basis.

<!--  If it fixes an open issue, please link to the issue here.-->

## Approach
<!-- Describe your changes in reasonable detail -->

## How Has This Been Tested?
<!-- Describe in reasonable detail how you tested your changes. -->

by writing a bunch of @Macro decorators in a test file and checking they give the right behavior

<!-- If appropriate, include details of your testing environment, -->

typed_python/macro_test.py

<!-- tests ran to see how your change affects other areas of the code, etc. -->

Has zero effect unless Macro is actually used. Shares the code cache from typed_python/compiler/python_ast_util.py but is careful to avoid name clashes.

## Screenshots or console output (if appropriate)
<!-- if not appropriate, remove this section -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.