### PR TITLE
Gus getitem

### DIFF
--- a/typed_python/compiler/tests/arithmetic_compilation_test.py
+++ b/typed_python/compiler/tests/arithmetic_compilation_test.py
@@ -19,7 +19,8 @@ from typed_python import (
     OneOf,
     Int8, Int16, Int32,
     UInt8, UInt16, UInt32, UInt64,
-    Float32, Compiled, makeNamedTuple
+    Float32, Compiled, makeNamedTuple,
+    Tuple
 )
 from typed_python.type_promotion import (
     computeArithmeticBinaryResultType, isSignedInt, isUnsignedInt, bitness
@@ -612,3 +613,52 @@ class TestArithmeticCompilation(unittest.TestCase):
             return row.x % 1.0
 
         self.assertEqual(rf(makeNamedTuple(x=1.0)), 0.0)
+
+    def test_unary_ops_on_constants(self):
+        @Entrypoint
+        def sliceAtPositiveZero(x):
+            return x[+0]
+
+        self.assertIs(sliceAtPositiveZero.resultTypeFor(Tuple(int, float)).interpreterTypeRepresentation, int)
+
+        @Entrypoint
+        def sliceAtNegativeZero(x):
+            return x[-0]
+
+        self.assertIs(sliceAtNegativeZero.resultTypeFor(Tuple(int, float)).interpreterTypeRepresentation, int)
+
+        @Entrypoint
+        def sliceAtInvertZero(x):
+            return x[~0]
+
+        self.assertIs(sliceAtInvertZero.resultTypeFor(Tuple(int, float)).interpreterTypeRepresentation, float)
+
+        @Entrypoint
+        def sliceAtNotZero(x):
+            return x[int(not 0)]
+
+        self.assertIs(sliceAtNotZero.resultTypeFor(Tuple(int, float)).interpreterTypeRepresentation, float)
+
+        @Entrypoint
+        def sliceAtPositiveZeroFloat(x):
+            return x[int(+0.0)]
+
+        self.assertIs(sliceAtPositiveZeroFloat.resultTypeFor(Tuple(int, float)).interpreterTypeRepresentation, int)
+
+        @Entrypoint
+        def sliceAtNegativeZeroFloat(x):
+            return x[int(-0.0)]
+
+        self.assertIs(sliceAtNegativeZeroFloat.resultTypeFor(Tuple(int, float)).interpreterTypeRepresentation, int)
+
+        @Entrypoint
+        def sliceAtNotZeroFloat(x):
+            return x[int(not 0.0)]
+
+        self.assertIs(sliceAtNotZeroFloat.resultTypeFor(Tuple(int, float)).interpreterTypeRepresentation, float)
+
+        @Entrypoint
+        def sliceAtNotFalse(x):
+            return x[int(not False)]
+
+        self.assertIs(sliceAtNotZeroFloat.resultTypeFor(Tuple(int, float)).interpreterTypeRepresentation, float)

--- a/typed_python/compiler/tests/tuple_compilation_test.py
+++ b/typed_python/compiler/tests/tuple_compilation_test.py
@@ -14,7 +14,7 @@
 
 from typed_python import (
     Tuple, NamedTuple, Class, Member, ListOf, Compiled,
-    Final, Forward
+    Final, Forward, Function, OneOf
 )
 import typed_python._types as _types
 import unittest
@@ -275,3 +275,33 @@ class TestTupleCompilation(unittest.TestCase):
                 check(lambda: t1 >= t2)
                 check(lambda: t1 == t2)
                 check(lambda: t1 != t2)
+
+    def test_negative_indexing(self):
+        @Entrypoint
+        def sliceAt(tup, ix):
+            return tup[ix]
+
+        @Entrypoint
+        def sliceAtOne(tup):
+            return tup[1]
+
+        @Entrypoint
+        def sliceAtMinusOne(tup):
+            return tup[-1]
+
+        class A(Class):
+            pass
+
+        class B(Class):
+            pass
+
+        tup = Tuple(A, B)([A(), B()])
+
+        self.assertEqual(sliceAtMinusOne(tup), sliceAtOne(tup))
+        self.assertEqual(sliceAt(tup, -2), sliceAt(tup, 0))
+        with self.assertRaises(IndexError):
+            sliceAt(tup, -3)
+
+        self.assertIs(sliceAtMinusOne.resultTypeFor(type(tup)).interpreterTypeRepresentation, B)
+
+        self.assertIs(Function(lambda tup: sliceAt(tup, -2)).resultTypeFor(type(tup)).interpreterTypeRepresentation, OneOf(A, B))

--- a/typed_python/compiler/type_wrappers/arithmetic_wrapper.py
+++ b/typed_python/compiler/type_wrappers/arithmetic_wrapper.py
@@ -328,12 +328,20 @@ class IntWrapper(ArithmeticTypeWrapper):
 
     def convert_unary_op(self, context, left, op):
         if op.matches.Not:
+            if left.isConstant:
+                return context.constant(not left.constantValue)
             return context.pushPod(bool, left.nonref_expr.logical_not())
         if op.matches.Invert:
+            if left.isConstant:
+                return context.constant(~left.constantValue)
             return context.pushPod(self, left.nonref_expr.bitwise_not())
         if op.matches.USub:
+            if left.isConstant:
+                return context.constant(-left.constantValue)
             return context.pushPod(self, left.nonref_expr.negate())
         if op.matches.UAdd:
+            if left.isConstant:
+                return context.constant(left.constantValue)
             return context.pushPod(self, left.nonref_expr)
 
         return super().convert_unary_op(context, left, op)
@@ -546,6 +554,8 @@ class BoolWrapper(ArithmeticTypeWrapper):
 
     def convert_unary_op(self, context, left, op):
         if op.matches.Not:
+            if left.isConstant:
+                return context.constant(not left.constantValue)
             return context.pushPod(bool, left.nonref_expr.logical_not())
 
         return super().convert_unary_op(context, left, op)
@@ -727,10 +737,16 @@ class FloatWrapper(ArithmeticTypeWrapper):
 
     def convert_unary_op(self, context, left, op):
         if op.matches.Not:
+            if left.isConstant:
+                return context.constant(not left.constantValue)
             return context.pushPod(bool, left.nonref_expr.eq(self.getNativeLayoutType().zero()))
         if op.matches.USub:
+            if left.isConstant:
+                return context.constant(-left.constantValue)
             return context.pushPod(self, left.nonref_expr.negate())
         if op.matches.UAdd:
+            if left.isConstant:
+                return context.constant(left.constantValue)
             return context.pushPod(self, left.nonref_expr)
 
         return super().convert_unary_op(context, left, op)

--- a/typed_python/compiler/type_wrappers/tuple_wrapper.py
+++ b/typed_python/compiler/type_wrappers/tuple_wrapper.py
@@ -276,7 +276,7 @@ class TupleWrapper(Wrapper):
         result = context.allocateUninitializedSlot(self.unionType)
         with context.switch(
             index.nonref_expr,
-            range(len(self.subTypeWrappers)),
+            range(-len(self.subTypeWrappers), len(self.subTypeWrappers)),
             True
         ) as indicesAndContexts:
             for i, subcontext in indicesAndContexts:

--- a/typed_python/compiler/type_wrappers/tuple_wrapper.py
+++ b/typed_python/compiler/type_wrappers/tuple_wrapper.py
@@ -270,7 +270,6 @@ class TupleWrapper(Wrapper):
 
                 return self.refAs(context, expr, indexVal)
 
-        index = index.convert_to_type(int)
         if index is None:
             return None
 

--- a/typed_python/compiler/type_wrappers/tuple_wrapper.py
+++ b/typed_python/compiler/type_wrappers/tuple_wrapper.py
@@ -260,15 +260,15 @@ class TupleWrapper(Wrapper):
 
         # if the argument is a constant, we can be very precise about what type
         # we're going to get out of the indexing operation
-        if index.expr.matches.Constant:
-            if index.expr.val.matches.Int:
-                indexVal = index.expr.val.val
+        if index.isConstant:
+            indexVal = index.constantValue
+            assert isinstance(indexVal, int)
 
-                if indexVal >= - len(self.subTypeWrappers) and indexVal < len(self.subTypeWrappers):
-                    if indexVal < 0:
-                        indexVal += len(self.subTypeWrappers)
+            if indexVal >= - len(self.subTypeWrappers) and indexVal < len(self.subTypeWrappers):
+                if indexVal < 0:
+                    indexVal += len(self.subTypeWrappers)
 
-                    return self.refAs(context, expr, indexVal)
+                return self.refAs(context, expr, indexVal)
 
         index = index.convert_to_type(int)
         if index is None:


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

Let the compiler understand that unary ops on arithmetic constants are still constants. Also allow the slicing of Tuples on negative integers.

## Motivation and Context
<!-- Why is this change required? -->

Previously, compiler couldn't see that x[-1] would be a float for x of type Tuple(int, float). That's because -1 was not treated as a constant, so the compiler just thought it was any old int. So the output type was OneOf(int, float). Moreover, it couldn't actually do the slice at runtime because it didn't generate code for slicing by non-constant negative ints. Fixed both of these bugs.

<!-- What problem does it solve? -->
<!--  If it fixes an open issue, please link to the issue here.-->

## Approach
<!-- Describe your changes in reasonable detail -->

## How Has This Been Tested?
<!-- Describe in reasonable detail how you tested your changes. -->
<!-- If appropriate, include details of your testing environment, -->
<!-- tests ran to see how your change affects other areas of the code, etc. -->

## Screenshots or console output (if appropriate)
<!-- if not appropriate, remove this section -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.