### PR TITLE
Compile 'bytes' operations. Refs #342, #351, #355.

### DIFF
--- a/typed_python/BytesType.cpp
+++ b/typed_python/BytesType.cpp
@@ -97,76 +97,267 @@ char BytesType::cmpStatic(layout* left, layout* right) {
 }
 
 /* static */
-void BytesType::split(ListOfType::layout *outList, layout* bytesLayout, layout* sep, int64_t max) {
-    static ListOfType* listOfBytes = ListOfType::Make(StringType::Make());
+// assumes outList was initialized to an empty list before calling
+// x.split() with no parameters is not the same thing as x.split(b' \t\r\n\x0B\f')
+// x.split() combines successive matches (of whitespace) into a single match
+void BytesType::split(ListOfType::layout *outList, layout* in, layout* sep, int64_t max) {
+    static ListOfType* listOfBytes = ListOfType::Make(BytesType::Make());
 
     int64_t cur = 0;
     int64_t count = 0;
 
     listOfBytes->reserve((instance_ptr)&outList, 10);
 
-    uint8_t* bytesData = (uint8_t*)bytesLayout->data;
+    uint8_t* inData = in ? (uint8_t*)in->data : nullptr;
+    int64_t inLen = in ? in->bytecount : 0;
     uint8_t sepChar = sep ? *(uint8_t*)sep->data : 0;
     uint8_t* sepDat = sep ? (uint8_t*)sep->data : 0;
     int64_t sepLen = sep ? sep->bytecount : 1;
 
     if (max == 0) {
-        layout* remainder = createFromPtr((const char*)bytesData, bytesLayout->bytecount);
+        layout* remainder = createFromPtr((const char*)inData, inLen);
         listOfBytes->append((instance_ptr)&outList, (instance_ptr)&remainder);
         destroyStatic((instance_ptr)&remainder);
         return;
     }
 
-    while (cur < bytesLayout->bytecount) {
+    while (cur < inLen) {
         int64_t match = cur;
 
         if (sep) {
             if (sepLen == 1) {
-                while (match < bytesLayout->bytecount && bytesData[match] != sepChar) {
+                while (match < inLen && inData[match] != sepChar) {
                     match++;
                 }
             } else {
-                while (match + sepLen <= bytesLayout->bytecount && strncmp((const char*)bytesData, (const char*)sepDat, match)) {
+                while (match + sepLen <= inLen && memcmp((const char*)inData + match, (const char*)sepDat, sepLen)) {
                     match++;
                 }
             }
         } else {
-            while (match < bytesLayout->bytecount && (
-                    bytesData[match] != '\n'
-                &&  bytesData[match] != '\r'
-                &&  bytesData[match] != '\t'
-                &&  bytesData[match] != ' '
-                &&  bytesData[match] != '\b'
-                &&  bytesData[match] != '\f'
+            while (match < inLen && (
+                    inData[match] != '\n'
+                &&  inData[match] != '\r'
+                &&  inData[match] != '\t'
+                &&  inData[match] != ' '
+                &&  inData[match] != '\x0B'  // note: \x0B is whitespace, but \b is not whitespace
+                &&  inData[match] != '\f'
                 )
             ) {
                 match++;
             }
         }
 
-        if (match + sepLen > bytesLayout->bytecount) {
+        if (match + sepLen > inLen) {
             break;
         }
 
-        layout* piece = createFromPtr((const char*)bytesData + cur, match - cur);
+        if (sep || match != cur) {
+            layout* piece = createFromPtr((const char*)inData + cur, match - cur);
+
+            if (outList->count == outList->reserved) {
+                listOfBytes->reserve((instance_ptr)&outList, outList->reserved * 1.5);
+            }
+
+            ((layout**)outList->data)[outList->count++] = piece;
+            cur = match + sepLen;
+            count++;
+            if (max >= 0 && count >= max)
+                break;
+        }
+        else if (!sep)
+            cur++;
+    }
+    if (sep || inLen != cur) {
+        layout* remainder = createFromPtr((const char*)inData + cur, inLen - cur);
+        listOfBytes->append((instance_ptr)&outList, (instance_ptr)&remainder);
+        destroyStatic((instance_ptr)&remainder);
+    }
+}
+
+/* static */
+// assumes outList was initialized to an empty list before calling
+void BytesType::rsplit(ListOfType::layout *outList, layout* in, layout* sep, int64_t max) {
+    static ListOfType* listOfBytes = ListOfType::Make(BytesType::Make());
+    int64_t cur = in ? in->bytecount - 1 : -1;
+    int64_t count = 0;
+
+    listOfBytes->reserve((instance_ptr)&outList, 10);
+
+    uint8_t* inData = in ? (uint8_t*)in->data : nullptr;
+    int64_t inLen = in ? in->bytecount : 0;
+    uint8_t sepChar = sep ? *(uint8_t*)sep->data : 0;
+    uint8_t* sepDat = sep ? (uint8_t*)sep->data : 0;
+    int64_t sepLen = sep ? sep->bytecount : 1;
+
+    if (max == 0) {
+        layout* remainder = createFromPtr((const char*)inData, inLen);
+        listOfBytes->append((instance_ptr)&outList, (instance_ptr)&remainder);
+        destroyStatic((instance_ptr)&remainder);
+        return;
+    }
+
+    while (cur >= 0) {
+        int64_t match = cur;
+
+        if (sep) {
+            if (sepLen == 1) {
+                while (match >= 0 && inData[match] != sepChar) {
+                    match--;
+                }
+            } else {
+                while (match - sepLen + 1 >= 0 && memcmp((const char*)inData + match - sepLen + 1, (const char*)sepDat, sepLen)) {
+                    match--;
+                }
+            }
+        } else {
+            while (match >= 0 && (
+                    inData[match] != '\n'
+                &&  inData[match] != '\r'
+                &&  inData[match] != '\t'
+                &&  inData[match] != ' '
+                &&  inData[match] != '\x0B'  // note: \x0B is whitespace, but \b is not whitespace
+                &&  inData[match] != '\f'
+                )
+            ) {
+                match--;
+            }
+        }
+
+        if (match - sepLen + 1 < 0) {
+            break;
+        }
+
+        if (sep || match != cur) {
+            layout* piece = createFromPtr((const char*)inData + match + 1, cur - match);
+
+            if (outList->count == outList->reserved) {
+                listOfBytes->reserve((instance_ptr)&outList, outList->reserved * 1.5);
+            }
+
+            ((layout**)outList->data)[outList->count++] = piece;
+            cur = match - sepLen;
+            count++;
+            if (max >= 0 && count >= max) break;
+        }
+        else if (!sep) {
+            cur--;
+        }
+    }
+    if (sep || cur != -1) {
+        layout* remainder = createFromPtr((const char*)inData, cur + 1);
+        listOfBytes->append((instance_ptr)&outList, (instance_ptr)&remainder);
+        destroyStatic((instance_ptr)&remainder);
+    }
+    listOfBytes->reverse((instance_ptr)&outList);
+}
+
+/* static */
+// assumes outList was initialized to an empty list before calling
+void BytesType::splitlines(ListOfType::layout *outList, layout* in, bool keepends) {
+    static ListOfType* listOfBytes = ListOfType::Make(BytesType::Make());
+
+    int64_t cur = 0;
+
+    listOfBytes->reserve((instance_ptr)&outList, 10);
+
+    uint8_t* inData = in ? (uint8_t*)in->data : nullptr;
+    int64_t inLen = in ? in->bytecount : 0;
+    int sepLen = 0;
+
+    while (cur < inLen) {
+        int64_t match = cur;
+
+        while (match < inLen && inData[match] != '\n' &&  inData[match] != '\r') {
+            match++;
+        }
+        sepLen = 0;
+        if (match < inLen) {
+            if (inData[match] == '\r' && match + 1 < inLen && inData[match+1] == '\n') {
+                sepLen = 2;
+            }
+            else {
+                sepLen = 1;
+            }
+        }
+
+        if (match + sepLen > inLen) {
+            break;
+        }
+
+        layout* piece = createFromPtr((const char*)inData + cur, match - cur + (keepends ? sepLen : 0));
 
         if (outList->count == outList->reserved) {
             listOfBytes->reserve((instance_ptr)&outList, outList->reserved * 1.5);
         }
 
         ((layout**)outList->data)[outList->count++] = piece;
-
         cur = match + sepLen;
-
-        count++;
-
-        if (max >= 0 && count >= max)
-            break;
     }
-    layout* remainder = createFromPtr((const char*)bytesData + cur, bytesLayout->bytecount - cur);
-    listOfBytes->append((instance_ptr)&outList, (instance_ptr)&remainder);
-    destroyStatic((instance_ptr)&remainder);
+    if (inLen != cur) {
+        layout* remainder = createFromPtr((const char*)inData + cur, inLen - cur + (keepends ? sepLen : 0));
+        listOfBytes->append((instance_ptr)&outList, (instance_ptr)&remainder);
+        destroyStatic((instance_ptr)&remainder);
+    }
 }
+
+void BytesType::join(BytesType::layout **out, BytesType::layout *separator, ListOfType::layout *toJoin) {
+    if (!out)
+        throw std::invalid_argument("missing return argument");
+
+    BytesType::Make()->constructor((instance_ptr)out);
+
+    // return empty bytes when there is nothing to join
+    if (toJoin->count == 0)
+    {
+        return;
+    }
+
+    static ListOfType *listOfBytesType = ListOfType::Make(BytesType::Make());
+    int total_bytes = 0;
+
+    for (int64_t i = 0; i < toJoin->count; i++)
+    {
+        instance_ptr item = listOfBytesType->eltPtr(toJoin, i);
+        BytesType::layout** itemLayout = (BytesType::layout**)item;
+        if (*itemLayout != nullptr) {
+            total_bytes += (*itemLayout)->bytecount;
+        }
+    }
+
+    // add the separators size
+    if (separator != nullptr)
+    {
+        total_bytes += separator->bytecount * (toJoin->count - 1);
+    }
+
+    // add all the parts together
+    *out = (layout*)malloc(sizeof(layout) + total_bytes);
+    (*out)->hash_cache = -1;
+    (*out)->refcount = 1;
+    (*out)->bytecount = total_bytes;
+
+    // position in the output data array
+    int position = 0;
+
+    for (int64_t i = 0; i < toJoin->count; i++)
+    {
+        instance_ptr instptr_item = listOfBytesType->eltPtr(toJoin, i);
+        BytesType::layout* item = *(BytesType::layout**)instptr_item;
+        if (item != nullptr)
+        {
+            memcpy((*out)->data + position, item->data, item->bytecount);
+            position += item->bytecount;
+        }
+
+        if (separator != nullptr && i != toJoin->count - 1)
+        {
+            memcpy((*out)->data + position, separator->data, separator->bytecount);
+            position += separator->bytecount;
+        }
+    }
+}
+
 
 BytesType::layout* BytesType::concatenate(layout* lhs, layout* rhs) {
     if (!rhs && !lhs) {
@@ -502,4 +693,314 @@ bool BytesType::to_float64(BytesType::layout* b, double* value) {
         *value = 0.0;
         return false;
     }
+}
+
+BytesType::layout* BytesType::lower(layout *l) {
+    if (!l) {
+        return l;
+    }
+
+    int64_t new_byteCount = sizeof(layout) + l->bytecount;
+    layout* new_layout = (layout*)malloc(new_byteCount);
+    new_layout->refcount = 1;
+    new_layout->hash_cache = -1;
+    new_layout->bytecount = l->bytecount;
+
+    for (uint8_t *src = l->data, *dest = new_layout->data, *end = src + l->bytecount; src < end; ) {
+        *dest++ = (uint8_t)tolower(*src++);
+    }
+    return new_layout;
+}
+
+BytesType::layout* BytesType::upper(layout *l) {
+    if (!l) {
+        return l;
+    }
+
+    int64_t new_byteCount = sizeof(layout) + l->bytecount;
+    layout* new_layout = (layout*)malloc(new_byteCount);
+    new_layout->refcount = 1;
+    new_layout->hash_cache = -1;
+    new_layout->bytecount = l->bytecount;
+
+    for (uint8_t *src = l->data, *dest = new_layout->data, *end = src + l->bytecount; src < end; ) {
+        *dest++ = (uint8_t)toupper(*src++);
+    }
+    return new_layout;
+}
+
+BytesType::layout* BytesType::capitalize(layout *l) {
+    if (!l) {
+        return l;
+    }
+
+    int64_t new_byteCount = sizeof(layout) + l->bytecount;
+    layout* new_layout = (layout*)malloc(new_byteCount);
+    new_layout->refcount = 1;
+    new_layout->hash_cache = -1;
+    new_layout->bytecount = l->bytecount;
+
+    uint8_t *src = l->data, *dest = new_layout->data, *end = src + l->bytecount;
+    if (l->bytecount) {
+        *dest++ = (uint8_t)toupper(*src++);
+        while (src < end) {
+            *dest++ = (uint8_t)tolower(*src++);
+        }
+    }
+    return new_layout;
+}
+
+BytesType::layout* BytesType::swapcase(layout *l) {
+    if (!l) {
+        return l;
+    }
+
+    int64_t new_byteCount = sizeof(layout) + l->bytecount;
+    layout* new_layout = (layout*)malloc(new_byteCount);
+    new_layout->refcount = 1;
+    new_layout->hash_cache = -1;
+    new_layout->bytecount = l->bytecount;
+
+    for (uint8_t *src = l->data, *dest = new_layout->data, *end = src + l->bytecount; src < end; ) {
+        uint8_t c = *src++;
+        if (islower(c))
+            *dest++ = (uint8_t)toupper(c);
+        else if (isupper(c))
+            *dest++ = (uint8_t)tolower(c);
+        else
+            *dest++ = c;
+    }
+    return new_layout;
+}
+
+BytesType::layout* BytesType::title(layout *l) {
+    if (!l) {
+        return l;
+    }
+
+    int64_t new_byteCount = sizeof(layout) + l->bytecount;
+    layout* new_layout = (layout*)malloc(new_byteCount);
+    new_layout->refcount = 1;
+    new_layout->hash_cache = -1;
+    new_layout->bytecount = l->bytecount;
+
+    bool word = false;
+    for (uint8_t *src = l->data, *dest = new_layout->data, *end = src + l->bytecount; src < end; ) {
+        uint8_t c = *src++;
+        if (word) {
+            if (isalpha(c)) {
+                *dest++ = (uint8_t)tolower(c);
+            } else {
+                *dest++ = c;
+                word = false;
+            }
+        } else {
+            if (isalpha(c)) {
+                *dest++ = (uint8_t)toupper(c);
+                word = true;
+            } else {
+                *dest++ = c;
+            }
+        }
+    }
+    return new_layout;
+}
+
+bool matchchar(uint8_t v, bool whiteSpace, BytesType::layout* values) {
+    if (whiteSpace) return isspace(v);
+
+    if (!values) return false;
+
+    for (int i = 0; i < values->bytecount; i++) {
+        if (v == values->data[i]) return true;
+    }
+    return false;
+}
+
+BytesType::layout* BytesType::strip(layout* l, bool whiteSpace, layout* values, bool fromLeft, bool fromRight) {
+    if (!l) {
+        return l;
+    }
+
+    int64_t leftPos = 0;
+    int64_t rightPos = l->bytecount;
+
+    uint8_t* dataPtr = l->data;
+
+    if (fromLeft) {
+        while (leftPos < rightPos && matchchar(dataPtr[leftPos], whiteSpace, values)) {
+            leftPos++;
+        }
+    }
+
+    if (fromRight) {
+        while (leftPos < rightPos && matchchar(dataPtr[rightPos-1], whiteSpace, values)) {
+            rightPos--;
+        }
+    }
+
+    if (leftPos == rightPos) {
+        return nullptr;
+    }
+
+    if (leftPos == 0 && rightPos == l->bytecount) {
+        l->refcount++;
+        return l;
+    }
+
+    size_t datalength = rightPos - leftPos;
+    layout* new_layout = (layout*)malloc(sizeof(layout) + datalength);
+    new_layout->refcount = 1;
+    new_layout->hash_cache = -1;
+    new_layout->bytecount = datalength;
+
+    memcpy(new_layout->data, l->data + leftPos, datalength);
+
+    return new_layout;
+}
+
+BytesType::layout* BytesType::mult(layout* lhs, int64_t rhs) {
+    if (!lhs) {
+        return lhs;
+    }
+    if (rhs <= 0)
+        return 0;
+    int64_t new_length = lhs->bytecount * rhs;
+    int64_t new_byteCount = sizeof(layout) + new_length;
+
+    layout* new_layout = (layout*)malloc(new_byteCount);
+    new_layout->refcount = 1;
+    new_layout->hash_cache = -1;
+    new_layout->bytecount = new_length;
+
+    for (size_t i = 0; i < rhs; i++) {
+        memcpy(new_layout->data + i * lhs->bytecount, lhs->data, lhs->bytecount);
+    }
+
+    return new_layout;
+}
+
+// This 'replace' is slightly faster (5%) than 'bytes_replace' in bytes_wrapper.py.
+// However, this 'replace' needs better memory management.
+// Some notable special cases:
+// 'aa'.replace('','z') = 'zazaz'
+// 'aa'.replace('','z', 5) = 'aa'
+// 'aa'.replace('','z', -1) = 'zazaz'
+// ''.replace('','z') = 'z'
+// ''.replace('','z', 5) = ''
+// ''.replace('','z', -1) = 'z'
+BytesType::layout* BytesType::replace(layout* l, layout* old, layout* repl, int64_t count) {
+    if (!l) {
+        if (old || !repl || count >= 0)
+            return 0;
+        layout *new_layout = (layout*)malloc(sizeof(layout) + repl->bytecount);
+        new_layout->refcount = 1;
+        new_layout->hash_cache = -1;
+        new_layout->bytecount = repl->bytecount;
+        memcpy(new_layout->data, repl->data, repl->bytecount);
+        return new_layout;
+    }
+
+    int64_t c = 0;
+    size_t repl_len = repl ? repl->bytecount : 0;
+    size_t old_len = old ? old->bytecount : 0;
+    size_t max_matches = old_len ? l->bytecount / old_len : l->bytecount + 1;
+    size_t max_increase = repl_len > old_len ? max_matches * (repl_len - old_len) : 0;
+    size_t new_layout_size = sizeof(layout) + l->bytecount + max_increase;
+    layout* new_layout = (layout*)malloc(new_layout_size);
+    new_layout->refcount = 1;
+    new_layout->hash_cache = -1;
+    new_layout->bytecount = l->bytecount;
+
+    if ((!old_len && !repl_len) || old_len > l->bytecount || count == 0) {
+         memcpy(new_layout->data, l->data, l->bytecount);
+         return new_layout;
+    }
+
+    uint8_t* src = l->data;
+    uint8_t* dst = new_layout->data;
+    uint8_t* end_scan = l->data + l->bytecount - old_len + 1;
+    uint8_t* end_src = l->data + l->bytecount;
+    while (src < end_scan) {
+        if (!old_len || 0 == memcmp(src, old->data, old_len)) {
+            if (repl) {
+                memcpy(dst, repl->data, repl_len);
+                dst += repl_len;
+            }
+            if (!old_len) {
+                *dst++ = *src++;
+            }
+            else {
+                src += old_len;
+            }
+            new_layout->bytecount += repl_len - old_len;
+            if (count > 0 && ++c >= count) break;
+        }
+        else {
+            *dst++ = *src++;
+        }
+    }
+    if (src < end_src) memcpy(dst, src, end_src - src);
+
+    if (sizeof(layout) + new_layout->bytecount < new_layout_size) {
+        new_layout = (layout*)realloc(new_layout, sizeof(layout) + new_layout->bytecount);
+    }
+    return new_layout;
+}
+
+
+BytesType::layout* BytesType::translate(layout* l, layout* table, layout* to_delete) {
+    if (!l) return 0;
+
+    if (table && table->bytecount != 256) {
+        throw std::invalid_argument("translation table must be 256 characters long");
+    }
+
+    layout *new_layout = (layout*)malloc(sizeof(layout) + l->bytecount);
+    new_layout->refcount = 1;
+    new_layout->hash_cache = -1;
+
+    uint8_t* dst = new_layout->data;
+    for (int i = 0; i < l->bytecount; i++) {
+        uint8_t c = l->data[i];
+        if (to_delete) {
+            bool delete_this = false;
+            for (int j = 0; j < to_delete->bytecount; j++)
+                if (c == to_delete->data[j]) {
+                    delete_this = true;
+                    break;
+                }
+            if (delete_this) continue;
+        }
+        if (table)
+            *dst++ = table->data[c];
+        else
+            *dst++ = c;
+    }
+    new_layout->bytecount = dst - new_layout->data;
+
+    // might have shrunk
+    if (new_layout->bytecount < l->bytecount) {
+        new_layout = (layout*)realloc(new_layout, sizeof(layout) + new_layout->bytecount);
+    }
+    return new_layout;
+}
+
+// assumes len(from) == len(to) checked before calling
+BytesType::layout* BytesType::maketrans(layout* from, layout* to) {
+    const int table_size = 256;
+    layout* new_layout = (layout*)malloc(sizeof(layout) + table_size);
+    new_layout->refcount = 1;
+    new_layout->hash_cache = -1;
+    new_layout->bytecount = table_size;
+
+    for (int i = 0; i < table_size; i++) {
+        new_layout->data[i] = i;
+    }
+
+    for (int j = 0; j < (from ? from->bytecount : 0); j++) {
+        new_layout->data[from->data[j]] = to->data[j];
+    }
+
+    return new_layout;
 }

--- a/typed_python/BytesType.hpp
+++ b/typed_python/BytesType.hpp
@@ -73,11 +73,6 @@ public:
     //return an increffed bytes object containing a pointer to the requisite bytes
     static layout* createFromPtr(const char* data, int64_t len);
 
-    // split 'bytesLayout' depositing results into a ListOf<Bytes> in 'outList'
-    // if 'sep' is nullptr, split on whitespace
-    // max is the maximum number of splits. If its -1, then split as many times as is necessary
-    static void split(ListOfType::layout *outList, layout* bytesLayout, layout* sep, int64_t max);
-
     template<class visitor_type>
     void _visitReferencedTypes(const visitor_type& v) {}
 
@@ -116,4 +111,24 @@ public:
     static bool to_int64(layout* s, int64_t* value);
 
     static bool to_float64(layout* s, double* value);
+
+    // split 'bytesLayout' depositing results into a ListOf<Bytes> in 'outList'
+    // if 'sep' is nullptr, split on whitespace
+    // max is the maximum number of splits. If its -1, then split as many times as is necessary
+    static void split(ListOfType::layout *outList, layout* bytesLayout, layout* sep, int64_t max);
+    static void rsplit(ListOfType::layout *outList, layout* bytesLayout, layout* sep, int64_t max);
+    static void splitlines(ListOfType::layout *outList, layout* bytesLayout, bool keepends);
+
+    static void join(BytesType::layout **out, BytesType::layout *separator, ListOfType::layout *toJoin);
+
+    static layout* mult(layout* lhs, int64_t rhs);
+    static layout* lower(layout* l);
+    static layout* upper(layout* l);
+    static layout* capitalize(layout* l);
+    static layout* swapcase(layout* l);
+    static layout* title(layout* l);
+    static layout* strip(layout* l, bool whiteSpace, layout* values, bool fromLeft=true, bool fromRight=true);
+    static layout* replace(layout* l, layout* old, layout* the_new, int64_t count);
+    static layout* translate(layout* l, layout* table, layout* to_delete);
+    static layout* maketrans(layout* from, layout* to);
 };

--- a/typed_python/PyTupleOrListOfInstance.cpp
+++ b/typed_python/PyTupleOrListOfInstance.cpp
@@ -737,7 +737,7 @@ PyObject* PyListOfInstance::listPop(PyObject* o, PyObject* args) {
 
 PyObject* PyListOfInstance::listTranspose(PyObject* o, PyObject* args) {
     if (PyTuple_Size(args) != 0) {
-        PyErr_SetString(PyExc_TypeError, "ListOf.trasnpose takes zero arguments");
+        PyErr_SetString(PyExc_TypeError, "ListOf.transpose takes zero arguments");
         return NULL;
     }
 

--- a/typed_python/PyTupleOrListOfInstance.hpp
+++ b/typed_python/PyTupleOrListOfInstance.hpp
@@ -1,5 +1,5 @@
 /******************************************************************************
-   Copyright 2017-2019 typed_python Authors
+   Copyright 2017-2020 typed_python Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/typed_python/StringType.cpp
+++ b/typed_python/StringType.cpp
@@ -1342,3 +1342,27 @@ bool StringType::to_float64(StringType::layout* s, double* value) {
         return false;
     }
 }
+
+
+StringType::layout* StringType::mult(layout* lhs, int64_t rhs) {
+    if (!lhs) {
+        return lhs;
+    }
+    if (rhs <= 0)
+        return 0;
+    int64_t new_length = lhs->pointcount * rhs;
+    int64_t new_byteCount = sizeof(layout) + new_length * lhs->bytes_per_codepoint;
+
+    layout* new_layout = (layout*)malloc(new_byteCount);
+    new_layout->refcount = 1;
+    new_layout->hash_cache = -1;
+    new_layout->bytes_per_codepoint = lhs->bytes_per_codepoint;
+    new_layout->pointcount = new_length;
+
+    int64_t old_size = lhs->pointcount * lhs->bytes_per_codepoint;
+    for (size_t i = 0; i < rhs; i++) {
+        memcpy(new_layout->data + i * old_size, lhs->data, old_size);
+    }
+
+    return new_layout;
+}

--- a/typed_python/StringType.hpp
+++ b/typed_python/StringType.hpp
@@ -75,9 +75,9 @@ public:
     static void split_3(ListOfType::layout *outList, layout* l, int64_t max);
 
     /**
-     * It should behave like outString = separator.join(toJoin).
+     * It should behave like out = separator.join(toJoin).
      */
-    static void join(StringType::layout **outString, StringType::layout *separator, ListOfType::layout *toJoin);
+    static void join(StringType::layout **out, StringType::layout *separator, ListOfType::layout *toJoin);
 
     static bool isalpha(layout *l);
     static bool isalnum(layout *l);
@@ -89,6 +89,8 @@ public:
     static bool isspace(layout *l);
     static bool istitle(layout *l);
     static bool isupper(layout *l);
+
+    static layout* mult(layout* lhs, int64_t rhs);
 
     //return an increffed string containing the one codepoint at 'offset'. this function
     //will correctly map negative indices, but performs no other boundschecking.

--- a/typed_python/TupleOrListOfType.cpp
+++ b/typed_python/TupleOrListOfType.cpp
@@ -1,5 +1,5 @@
 /******************************************************************************
-   Copyright 2017-2019 typed_python Authors
+   Copyright 2017-2020 typed_python Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -263,6 +263,23 @@ void TupleOrListOfType::reserve(instance_ptr self, size_t target) {
     self_layout->reserved = target;
 }
 
+void TupleOrListOfType::reverse(instance_ptr self) {
+    layout_ptr& self_layout = *(layout_ptr*)self;
+    if (!self_layout || self_layout->count <= 1) return;
+
+    long elt_size = getEltType()->bytecount();
+
+    // swap memory without caring what the elements are
+    uint8_t* swap = (uint8_t*)malloc(elt_size);
+    for (long k = 0; k < self_layout->count / 2; k++) {
+        uint8_t* ptr1 = (uint8_t*)eltPtr(self_layout, k);
+        uint8_t* ptr2 = (uint8_t*)eltPtr(self_layout, self_layout->count - 1 - k);
+        memcpy(swap, ptr1, elt_size);
+        memcpy(ptr1, ptr2, elt_size);
+        memcpy(ptr2, swap, elt_size);
+    }
+    free(swap);
+}
 
 //static
 void ListOfType::copyListObject(instance_ptr target, instance_ptr src) {

--- a/typed_python/TupleOrListOfType.hpp
+++ b/typed_python/TupleOrListOfType.hpp
@@ -1,5 +1,5 @@
 /******************************************************************************
-   Copyright 2017-2019 typed_python Authors
+   Copyright 2017-2020 typed_python Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -181,6 +181,8 @@ public:
     void assign(instance_ptr self, instance_ptr other);
 
     void reserve(instance_ptr self, size_t count);
+
+    void reverse(instance_ptr self);
 
 protected:
     Type* m_element_type;

--- a/typed_python/_runtime.cpp
+++ b/typed_python/_runtime.cpp
@@ -483,8 +483,12 @@ extern "C" {
         return StringType::find(l, sub, start, l ? l->pointcount : 0);
     }
 
-    void nativepython_runtime_string_join(StringType::layout** outString, StringType::layout* separator, ListOfType::layout* toJoin) {
-        StringType::join(outString, separator, toJoin);
+    void nativepython_runtime_bytes_join(BytesType::layout** out, BytesType::layout* separator, ListOfType::layout* toJoin) {
+        BytesType::join(out, separator, toJoin);
+    }
+
+    void nativepython_runtime_string_join(StringType::layout** out, StringType::layout* separator, ListOfType::layout* toJoin) {
+        StringType::join(out, separator, toJoin);
     }
 
     ListOfType::layout* nativepython_runtime_bytes_split(BytesType::layout* l, BytesType::layout* sep, int64_t max) {
@@ -495,6 +499,30 @@ extern "C" {
         listOfBytesT->constructor((instance_ptr)&outList);
 
         BytesType::split(outList, l, sep, max);
+
+        return outList;
+    }
+
+    ListOfType::layout* nativepython_runtime_bytes_rsplit(BytesType::layout* l, BytesType::layout* sep, int64_t max) {
+        static ListOfType* listOfBytesT = ListOfType::Make(BytesType::Make());
+
+        ListOfType::layout* outList;
+
+        listOfBytesT->constructor((instance_ptr)&outList);
+
+        BytesType::rsplit(outList, l, sep, max);
+
+        return outList;
+    }
+
+    ListOfType::layout* nativepython_runtime_bytes_splitlines(BytesType::layout* l, bool keepends) {
+        static ListOfType* listOfBytesT = ListOfType::Make(BytesType::Make());
+
+        ListOfType::layout* outList;
+
+        listOfBytesT->constructor((instance_ptr)&outList);
+
+        BytesType::splitlines(outList, l, keepends);
 
         return outList;
     }
@@ -591,6 +619,10 @@ extern "C" {
         return StringType::getitem(lhs, index);
     }
 
+    StringType::layout* nativepython_runtime_string_mult(StringType::layout* lhs, int64_t rhs) {
+        return StringType::mult(lhs, rhs);
+    }
+
     StringType::layout* nativepython_runtime_string_chr(int64_t code) {
         if (code < 0 || code > 0x10ffff) {
             PyEnsureGilAcquired getTheGil;
@@ -668,6 +700,90 @@ extern "C" {
 
     BytesType::layout* nativepython_runtime_bytes_from_ptr_and_len(const char* utf8_str, int64_t len) {
         return BytesType::createFromPtr(utf8_str, len);
+    }
+
+    BytesType::layout* nativepython_runtime_bytes_lower(BytesType::layout* l) {
+        return BytesType::lower(l);
+    }
+
+    BytesType::layout* nativepython_runtime_bytes_upper(BytesType::layout* l) {
+        return BytesType::upper(l);
+    }
+
+    BytesType::layout* nativepython_runtime_bytes_capitalize(BytesType::layout* l) {
+        return BytesType::capitalize(l);
+    }
+
+    BytesType::layout* nativepython_runtime_bytes_swapcase(BytesType::layout* l) {
+        return BytesType::swapcase(l);
+    }
+
+    BytesType::layout* nativepython_runtime_bytes_title(BytesType::layout* l) {
+        return BytesType::title(l);
+    }
+
+    BytesType::layout* nativepython_runtime_bytes_strip(BytesType::layout* l, bool fromLeft, bool fromRight) {
+        return BytesType::strip(l, true, nullptr, fromLeft, fromRight);
+    }
+
+    BytesType::layout* nativepython_runtime_bytes_strip2(BytesType::layout* l, BytesType::layout* values, bool fromLeft, bool fromRight) {
+        return BytesType::strip(l, false, values, fromLeft, fromRight);
+    }
+
+    BytesType::layout* nativepython_runtime_bytes_mult(BytesType::layout* lhs, int64_t rhs) {
+        return BytesType::mult(lhs, rhs);
+    }
+
+    BytesType::layout* nativepython_runtime_bytes_replace(
+            BytesType::layout* l,
+            BytesType::layout* old,
+            BytesType::layout* the_new,
+            int64_t count
+    ) {
+        return BytesType::replace(l, old, the_new, count);
+    }
+
+    StringType::layout* nativepython_runtime_bytes_decode(
+            BytesType::layout* l,
+            StringType::layout* encoding,
+            StringType::layout* errors
+    ) {
+        PyEnsureGilAcquired getTheGil;
+
+        PyObject* b = PyInstance::extractPythonObject((instance_ptr)&l, BytesType::Make());
+        if (!b) {
+            throw PythonExceptionSet();
+        }
+
+        char* utf8_encoding = encoding ? strdup(StringType::Make()->toUtf8String((instance_ptr)&encoding).c_str()) : 0;
+        const char* utf8_errors = errors ? StringType::Make()->toUtf8String((instance_ptr)&errors).c_str() : 0;
+        PyObject* s = PyUnicode_FromEncodedObject(b, utf8_encoding, utf8_errors);
+        free(utf8_encoding);
+        decref(b);
+        if (!s) {
+            throw PythonExceptionSet();
+        }
+
+        StringType::layout* ret = 0;
+        PyInstance::copyConstructFromPythonInstance(StringType::Make(), (instance_ptr)&ret, s, true);
+        decref(s);
+
+        return ret;
+    }
+
+    BytesType::layout* nativepython_runtime_bytes_translate(
+            BytesType::layout* l,
+            BytesType::layout* table,
+            BytesType::layout* to_delete
+    ) {
+        return BytesType::translate(l, table, to_delete);
+    }
+
+    BytesType::layout* nativepython_runtime_bytes_maketrans(
+            BytesType::layout* from,
+            BytesType::layout* to
+    ) {
+        return BytesType::maketrans(from, to);
     }
 
     PythonObjectOfType::layout_type* nativepython_runtime_create_pyobj(PyObject* p) {

--- a/typed_python/compiler/python_object_representation.py
+++ b/typed_python/compiler/python_object_representation.py
@@ -1,4 +1,4 @@
-#   Copyright 2017-2019 typed_python Authors
+#   Copyright 2017-2020 typed_python Authors
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
@@ -54,7 +54,7 @@ from typed_python.compiler.type_wrappers.builtin_wrappers import BuiltinWrapper
 from typed_python.compiler.type_wrappers.bytecount_wrapper import BytecountWrapper
 from typed_python.compiler.type_wrappers.arithmetic_wrapper import IntWrapper, FloatWrapper, BoolWrapper
 from typed_python.compiler.type_wrappers.string_wrapper import StringWrapper
-from typed_python.compiler.type_wrappers.bytes_wrapper import BytesWrapper
+from typed_python.compiler.type_wrappers.bytes_wrapper import BytesWrapper, BytesMaketransWrapper
 from typed_python.compiler.type_wrappers.python_object_of_type_wrapper import PythonObjectOfTypeWrapper
 from typed_python.compiler.type_wrappers.abs_wrapper import AbsWrapper
 from typed_python.compiler.type_wrappers.min_max_wrapper import MinWrapper, MaxWrapper
@@ -214,6 +214,9 @@ def pythonObjectRepresentation(context, f, owningGlobalScopeAndName=None):
 
     if f is range:
         return TypedExpression(context, native_ast.nullExpr, _RangeWrapper, False)
+
+    if f is bytes.maketrans:
+        return TypedExpression(context, native_ast.nullExpr, BytesMaketransWrapper(), False)
 
     if f is isinstance:
         return TypedExpression(context, native_ast.nullExpr, IsinstanceWrapper(), False)

--- a/typed_python/compiler/tests/builtin_compilation_test.py
+++ b/typed_python/compiler/tests/builtin_compilation_test.py
@@ -264,6 +264,23 @@ class TestBuiltinCompilation(unittest.TestCase):
                 self.assertEqual(r1, r2)
                 self.assertEqual(type(r1), type(r2))
 
+        def f_min3(*v):
+            return min(v, spuriousparam="x")
+
+        def f_max3(*v):
+            return min(v, spuriousparam="x")
+
+        def f_min4(*v):
+            return min(v, key=f_key2, spuriousparam="x")
+
+        def f_max4(*v):
+            return min(v, key=f_key2, spuriousparam="x")
+
+        for f in [f_min3, f_max3, f_min4, f_max4]:
+            v = [3, 1, 2]
+            with self.assertRaises(TypeError):
+                Entrypoint(f)(v)
+
     def test_min_max_iterable(self):
         def f_min(v):
             return min(v)

--- a/typed_python/compiler/tests/bytes_compilation_test.py
+++ b/typed_python/compiler/tests/bytes_compilation_test.py
@@ -1,4 +1,4 @@
-#   Copyright 2017-2019 typed_python Authors
+#   Copyright 2017-2020 typed_python Authors
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
@@ -12,7 +12,13 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-from typed_python import Compiled, Entrypoint, ListOf
+from typed_python import Compiled, Entrypoint, ListOf, TupleOf, Dict, ConstDict
+from typed_python.compiler.type_wrappers.bytes_wrapper import bytes_isalnum, bytes_isalpha, \
+    bytes_isdigit, bytes_islower, bytes_isspace, bytes_istitle, bytes_isupper, bytes_replace, \
+    bytes_startswith, bytes_endswith, bytes_count, bytes_count_single, bytes_find, bytes_find_single, \
+    bytes_rfind, bytes_rfind_single, bytes_index, bytes_index_single, bytes_rindex, bytes_rindex_single, \
+    bytes_partition, bytes_rpartition, bytes_center, bytes_ljust, bytes_rjust, bytes_expandtabs, \
+    bytes_zfill
 from typed_python.test_util import compilerPerformanceComparison
 import flaky
 
@@ -27,6 +33,13 @@ someBytes = [
     b"\x00\x01",
     b"\x00\x01\x02\x00\x01",
 ]
+
+
+def result_or_exception(f, *p):
+    try:
+        return f(*p)
+    except Exception as e:
+        return type(e)
 
 
 class TestBytesCompilation(unittest.TestCase):
@@ -208,16 +221,27 @@ class TestBytesCompilation(unittest.TestCase):
         def split(someBytes, *args):
             return someBytes.split(*args)
 
+        def rsplit(someBytes, *args):
+            return someBytes.rsplit(*args)
+
         compiledSplit = Entrypoint(split)
+        compiledRsplit = Entrypoint(rsplit)
 
         for args in [
+            (b'',),
+            (b'', b'a'),
+            (b'', b'ab'),
             (b'asdf',),
             (b'asdf', b'blahblah'),
             (b'asdf', b'a'),
             (b'asdf', b's'),
             (b'asdf', b'K'),
             (b'asdf', b's', 0),
+            (b'asdf', b's', -1),
             (b'a aaa bababa a',),
+            (b'a  aaa  bababa  a',),
+            (b'  a   ',),
+            (b' \t\n\r\x0b\f ',),
             (b'a aaa bababa a', b'b'),
             (b'a aaa bababa a', b'b', 1),
             (b'a aaa bababa a', b'b', 2),
@@ -225,9 +249,30 @@ class TestBytesCompilation(unittest.TestCase):
             (b'a aaa bababa a', b'b', 4),
             (b'a aaa bababa a', b'b', 5),
             (b'a aaa bababa a', b'a', 5),
+            (b'a aaa bababa a', b'a', 500),
             (b'a aaa bababa a', b'K', 5),
+            (b'A B\tC\nD\rE\x0bF\fG',),
+            (b'AxyBxyCxyxyxyDEFxyGxyxy', b'xy'),
+            (b'AxyBxy\x00CxyDEFxyGxy', b'xy'),
+            (b'A\x00B\x00C\x00DEF\x00G\x00', b'\x00'),
+            (b'A\x00BA\x00C', b'A\x00B'),
+            (b'A\x00b\x00C\x00DEF\x00G\x00', b'\x00b'),
+            (b'Ax\x00yBx\x00Cx\x00yDEFx\x00yGx\x00y', b'x\x00y')
         ]:
-            assert split(*args) == compiledSplit(*args)
+            self.assertEqual(split(*args), compiledSplit(*args), args)
+            self.assertEqual(rsplit(*args), compiledRsplit(*args), args)
+
+        with self.assertRaises(ValueError):
+            compiledSplit(b'', b'')
+
+        with self.assertRaises(ValueError):
+            compiledRsplit(b'', b'')
+
+        with self.assertRaises(ValueError):
+            compiledSplit(b'abc', b'')
+
+        with self.assertRaises(ValueError):
+            compiledRsplit(b'abc', b'')
 
     @flaky.flaky(max_runs=3, min_passes=1)
     def test_bytes_split_perf(self):
@@ -252,3 +297,610 @@ class TestBytesCompilation(unittest.TestCase):
             f"Expected compiled time {compiled} to be not much slower than uncompiled time {uncompiled}. "
             f"Compiler was {compiled / uncompiled} times slower."
         )
+
+    def test_bytes_iteration(self):
+        def iter(x: bytes):
+            r = ListOf(int)()
+            for a in x:
+                r.append(a)
+            return r
+
+        def iter_constant():
+            r = ListOf(int)()
+            for a in b'constant':
+                r.append(a)
+            return r
+
+        def contains_space(x: bytes):
+            for i in x:
+                if i == 32:
+                    return True
+            return False
+
+        def f_index(x: bytes, i: int):
+            return x[i]
+
+        r1 = iter_constant()
+        r2 = Compiled(iter_constant)()
+        self.assertEqual(type(r1), type(r2))
+        self.assertEqual(r1, r2)
+
+        for v in [b'whatever', b'o', b'']:
+            r1 = iter(v)
+            r2 = Compiled(iter)(v)
+            self.assertEqual(type(r1), type(r2))
+            self.assertEqual(r1, r2)
+
+        for v in [b'', b'a', b' ', b'abc ', b'x' * 1000 + b' ' + b'x' * 1000, b'y' * 1000]:
+            r1 = contains_space(v)
+            r2 = Compiled(contains_space)(v)
+            self.assertEqual(r1, r2)
+
+    def test_bytes_bool_fns(self):
+        def f_isalnum(x):
+            return x.isalnum()
+
+        def f_isalpha(x):
+            return x.isalpha()
+
+        def f_isdigit(x):
+            return x.isdigit()
+
+        def f_islower(x):
+            return x.islower()
+
+        def f_isspace(x):
+            return x.isspace()
+
+        def f_istitle(x):
+            return x.istitle()
+
+        def f_isupper(x):
+            return x.isupper()
+
+        cases = [b'abc' + bytes([i]) + b'abc' for i in range(256)]
+        cases += [b'ABC' + bytes([i]) + b'ABC' for i in range(256)]
+        cases += [b'123' + bytes([i]) for i in range(256)]
+        cases += [b'  \t\r\n\f' + bytes([i]) for i in range(256)]
+        cases += [bytes([i]) + b'123' for i in range(256)]
+        cases += [bytes([i]) + b'   'for i in range(256)]
+        cases += [b'', b'A' * 1000, b'9' * 1000]
+        cases += [b'Title Case', b'NotTitleCase']
+        for f in [f_isalnum, f_isalpha, f_isdigit, f_islower, f_isspace, f_istitle, f_isupper]:
+            for v in cases:
+                r1 = f(v)
+                r2 = Entrypoint(f)(v)
+                self.assertEqual(r1, r2, (f, v))
+
+    def test_bytes_startswith_endswith(self):
+        def f_startswith(x, y):
+            return x.startswith(y)
+
+        def f_endswith(x, y):
+            return x.endswith(y)
+
+        xcases = [b'abaabaaabaaaaabaaaabaaabaabab', b'']
+        ycases = [b'a', b'ab', b'ba', b'abaabaaabaaaaabaaaabaaabaabab', b'abaabaaabaaaaabaaaabaaabaababa', b'']
+        for f in [f_startswith, f_endswith]:
+            for x in xcases:
+                for y in ycases:
+                    r1 = f(x, y)
+                    r2 = Entrypoint(f)(x, y)
+                    self.assertEqual(r1, r2, (f, x, y))
+
+    def test_bytes_case(self):
+        def f_lower(x):
+            return x.lower()
+
+        def f_upper(x):
+            return x.upper()
+
+        def f_capitalize(x):
+            return x.capitalize()
+
+        def f_swapcase(x):
+            return x.swapcase()
+
+        def f_title(x):
+            return x.title()
+
+        cases = [b'abc'*10, b'ABC'*10, b'aBc'*10, b'1@=.,z', b'']
+        cases += [x + b' ' + y for x in cases for y in cases]
+        for f in [f_lower, f_upper, f_capitalize, f_swapcase, f_title]:
+            for v in cases:
+                r1 = f(v)
+                r2 = Entrypoint(f)(v)
+                self.assertEqual(r1, r2, (f, v))
+
+    def test_bytes_strip(self):
+        def f_strip(x):
+            return x.strip()
+
+        def f_lstrip(x):
+            return x.lstrip()
+
+        def f_rstrip(x):
+            return x.rstrip()
+
+        pieces = [b'', b' ', b'\t\n\r\x0B\f', b'abc']
+        cases = [a + b + c for a in pieces for b in pieces for c in pieces]
+
+        for f in [f_strip, f_lstrip, f_rstrip]:
+            for v in cases:
+                r1 = f(v)
+                r2 = Entrypoint(f)(v)
+                self.assertEqual(r1, r2, (f, v))
+
+        def f_strip2(x, y):
+            return x.strip(y)
+
+        def f_lstrip2(x, y):
+            return x.lstrip(y)
+
+        def f_rstrip2(x, y):
+            return x.rstrip(y)
+
+        for f in [f_strip2, f_lstrip2, f_rstrip2]:
+            for y in [b'', b'a', b'ab', b'Z']:
+                for v in cases:
+                    r1 = f(v, y)
+                    r2 = Entrypoint(f)(v, y)
+                    self.assertEqual(r1, r2, (f, v, y))
+
+    def test_bytes_count(self):
+        def f_count(x, sub):
+            return x.count(sub)
+
+        def f_count2(x, sub, start):
+            return x.count(sub, start)
+
+        def f_count3(x, sub, start, end):
+            return x.count(sub, start, end)
+
+        cases = [b'ababcab', b'ababcabcab', b'aabbabbbaaabbaaba']
+        subs = [b'a', b'ab', b'ba', b'abc', b'']
+        for v in cases:
+            for sub in subs:
+                f = f_count
+                r1 = f(v, sub)
+                r2 = Entrypoint(f)(v, sub)
+                self.assertEqual(r1, r2, (v, sub))
+
+                for start in range(-10, 11, 2):
+                    f = f_count2
+                    r1 = f(v, sub, start)
+                    r2 = Entrypoint(f)(v, sub, start)
+                    self.assertEqual(r1, r2, (v, sub, start))
+                    for end in range(-10, 11, 2):
+                        f = f_count3
+                        r1 = f(v, sub, start, end)
+                        r2 = Entrypoint(f)(v, sub, start, end)
+                        self.assertEqual(r1, r2, (v, sub, start, end))
+
+    def test_bytes_find(self):
+        def f_find(x, sub):
+            return x.find(sub)
+
+        def f_find2(x, sub, start):
+            return x.find(sub, start)
+
+        def f_find3(x, sub, start, end):
+            return x.find(sub, start, end)
+
+        def f_rfind(x, sub):
+            return x.rfind(sub)
+
+        def f_rfind2(x, sub, start):
+            return x.rfind(sub, start)
+
+        def f_rfind3(x, sub, start, end):
+            return x.rfind(sub, start, end)
+
+        def f_index(x, sub):
+            return x.index(sub)
+
+        def f_index2(x, sub, start):
+            return x.index(sub, start)
+
+        def f_index3(x, sub, start, end):
+            return x.index(sub, start, end)
+
+        def f_rindex(x, sub):
+            return x.rindex(sub)
+
+        def f_rindex2(x, sub, start):
+            return x.rindex(sub, start)
+
+        def f_rindex3(x, sub, start, end):
+            return x.rindex(sub, start, end)
+
+        cases = [b'ababcab', b'ababcabcab', b'aabbabbbaaabbaaba']
+        subs = [97, 98, b'a', b'c', b'X', b'ab', b'ba', b'abc', b'']
+        for v in cases:
+            for sub in subs:
+                for f in [f_find, f_rfind]:
+                    r1 = f(v, sub)
+                    r2 = Entrypoint(f)(v, sub)
+                    self.assertEqual(r1, r2, (f, v, sub))
+                    g = f_index if f == f_find else f_rindex
+                    if r1 != -1:
+                        r3 = Entrypoint(g)(v, sub)
+                        self.assertEqual(r1, r3, (g, v, sub))
+                    else:
+                        with self.assertRaises(ValueError):
+                            Entrypoint(g)(v, sub)
+
+                for start in range(-10, 11, 2):
+                    for f in [f_find2, f_rfind2]:
+                        r1 = f(v, sub, start)
+                        r2 = Entrypoint(f)(v, sub, start)
+                        self.assertEqual(r1, r2, (f, v, sub, start))
+                        g = f_index2 if f == f_find2 else f_rindex2
+                        if r1 != -1:
+                            r3 = Entrypoint(g)(v, sub, start)
+                            self.assertEqual(r1, r3, (g, v, sub, start))
+                        else:
+                            with self.assertRaises(ValueError):
+                                Entrypoint(g)(v, sub, start)
+                    for end in range(-10, 11, 2):
+                        for f in [f_find3, f_rfind3]:
+                            r1 = f(v, sub, start, end)
+                            r2 = Entrypoint(f)(v, sub, start, end)
+                            self.assertEqual(r1, r2, (f, v, sub, start, end))
+
+                            g = f_index3 if f == f_find3 else f_rindex3
+                            if r1 != -1:
+                                r3 = Entrypoint(g)(v, sub, start, end)
+                                self.assertEqual(r1, r3, (g, v, sub, start, end))
+                            else:
+                                with self.assertRaises(ValueError):
+                                    Entrypoint(g)(v, sub, start, end)
+
+    def test_bytes_mult(self):
+        def f_mult(x, n):
+            return x * n
+
+        v = b'XyZ'
+        for n in [1, 5, 100, 0, -1]:
+            r1 = f_mult(v, n)
+            r2 = Entrypoint(f_mult)(v, n)
+            self.assertEqual(r1, r2, n)
+
+    def test_bytes_contains_bytes(self):
+        @Entrypoint
+        def f_contains(x, y):
+            return x in y
+
+        @Entrypoint
+        def f_not_contains(x, y):
+            return x not in y
+
+        self.assertTrue(f_contains(b'a', b'asfd'))
+        self.assertFalse(f_contains(b'b', b'asfd'))
+        self.assertFalse(f_contains(b'b', ListOf(bytes)([b'asfd'])))
+        self.assertTrue(f_contains(b'asdf', ListOf(bytes)([b'asdf'])))
+
+        self.assertFalse(f_not_contains(b'a', b'asfd'))
+        self.assertTrue(f_not_contains(b'b', b'asfd'))
+        self.assertTrue(f_not_contains(b'b', ListOf(bytes)([b'asfd'])))
+        self.assertFalse(f_not_contains(b'asdf', ListOf(bytes)([b'asdf'])))
+
+    def test_bytes_replace(self):
+        def replace(x: bytes, y: bytes, z: bytes):
+            return x.replace(y, z)
+
+        def replace2(x: bytes, y: bytes, z: bytes, i: int):
+            return x.replace(y, z, i)
+
+        replaceCompiled = Compiled(replace)
+        replace2Compiled = Compiled(replace2)
+
+        values = {b'', b'ba', b'abc'}
+        for _ in range(2):
+            for y in [b'ab', b'ba'*100]:
+                values = values.union({x + y for x in values})
+
+        for s1 in values:
+            for s2 in values:
+                for s3 in values:
+                    r1 = replace(s1, s2, s3)
+                    r2 = replaceCompiled(s1, s2, s3)
+                    self.assertEqual(r1, r2)
+
+                    for i in [-1, 0, 1, 2]:
+                        r1 = replace2(s1, s2, s3, i)
+                        r2 = replace2Compiled(s1, s2, s3, i)
+                        self.assertEqual(r1, r2, (s1, s2, s3, i))
+
+    def validate_joining_bytes(self, function, make_obj):
+        # Test data, the fields are: description, separator, items, expected output
+        test_data = [
+            ["simple data",
+             b",", [b"1", b"2", b"3"], b"1,2,3"],
+
+            ["longer separator",
+             b"---", [b"1", b"2", b"3"], b"1---2---3"],
+
+            ["longer items",
+             b"---", [b"aaa", b"bb", b"c"], b"aaa---bb---c"],
+
+            ["empty separator",
+             b"", [b"1", b"2", b"3"], b"123"],
+
+            ["everything empty",
+             b"", [], b""],
+
+            ["empty list",
+             b"a", [], b""],
+
+            ["empty bytes in the items",
+             b"--", [b"", b"1", b"3"], b"--1--3"],
+
+            ["blank bytes in the items",
+             b"--", [b" ", b"1", b"3"], b" --1--3"],
+        ]
+
+        for description, separator, items, expected in test_data:
+            res = function(separator, make_obj(items))
+            self.assertEqual(expected, res, description)
+
+    def test_bytes_join_for_tuple_of_bytes(self):
+        # test passing tuple of bytes
+        @Compiled
+        def f(sep: bytes, items: TupleOf(bytes)) -> bytes:
+            return sep.join(items)
+
+        self.validate_joining_bytes(f, lambda items: TupleOf(bytes)(items))
+
+    def test_bytes_join_for_list_of_bytes(self):
+        # test passing list of bytes
+        @Compiled
+        def f(sep: bytes, items: ListOf(bytes)) -> bytes:
+            return sep.join(items)
+
+        self.validate_joining_bytes(f, lambda items: ListOf(bytes)(items))
+
+    def test_bytes_join_for_dict_of_bytes(self):
+        # test passing list of bytes
+        @Compiled
+        def f(sep: bytes, items: Dict(bytes, bytes)) -> bytes:
+            return sep.join(items)
+
+        self.validate_joining_bytes(f, lambda items: Dict(bytes, bytes)({i: b"a" for i in items}))
+
+    def test_bytes_join_for_const_dict_of_bytes(self):
+        # test passing list of bytes
+        @Compiled
+        def f(sep: bytes, items: ConstDict(bytes, bytes)) -> bytes:
+            return sep.join(items)
+
+        self.validate_joining_bytes(f, lambda items: ConstDict(bytes, bytes)({i: b"a" for i in items}))
+
+    def test_bytes_join_for_bad_types(self):
+        """bytes.join supports only joining iterables of bytes."""
+
+        # test passing tuple of ints
+        @Compiled
+        def f_tup_int(sep: bytes, items: TupleOf(int)) -> bytes:
+            return sep.join(items)
+
+        with self.assertRaisesRegex(TypeError, ""):
+            f_tup_int(b",", ListOf(int)([1, 2, 3]))
+
+        # test passing list of other types than bytes
+        @Compiled
+        def f_int(sep: bytes, items: ListOf(str)) -> bytes:
+            return sep.join(items)
+
+        with self.assertRaisesRegex(TypeError, ""):
+            f_int(b",", ListOf(int)(["1", "2", "3"]))
+
+    def test_bytes_decode(self):
+        def f_decode1(x, _i1, _i2):
+            return x.decode()
+
+        def f_decode2(x, enc, _i2):
+            return x.decode(enc)
+
+        def f_decode3(x, enc, err):
+            return x.decode(enc, err)
+
+        for v in [b'quarter'*1000, b'25\xC2\xA2', b'\xE2\x82\xAC100', b'\xF0\x9F\x98\x80', b'']:
+            for f in [f_decode1, f_decode2, f_decode3]:
+                for enc in ["utf-8", "ascii", "cp863", "hz"]:
+                    for err in ["strict", "ignore", "replace"]:
+                        r1 = result_or_exception(f, v, enc, err)
+                        r2 = result_or_exception(Entrypoint(f), v, enc, err)
+                        self.assertEqual(r1, r2)
+
+    def test_bytes_translate(self):
+        def f_translate1(x, table):
+            return x.translate(table)
+
+        def f_translate2(x, table, to_delete):
+            return x.translate(table, to_delete)
+
+        def f_translate3(x, table, to_delete):
+            return x.translate(table, delete=to_delete)
+
+        t1 = b'0123456789abcdef'*16
+        t2 = b'ABCDEFGHIJKLMNOP'*16
+        t3 = bytes.maketrans(b'abc123', b'XYZijk')
+
+        for v in [b'Abc', b'1234\r\n\f\x00ABCDabcd'*256, b'']:
+            for t in [None, t1, t2, t3]:
+                r1 = f_translate1(v, t)
+                r2 = Entrypoint(f_translate1)(v, t)
+                self.assertEqual(r1, r2, (v, t))
+
+                for d in [b'a', b'Bb', b'']:
+                    r1 = f_translate2(v, t, d)
+                    r2 = Entrypoint(f_translate2)(v, t, d)
+                    self.assertEqual(r1, r2, (v, t, d))
+
+                    r1 = f_translate3(v, t, d)
+                    r2 = Entrypoint(f_translate3)(v, t, d)
+                    self.assertEqual(r1, r2, (v, t, d))
+
+        with self.assertRaises(ValueError):
+            Entrypoint(f_translate1)(b'Abc', b'too short')
+
+        with self.assertRaises(ValueError):
+            Entrypoint(f_translate1)(b'Abc', b'too long'*100)
+
+        with self.assertRaises(TypeError):
+            Entrypoint(f_translate1)(b'Abc', 'wrong type')
+
+        def f_maketrans1(x, y):
+            return b''.maketrans(x, y)
+
+        def f_maketrans2(x, y):
+            return bytes.maketrans(x, y)
+
+        def f_maketrans3(t, x, y):
+            return t.maketrans(x, y)  # convincing myself that I'm recognizing maketrans properly
+
+        cases = (
+            (b'', b''),
+            (b'abc123', b'XYZijk'),
+            (b' ', b'-'),
+            (b' '*500, b'-'*500),
+            (b'a', b'ab'),
+            (b'ab', b'a'),
+            (b'wrong', 'type '),
+            (b'wrong', 123),
+        )
+        for f in [f_maketrans1, f_maketrans2]:
+            for x, y in cases:
+                r1 = result_or_exception(f, x, y)
+                r2 = result_or_exception(Entrypoint(f), x, y)
+                self.assertEqual(r1, r2, (f, x, y))
+        for x, y in cases:
+            r1 = result_or_exception(f_maketrans3, bytes, x, y)
+            r2 = result_or_exception(Entrypoint(f_maketrans3), bytes, x, y)
+            self.assertEqual(r1, r2, (f_maketrans3, x, y))
+
+    def test_bytes_partition(self):
+        def f_partition(x, sep):
+            return x.partition(sep)
+
+        def f_rpartition(x, sep):
+            return x.rpartition(sep)
+
+        for f in [f_partition, f_rpartition]:
+            for v in [b' beginning', b'end ', b'mid dle', b'wind', b'spin', b'']:
+                for sep in [b' ', b'in']:
+                    r1 = f(v, sep)
+                    r2 = Entrypoint(f)(v, sep)
+                    self.assertEqual(r1, r2, (f, v, sep))
+
+                with self.assertRaises(ValueError):
+                    Entrypoint(f)(v, b'')
+
+                with self.assertRaises(TypeError):
+                    Entrypoint(f)(v, 'abc')
+
+    def test_bytes_just(self):
+        def f_center(x, w, fill):
+            if fill == ' ':
+                return x.center(w)
+            else:
+                return x.center(w, fill)
+
+        def f_ljust(x, w, fill):
+            if fill == ' ':
+                return x.ljust(w)
+            else:
+                return x.ljust(w, fill)
+
+        def f_rjust(x, w, fill):
+            if fill == ' ':
+                return x.rjust(w)
+            else:
+                return x.rjust(w, fill)
+
+        for f in [f_center, f_ljust, f_rjust]:
+            for v in [b'short', b'long'*100, b'']:
+                for w in [0, 8, 16, 100]:
+                    for fill in [b' ', b'X']:
+                        r1 = f(v, w, fill)
+                        r2 = Entrypoint(f)(v, w, fill)
+                        self.assertEqual(r1, r2, (f, v, w, fill))
+
+                    with self.assertRaises(TypeError):
+                        Entrypoint(f)(v, w, b'22')
+                    with self.assertRaises(TypeError):
+                        Entrypoint(f)(v, w, b'')
+                    with self.assertRaises(TypeError):
+                        Entrypoint(f)(v, w, 'X')
+
+    def test_bytes_tabs(self):
+        def f_expandtabs(x, t):
+            return x.expandtabs(t)
+
+        def f_splitlines(x, *a):
+            return x.splitlines(*a)
+
+        words = {b'one\ttwo\tthree', b'eleven\ttwelve\t', b'\tseveral words in a row\t', b'', b'\t', b'\n', b'\x00'}
+        words = words.union({x + y + z for x in words for y in words for z in words})
+        for v in words:
+            for t in [8, 3, 1, 0, -1]:
+                r1 = f_expandtabs(v, t)
+                r2 = Entrypoint(f_expandtabs)(v, t)
+                self.assertEqual(r1, r2, (v, t))
+
+        segments = {b'one\ntwo\rthree', b'\nseveral words on a line\r\n', b'', b'\t', b'\n', b'\r', b'\r\n', b'\n\r', b'\x00'}
+        segments = segments.union({x + y + z for x in segments for y in segments for z in segments})
+        for v in segments:
+            r1 = f_splitlines(v)
+            r2 = Entrypoint(f_splitlines)(v)
+            self.assertEqual(r1, r2, (v,))
+            for k in [True, False]:
+                r1 = f_splitlines(v, k)
+                r2 = Entrypoint(f_splitlines)(v, k)
+                self.assertEqual(r1, r2, (v, k))
+
+    def test_bytes_zfill(self):
+        def f_zfill(x, w):
+            return x.zfill(w)
+
+        for v in [b'123', b'-9876', b'+1', b'testing', b'+', b'-', b'']:
+            for w in [0, 1, 5, 10, 100, -1]:
+                r1 = f_zfill(v, w)
+                r2 = Entrypoint(f_zfill)(v, w)
+                self.assertEqual(r1, r2, (v, w))
+
+    def test_bytes_internal_fns(self):
+        """
+        These are functions that are normally not called directly.
+        They are called here in order to improve codecov coverage.
+        """
+        v = b'a1A\ta1A\n1A'
+        self.assertEqual(bytes_isalnum(v), v.isalnum())
+        self.assertEqual(bytes_isalpha(v), v.isalpha())
+        self.assertEqual(bytes_isdigit(v), v.isdigit())
+        self.assertEqual(bytes_islower(v), v.islower())
+        self.assertEqual(bytes_isspace(v), v.isspace())
+        self.assertEqual(bytes_istitle(v), v.istitle())
+        self.assertEqual(bytes_isupper(v), v.isupper())
+
+        self.assertEqual(bytes_replace(v, b'a', b'xyz', 1), v.replace(b'a', b'xyz', 1))
+        self.assertEqual(bytes_startswith(v, b'a'), v.startswith(b'a'))
+        self.assertEqual(bytes_endswith(v, b'A'), v.endswith(b'A'))
+        self.assertEqual(bytes_count(v, b'a1', 0, 10), v.count(b'a1', 0, 10))
+        self.assertEqual(bytes_count_single(v, 97, 0, 10), v.count(97, 0, 10))
+        self.assertEqual(bytes_find(v, b'a1', 0, 10), v.find(b'a1', 0, 10))
+        self.assertEqual(bytes_find_single(v, 97, 0, 10), v.find(97, 0, 10))
+        self.assertEqual(bytes_rfind(v, b'a1', 0, 10), v.rfind(b'a1', 0, 10))
+        self.assertEqual(bytes_rfind_single(v, 97, 0, 10), v.rfind(97, 0, 10))
+        self.assertEqual(bytes_index(v, b'a1', 0, 10), v.index(b'a1', 0, 10))
+        self.assertEqual(bytes_index_single(v, 97, 0, 10), v.index(97, 0, 10))
+        self.assertEqual(bytes_rindex(v, b'a1', 0, 10), v.rindex(b'a1', 0, 10))
+        self.assertEqual(bytes_rindex_single(v, 97, 0, 10), v.rindex(97, 0, 10))
+        self.assertEqual(bytes_partition(v, b'1'), v.partition(b'1'))
+        self.assertEqual(bytes_rpartition(v, b'1'), v.rpartition(b'1'))
+        self.assertEqual(bytes_center(v, 20, b'X'), v.center(20, b'X'))
+        self.assertEqual(bytes_rjust(v, 20, b'X'), v.rjust(20, b'X'))
+        self.assertEqual(bytes_ljust(v, 20, b'X'), v.ljust(20, b'X'))
+        self.assertEqual(bytes_expandtabs(v, 8), v.expandtabs(8))
+        self.assertEqual(bytes_zfill(v, 20), v.zfill(20))

--- a/typed_python/compiler/tests/bytes_compilation_test.py
+++ b/typed_python/compiler/tests/bytes_compilation_test.py
@@ -13,7 +13,8 @@
 #   limitations under the License.
 
 from typed_python import Compiled, Entrypoint, ListOf, TupleOf, Dict, ConstDict
-from typed_python.compiler.type_wrappers.bytes_wrapper import bytes_isalnum, bytes_isalpha, \
+from typed_python.compiler.type_wrappers.bytes_wrapper import bytesJoinIterable, \
+    bytes_isalnum, bytes_isalpha, \
     bytes_isdigit, bytes_islower, bytes_isspace, bytes_istitle, bytes_isupper, bytes_replace, \
     bytes_startswith, bytes_endswith, bytes_count, bytes_count_single, bytes_find, bytes_find_single, \
     bytes_rfind, bytes_rfind_single, bytes_index, bytes_index_single, bytes_rindex, bytes_rindex_single, \
@@ -875,32 +876,58 @@ class TestBytesCompilation(unittest.TestCase):
         These are functions that are normally not called directly.
         They are called here in order to improve codecov coverage.
         """
-        v = b'a1A\ta1A\n1A'
-        self.assertEqual(bytes_isalnum(v), v.isalnum())
-        self.assertEqual(bytes_isalpha(v), v.isalpha())
-        self.assertEqual(bytes_isdigit(v), v.isdigit())
-        self.assertEqual(bytes_islower(v), v.islower())
-        self.assertEqual(bytes_isspace(v), v.isspace())
-        self.assertEqual(bytes_istitle(v), v.istitle())
-        self.assertEqual(bytes_isupper(v), v.isupper())
+        lst = [b'a', b'b', b'c']
+        sep = b','
+        self.assertEqual(bytesJoinIterable(sep, lst), sep.join(lst))
+        with self.assertRaises(TypeError):
+            bytesJoinIterable(sep, [b'a', 'b', b'c'])
 
+        for v in [b'', b'abc', b'ABC', b'123', b'a1A', b' \t\n', b'Abc', b'Abc Def']:
+            self.assertEqual(bytes_isalnum(v), v.isalnum())
+            self.assertEqual(bytes_isalpha(v), v.isalpha())
+            self.assertEqual(bytes_isdigit(v), v.isdigit())
+            self.assertEqual(bytes_islower(v), v.islower())
+            self.assertEqual(bytes_isspace(v), v.isspace())
+            self.assertEqual(bytes_istitle(v), v.istitle())
+            self.assertEqual(bytes_isupper(v), v.isupper())
+
+        v = b'a1A\ta1A\n1A'
         self.assertEqual(bytes_replace(v, b'a', b'xyz', 1), v.replace(b'a', b'xyz', 1))
+        self.assertEqual(bytes_replace(v, b'a', b'xyz', 0), v.replace(b'a', b'xyz', 0))
+        self.assertEqual(bytes_replace(v, b'', b'xyz', 2), v.replace(b'', b'xyz', 2))
         self.assertEqual(bytes_startswith(v, b'a'), v.startswith(b'a'))
+        self.assertEqual(bytes_startswith(v, b'A'), v.startswith(b'A'))
+        self.assertEqual(bytes_endswith(v, b'a'), v.endswith(b'a'))
         self.assertEqual(bytes_endswith(v, b'A'), v.endswith(b'A'))
-        self.assertEqual(bytes_count(v, b'a1', 0, 10), v.count(b'a1', 0, 10))
-        self.assertEqual(bytes_count_single(v, 97, 0, 10), v.count(97, 0, 10))
-        self.assertEqual(bytes_find(v, b'a1', 0, 10), v.find(b'a1', 0, 10))
-        self.assertEqual(bytes_find_single(v, 97, 0, 10), v.find(97, 0, 10))
-        self.assertEqual(bytes_rfind(v, b'a1', 0, 10), v.rfind(b'a1', 0, 10))
-        self.assertEqual(bytes_rfind_single(v, 97, 0, 10), v.rfind(97, 0, 10))
-        self.assertEqual(bytes_index(v, b'a1', 0, 10), v.index(b'a1', 0, 10))
-        self.assertEqual(bytes_index_single(v, 97, 0, 10), v.index(97, 0, 10))
-        self.assertEqual(bytes_rindex(v, b'a1', 0, 10), v.rindex(b'a1', 0, 10))
-        self.assertEqual(bytes_rindex_single(v, 97, 0, 10), v.rindex(97, 0, 10))
+        for start, end in [(0, 10), (-2, -1), (-20, 10), (0, -20)]:
+            self.assertEqual(bytes_count(v, b'a1', start, end), v.count(b'a1', start, end))
+            self.assertEqual(bytes_count(v, b'A1', start, end), v.count(b'A1', start, end))
+            self.assertEqual(bytes_count(v, b'', start, end), v.count(b'', start, end))
+            self.assertEqual(bytes_count_single(v, 97, start, end), v.count(97, start, end))
+            self.assertEqual(bytes_find(v, b'a1', start, end), v.find(b'a1', start, end))
+            self.assertEqual(bytes_find(v, b'A1', start, end), v.find(b'A1', start, end))
+            self.assertEqual(bytes_find(v, b'', start, end), v.find(b'', start, end))
+            self.assertEqual(bytes_find_single(v, 97, start, end), v.find(97, start, end))
+            self.assertEqual(bytes_rfind(v, b'a1', start, end), v.rfind(b'a1', start, end))
+            self.assertEqual(bytes_rfind(v, b'A1', start, end), v.rfind(b'A1', start, end))
+            self.assertEqual(bytes_rfind(v, b'', start, end), v.rfind(b'', start, end))
+            self.assertEqual(bytes_rfind_single(v, 97, start, end), v.rfind(97, start, end))
+            self.assertEqual(result_or_exception(bytes_index, v, b'a1', start, end), result_or_exception(v.index, b'a1', start, end))
+            self.assertEqual(result_or_exception(bytes_index, v, b'A1', start, end), result_or_exception(v.index, b'A1', start, end))
+            self.assertEqual(result_or_exception(bytes_index, v, b'', start, end), result_or_exception(v.index, b'', start, end))
+            self.assertEqual(result_or_exception(bytes_index_single, v, 97, start, end), result_or_exception(v.index, 97, start, end))
+            self.assertEqual(result_or_exception(bytes_rindex, v, b'a1', start, end), result_or_exception(v.rindex, b'a1', start, end))
+            self.assertEqual(result_or_exception(bytes_rindex, v, b'A1', start, end), result_or_exception(v.rindex, b'A1', start, end))
+            self.assertEqual(result_or_exception(bytes_rindex, v, b'', start, end), result_or_exception(v.rindex, b'', start, end))
+            self.assertEqual(result_or_exception(bytes_rindex_single, v, 97, start, end), result_or_exception(v.rindex, 97, start, end))
         self.assertEqual(bytes_partition(v, b'1'), v.partition(b'1'))
         self.assertEqual(bytes_rpartition(v, b'1'), v.rpartition(b'1'))
         self.assertEqual(bytes_center(v, 20, b'X'), v.center(20, b'X'))
+        self.assertEqual(bytes_center(v, 2, b'X'), v.center(2, b'X'))
         self.assertEqual(bytes_rjust(v, 20, b'X'), v.rjust(20, b'X'))
+        self.assertEqual(bytes_rjust(v, 2, b'X'), v.rjust(2, b'X'))
         self.assertEqual(bytes_ljust(v, 20, b'X'), v.ljust(20, b'X'))
+        self.assertEqual(bytes_ljust(v, 2, b'X'), v.ljust(2, b'X'))
         self.assertEqual(bytes_expandtabs(v, 8), v.expandtabs(8))
         self.assertEqual(bytes_zfill(v, 20), v.zfill(20))
+        self.assertEqual(bytes_zfill(b'+123', 20), b'+123'.zfill(20))

--- a/typed_python/compiler/tests/string_compilation_test.py
+++ b/typed_python/compiler/tests/string_compilation_test.py
@@ -1,4 +1,4 @@
-#   Copyright 2017-2019 typed_python Authors
+#   Copyright 2017-2020 typed_python Authors
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
@@ -191,8 +191,6 @@ class TestStringCompilation(unittest.TestCase):
         def replace(x: str, y: str, z: str):
             return x.replace(y, z)
 
-        replaceCompiled = Compiled(replace)
-
         def replace2(x: str, y: str, z: str, i: int):
             return x.replace(y, z, i)
 
@@ -200,17 +198,17 @@ class TestStringCompilation(unittest.TestCase):
         replace2Compiled = Compiled(replace2)
 
         strings = [""]
-        for _ in range(6):
-            for s in ["ab"]:
-                strings = [x + s for x in strings]
+        for _ in range(2):
+            for s in ["ab", "c", "ba"*100]:
+                strings += [x + s for x in strings]
 
         for s1 in strings:
             for s2 in strings:
                 for s3 in strings:
-                    self.assertEqual(replace(s1, s2, s3), replaceCompiled(s1, s2, s3))
+                    self.assertEqual(replace(s1, s2, s3), replaceCompiled(s1, s2, s3), (s1, s2, s3))
 
                     for i in [-1, 0, 1, 2]:
-                        self.assertEqual(replace2(s1, s2, s3, i), replace2Compiled(s1, s2, s3, i))
+                        self.assertEqual(replace2(s1, s2, s3, i), replace2Compiled(s1, s2, s3, i), (s1, s2, s3, i))
 
     def test_string_getitem_slice(self):
         def getitem1(x: str, y: int):
@@ -806,3 +804,48 @@ class TestStringCompilation(unittest.TestCase):
             return int(x)
 
         assert f("1") == 1
+
+    def test_string_iteration(self):
+        def iter(x: str):
+            r = ListOf(str)()
+            for a in x:
+                r.append(a)
+            return r
+
+        def iter_constant():
+            r = ListOf(str)()
+            for a in "constant":
+                r.append(a)
+            return r
+
+        def contains_space(x: str):
+            for c in x:
+                if c == ' ':
+                    return True
+            return False
+
+        r1 = iter_constant()
+        r2 = Compiled(iter_constant)()
+        self.assertEqual(type(r1), type(r2))
+        self.assertEqual(r1, r2)
+
+        for v in ['whatever', 'o', '']:
+            r1 = iter(v)
+            r2 = Compiled(iter)(v)
+            self.assertEqual(type(r1), type(r2))
+            self.assertEqual(r1, r2)
+
+        for v in ['', 'a', ' ', 'abc ', 'x'*1000+' '+'x'*1000, 'y'*1000]:
+            r1 = contains_space(v)
+            r2 = Compiled(contains_space)(v)
+            self.assertEqual(r1, r2)
+
+    def test_string_mult(self):
+        def f_mult(x, n):
+            return x * n
+
+        v = "XyZ"
+        for n in [1, 5, 100, 0, -1]:
+            r1 = f_mult(v, n)
+            r2 = Entrypoint(f_mult)(v, n)
+            self.assertEqual(r1, r2)

--- a/typed_python/compiler/type_wrappers/arithmetic_wrapper.py
+++ b/typed_python/compiler/type_wrappers/arithmetic_wrapper.py
@@ -300,6 +300,9 @@ class IntWrapper(ArithmeticTypeWrapper):
 
     def convert_builtin(self, f, context, expr, a1=None):
         if f is chr and a1 is None:
+            if expr.isConstant:
+                return context.constant(chr(expr.constantValue))
+
             return context.push(
                 str,
                 lambda strRef: strRef.expr.store(

--- a/typed_python/compiler/type_wrappers/bytes_wrapper.py
+++ b/typed_python/compiler/type_wrappers/bytes_wrapper.py
@@ -88,7 +88,7 @@ def bytes_isalnum(x):
     if len(x) == 0:
         return False
     for i in x:
-        if i < ord('0') or (i > ord('9') and i < ord('A')) or (i > ord('Z') and i < ord('a')) or i > ord('z'):
+        if not (ord('0') <= i <= ord('9') or ord('A') <= i <= ord('Z') or ord('a') <= i <= ord('z')):
             return False
     return True
 
@@ -97,7 +97,7 @@ def bytes_isalpha(x):
     if len(x) == 0:
         return False
     for i in x:
-        if i < ord('A') or (i > ord('Z') and i < ord('a')) or i > ord('z'):
+        if not (ord('A') <= i <= ord('Z') or ord('a') <= i <= ord('z')):
             return False
     return True
 
@@ -106,7 +106,7 @@ def bytes_isdigit(x):
     if len(x) == 0:
         return False
     for i in x:
-        if i < ord('0') or i > ord('9'):
+        if not (ord('0') <= i <= ord('9')):
             return False
     return True
 
@@ -114,9 +114,9 @@ def bytes_isdigit(x):
 def bytes_islower(x):
     found_lower = False
     for i in x:
-        if i >= ord('a') and i <= ord('z'):
+        if ord('a') <= i <= ord('z'):
             found_lower = True
-        elif i >= ord('A') and i <= ord('Z'):
+        elif ord('A') <= i <= ord('Z'):
             return False
     return found_lower
 
@@ -136,8 +136,8 @@ def bytes_istitle(x):
     last_cased = False
     found_one = False
     for i in x:
-        upper = i >= ord('A') and i <= ord('Z')
-        lower = i >= ord('a') and i <= ord('z')
+        upper = ord('A') <= i <= ord('Z')
+        lower = ord('a') <= i <= ord('z')
         if upper and last_cased:
             return False
         if lower and not last_cased:
@@ -151,9 +151,9 @@ def bytes_istitle(x):
 def bytes_isupper(x):
     found_upper = False
     for i in x:
-        if i >= ord('A') and i <= ord('Z'):
+        if ord('A') <= i <= ord('Z'):
             found_upper = True
-        elif i >= ord('a') and i <= ord('z'):
+        elif ord('a') <= i <= ord('z'):
             return False
     return found_upper
 

--- a/typed_python/compiler/type_wrappers/bytes_wrapper.py
+++ b/typed_python/compiler/type_wrappers/bytes_wrapper.py
@@ -1,4 +1,4 @@
-#   Copyright 2017-2019 typed_python Authors
+#   Copyright 2017-2020 typed_python Authors
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
@@ -14,19 +14,459 @@
 
 from typed_python import sha_hash
 from typed_python.compiler.global_variable_definition import GlobalVariableMetadata
+from typed_python.compiler.type_wrappers.wrapper import Wrapper
 from typed_python.compiler.type_wrappers.refcounted_wrapper import RefcountedWrapper
 from typed_python.compiler.type_wrappers.bound_method_wrapper import BoundMethodWrapper
 import typed_python.compiler.type_wrappers.runtime_functions as runtime_functions
 from typed_python.compiler.type_wrappers.typed_list_masquerading_as_list_wrapper import TypedListMasqueradingAsList
 
-from typed_python import Int32, ListOf
+from typed_python import UInt8, Int32, ListOf, Tuple
+from typed_python.type_promotion import isInteger
 
 import typed_python.compiler.native_ast as native_ast
 import typed_python.compiler
 
 from typed_python.compiler.native_ast import VoidPtr
 
+
 typeWrapper = lambda t: typed_python.compiler.python_object_representation.typedPythonTypeToTypeWrapper(t)
+
+
+def bytesJoinIterable(sep, iterable):
+    """Converts the iterable container to list of bytes objects and call sep.join(iterable).
+
+    If any of the values in the container is not bytes type, an exception is thrown.
+
+    :param sep: string to separate the items
+    :param iterable: iterable container with strings only
+    :return: string with joined values
+    """
+    items = ListOf(bytes)()
+
+    for item in iterable:
+        if isinstance(item, bytes):
+            items.append(item)
+        else:
+            raise TypeError("expected str instance")
+    return sep.join(items)
+
+
+def bytes_replace(x, old, new, maxCount):
+    if maxCount == 0 or (maxCount >= 0 and len(x) == 0 and len(old) == 0):
+        return x
+
+    accumulator = ListOf(bytes)()
+
+    pos = 0
+    seen = 0
+    inc = 0 if len(old) else 1
+    if len(old) == 0:
+        accumulator.append(b'')
+        seen += 1
+
+    while True:
+        if maxCount >= 0 and seen >= maxCount:
+            nextLoc = -1
+        else:
+            nextLoc = x.find(old, pos)
+
+        if nextLoc >= 0 and nextLoc < len(x):
+            accumulator.append(x[pos:nextLoc + inc])
+
+            if len(old):
+                pos = nextLoc + len(old)
+            else:
+                pos += 1
+
+            seen += 1
+        else:
+            accumulator.append(x[pos:])
+            return new.join(accumulator)
+
+
+def bytes_isalnum(x):
+    if len(x) == 0:
+        return False
+    for i in x:
+        if i < ord('0') or (i > ord('9') and i < ord('A')) or (i > ord('Z') and i < ord('a')) or i > ord('z'):
+            return False
+    return True
+
+
+def bytes_isalpha(x):
+    if len(x) == 0:
+        return False
+    for i in x:
+        if i < ord('A') or (i > ord('Z') and i < ord('a')) or i > ord('z'):
+            return False
+    return True
+
+
+def bytes_isdigit(x):
+    if len(x) == 0:
+        return False
+    for i in x:
+        if i < ord('0') or i > ord('9'):
+            return False
+    return True
+
+
+def bytes_islower(x):
+    found_lower = False
+    for i in x:
+        if i >= ord('a') and i <= ord('z'):
+            found_lower = True
+        elif i >= ord('A') and i <= ord('Z'):
+            return False
+    return found_lower
+
+
+def bytes_isspace(x):
+    if len(x) == 0:
+        return False
+    for i in x:
+        if i != ord(' ') and i != ord('\t') and i != ord('\n') and i != ord('\r') and i != 0x0b and i != ord('\f'):
+            return False
+    return True
+
+
+def bytes_istitle(x):
+    if len(x) == 0:
+        return False
+    last_cased = False
+    found_one = False
+    for i in x:
+        upper = i >= ord('A') and i <= ord('Z')
+        lower = i >= ord('a') and i <= ord('z')
+        if upper and last_cased:
+            return False
+        if lower and not last_cased:
+            return False
+        last_cased = upper or lower
+        if last_cased:
+            found_one = True
+    return found_one
+
+
+def bytes_isupper(x):
+    found_upper = False
+    for i in x:
+        if i >= ord('A') and i <= ord('Z'):
+            found_upper = True
+        elif i >= ord('a') and i <= ord('z'):
+            return False
+    return found_upper
+
+
+def bytes_startswith(x, prefix):
+    if len(x) < len(prefix):
+        return False
+    index = 0
+    for i in prefix:
+        if x[index] != i:
+            return False
+        index += 1
+    return True
+
+
+def bytes_endswith(x, suffix):
+    index = len(x) - len(suffix)
+    if index < 0:
+        return False
+    for i in suffix:
+        if x[index] != i:
+            return False
+        index += 1
+    return True
+
+
+# sub is a bytes-like object
+def bytes_count(x, sub, start, end):
+    if start < 0:
+        start += len(x)
+    if start < 0:
+        start = 0
+    if end < 0:
+        end += len(x)
+    if end < 0:
+        end = 0
+    if end > len(x):
+        end = len(x)
+
+    len_sub = len(sub)
+    if len_sub == 0:
+        if start > len(x):
+            return 0
+        count = end - start + 1
+        if count < 0:
+            count = 0
+        return count
+
+    count = 0
+    index = start
+    while index < end - len_sub + 1:
+        subindex = 0
+        while subindex < len_sub:
+            if x[index+subindex] != sub[subindex]:
+                break
+            subindex += 1
+            if subindex == len_sub:
+                count += 1
+                index += len_sub - 1
+        index += 1
+    return count
+
+
+# sub is an integer
+def bytes_count_single(x, sub, start, end):
+    if sub < 0 or sub > 255:
+        raise ValueError("byte must be in range(0, 256)")
+    if start < 0:
+        start += len(x)
+    if start < 0:
+        start = 0
+    if end < 0:
+        end += len(x)
+    if end < 0:
+        end = 0
+    if end > len(x):
+        end = len(x)
+
+    count = 0
+    index = start
+    while index < end:
+        if x[index] == sub:
+            count += 1
+        index += 1
+    return count
+
+
+# sub is a bytes-like object
+def bytes_find(x, sub, start, end):
+    if start < 0:
+        start += len(x)
+    if start < 0:
+        start = 0
+    if end < 0:
+        end += len(x)
+    if end < 0:
+        end = 0
+    if end > len(x):
+        end = len(x)
+
+    len_sub = len(sub)
+    if len_sub == 0:
+        if start > len(x) or start > end:
+            return -1
+        return start
+
+    index = start
+    while index < end - len_sub + 1:
+        subindex = 0
+        while subindex < len_sub:
+            if x[index+subindex] != sub[subindex]:
+                break
+            subindex += 1
+            if subindex == len_sub:
+                return index
+        index += 1
+    return -1
+
+
+# sub is an integer
+def bytes_find_single(x, sub, start, end):
+    if sub < 0 or sub > 255:
+        raise ValueError("byte must be in range(0, 256)")
+    if start < 0:
+        start += len(x)
+    if start < 0:
+        start = 0
+    if end < 0:
+        end += len(x)
+    if end < 0:
+        end = 0
+    if end > len(x):
+        end = len(x)
+
+    index = start
+    while index < end:
+        if x[index] == sub:
+            return index
+        index += 1
+    return -1
+
+
+# sub is a bytes-like object
+def bytes_rfind(x, sub, start, end):
+    if start < 0:
+        start += len(x)
+    if start < 0:
+        start = 0
+    if end < 0:
+        end += len(x)
+    if end < 0:
+        end = 0
+    if end > len(x):
+        end = len(x)
+
+    len_sub = len(sub)
+    if len_sub == 0:
+        if start > len(x) or start > end:
+            return -1
+        return end
+
+    index = end - len_sub
+    while index >= start:
+        subindex = 0
+        while subindex < len_sub:
+            if x[index+subindex] != sub[subindex]:
+                break
+            subindex += 1
+            if subindex == len_sub:
+                return index
+        index -= 1
+    return -1
+
+
+# sub is an integer
+def bytes_rfind_single(x, sub, start, end):
+    if sub < 0 or sub > 255:
+        raise ValueError("byte must be in range(0, 256)")
+    if start < 0:
+        start += len(x)
+    if start < 0:
+        start = 0
+    if end < 0:
+        end += len(x)
+    if end < 0:
+        end = 0
+    if end > len(x):
+        end = len(x)
+
+    index = end - 1
+    while index >= start:
+        if x[index] == sub:
+            return index
+        index -= 1
+    return -1
+
+
+def bytes_index(x, sub, start, end):
+    ret = bytes_find(x, sub, start, end)
+    if ret == -1:
+        raise ValueError("subsection not found")
+    return ret
+
+
+def bytes_index_single(x, sub, start, end):
+    ret = bytes_find_single(x, sub, start, end)
+    if ret == -1:
+        raise ValueError("subsection not found")
+    return ret
+
+
+def bytes_rindex(x, sub, start, end):
+    ret = bytes_rfind(x, sub, start, end)
+    if ret == -1:
+        raise ValueError("subsection not found")
+    return ret
+
+
+def bytes_rindex_single(x, sub, start, end):
+    ret = bytes_rfind_single(x, sub, start, end)
+    if ret == -1:
+        raise ValueError("subsection not found")
+    return ret
+
+
+def bytes_partition(x, sep):
+    if len(sep) == 0:
+        raise ValueError("empty separator")
+
+    pos = x.find(sep)
+    if pos == -1:
+        return Tuple(bytes, bytes, bytes)((x, b'', b''))
+    return Tuple(bytes, bytes, bytes)((x[0:pos], sep, x[pos+len(sep):]))
+
+
+def bytes_rpartition(x, sep):
+    if len(sep) == 0:
+        raise ValueError("empty separator")
+
+    pos = x.rfind(sep)
+    if pos == -1:
+        return Tuple(bytes, bytes, bytes)((b'', b'', x))
+    return Tuple(bytes, bytes, bytes)((x[0:pos], sep, x[pos+len(sep):]))
+
+
+def bytes_center(x, width, fill):
+    if width <= len(x):
+        return x
+
+    left = (width - len(x)) // 2
+    right = (width - len(x)) - left
+    return fill * left + x + fill * right
+
+
+def bytes_ljust(x, width, fill):
+    if width <= len(x):
+        return x
+
+    return x + fill * (width - len(x))
+
+
+def bytes_rjust(x, width, fill):
+    if width <= len(x):
+        return x
+
+    return fill * (width - len(x)) + x
+
+
+def bytes_expandtabs(x, tabsize):
+    accumulator = ListOf(bytes)()
+
+    col = 0  # column mod tabsize, not necessarily actual column
+    last = 0
+    for i in range(len(x)):
+        c = x[i]
+        if c == ord('\t'):
+            accumulator.append(x[last:i])
+            spaces = tabsize - (col % tabsize) if tabsize > 0 else 0
+            accumulator.append(b' ' * spaces)
+            last = i + 1
+            col = 0
+        elif c == ord('\n') or c == ord('\r'):
+            col = 0
+        else:
+            col += 1
+    accumulator.append(x[last:])
+    return b''.join(accumulator)
+
+
+def bytes_zfill(x, width):
+    accumulator = ListOf(bytes)()
+
+    sign = False
+    if len(x):
+        c = x[0]
+        if c == ord('+') or c == ord('-'):
+            accumulator.append(x[0:1])
+            sign = True
+
+    fill = width - len(x)
+    if fill > 0:
+        accumulator.append(b'0' * fill)
+
+    accumulator.append(x[1:] if sign else x)
+
+    return b''.join(accumulator)
+
+
+def no_more_kwargs(context, **kwargs):
+    for e in kwargs:
+        context.pushException(TypeError, f"'{e}' is an invalid keyword argument for this function")
+        # just need to generate the first exception
+        break
 
 
 class BytesWrapper(RefcountedWrapper):
@@ -39,6 +479,8 @@ class BytesWrapper(RefcountedWrapper):
 
         self.layoutType = native_ast.Type.Struct(element_types=(
             ('refcount', native_ast.Int64),
+            ('hash_cache', native_ast.Int32),
+            ('bytecount', native_ast.Int32),
             ('data', native_ast.UInt8)
         ), name='BytesLayout').pointer()
 
@@ -58,6 +500,20 @@ class BytesWrapper(RefcountedWrapper):
         return super().convert_builtin(f, context, expr, a1)
 
     def convert_bin_op(self, context, left, op, right, inplace):
+        if op.matches.Mult and isInteger(right.expr_type.typeRepresentation):
+            if left.isConstant and right.isConstant:
+                return context.constant(left.constantValue * right.constantValue)
+
+            return context.push(
+                bytes,
+                lambda bytesRef: bytesRef.expr.store(
+                    runtime_functions.bytes_mult.call(
+                        left.nonref_expr.cast(VoidPtr),
+                        right.nonref_expr
+                    ).cast(self.layoutType)
+                )
+            )
+
         if right.expr_type == left.expr_type:
             if op.matches.Eq or op.matches.NotEq or op.matches.Lt or op.matches.LtE or op.matches.GtE or op.matches.Gt:
                 if left.isConstant and right.isConstant:
@@ -112,6 +568,15 @@ class BytesWrapper(RefcountedWrapper):
                         cmp_res.nonref_expr.gte(0)
                     )
 
+            if op.matches.In:
+                if left.isConstant and right.isConstant:
+                    return context.constant(left.constantValue in right.constantValue)
+
+                find_converted = right.convert_method_call("find", (left,), {})
+                if find_converted is None:
+                    return None
+                return find_converted >= 0
+
             if op.matches.Add:
                 if left.isConstant and right.isConstant:
                     return context.constant(left.constantValue + right.constantValue)
@@ -137,6 +602,9 @@ class BytesWrapper(RefcountedWrapper):
 
         if lower is None and upper is not None:
             lower = context.constant(0)
+
+        if lower is not None and upper is None:
+            upper = expr.convert_len()
 
         lower = lower.toInt64()
         if lower is None:
@@ -178,46 +646,242 @@ class BytesWrapper(RefcountedWrapper):
 
         return context.pushPod(
             int,
-            expr.nonref_expr.ElementPtrIntegers(0, 1).elemPtr(
+            expr.nonref_expr.ElementPtrIntegers(0, 3).elemPtr(
                 native_ast.Expression.Branch(
                     cond=item.nonref_expr.lt(native_ast.const_int_expr(0)),
                     false=item.nonref_expr,
                     true=item.nonref_expr.add(len_expr.nonref_expr)
-                ).add(native_ast.const_int_expr(8))
+                )
             ).load().cast(native_ast.Int64)
         )
 
+    # these map to py functions
+    _bool_methods = dict(
+        isalnum=bytes_isalnum,
+        isalpha=bytes_isalpha,
+        isdigit=bytes_isdigit,
+        islower=bytes_islower,
+        isspace=bytes_isspace,
+        istitle=bytes_istitle,
+        isupper=bytes_isupper
+    )
+
+    # these map to py functions
+    _find_methods = dict(
+        count=(bytes_count, bytes_count_single),
+        find=(bytes_find, bytes_find_single),
+        rfind=(bytes_rfind, bytes_rfind_single),
+        index=(bytes_index, bytes_index_single),
+        rindex=(bytes_rindex, bytes_rindex_single),
+    )
+
+    # these map to c++ functions
+    _bytes_methods = dict(
+        lower=runtime_functions.bytes_lower,
+        upper=runtime_functions.bytes_upper,
+        capitalize=runtime_functions.bytes_capitalize,
+        swapcase=runtime_functions.bytes_swapcase,
+        title=runtime_functions.bytes_title,
+    )
+
     def convert_attribute(self, context, instance, attr):
-        if attr in ("split",):
+        if (
+                attr in ('decode', 'translate', 'maketrans', 'split', 'rsplit', 'join', 'partition', 'rpartition',
+                         'strip', 'rstrip', 'lstrip', 'startswith', 'endswith', 'replace',
+                         '__iter__', 'center', 'ljust', 'rjust', 'expandtabs', 'splitlines', 'zfill')
+                or attr in self._bytes_methods
+                or attr in self._find_methods
+                or attr in self._bool_methods
+        ):
             return instance.changeType(BoundMethodWrapper.Make(self, attr))
 
         return super().convert_attribute(context, instance, attr)
 
-    def convert_method_call(self, context, instance, methodname, args, kwargs):
-        if kwargs:
-            return super().convert_method_call(context, instance, methodname, args, kwargs)
+    def convert_method_call(self, context, instance, methodname, args, kwargs0):
+        kwargs = kwargs0.copy()
+        if methodname == '__iter__' and not args and not kwargs:
+            res = context.push(
+                _BytesIteratorWrapper,
+                lambda instance:
+                instance.expr.ElementPtrIntegers(0, 0).store(-1)
+            )
 
-        if methodname == "split":
+            context.pushReference(
+                self,
+                res.expr.ElementPtrIntegers(0, 1)
+            ).convert_copy_initialize(instance)
+
+            return res
+
+        if methodname in self._bool_methods and not args and not kwargs:
+            return context.call_py_function(self._bool_methods[methodname], (instance,), {})
+
+        if methodname in self._bytes_methods and not args and not kwargs:
+            return context.push(
+                bytes,
+                lambda ref: ref.expr.store(
+                    self._bytes_methods[methodname].call(
+                        instance.nonref_expr.cast(VoidPtr)
+                    ).cast(self.layoutType)
+                )
+            )
+
+        if methodname in ['strip', 'lstrip', 'rstrip']:
+            fromLeft = methodname in ['strip', 'lstrip']
+            fromRight = methodname in ['strip', 'rstrip']
+            if len(args) == 0 and not kwargs:
+                return context.push(
+                    bytes,
+                    lambda ref: ref.expr.store(
+                        runtime_functions.bytes_strip.call(
+                            instance.nonref_expr.cast(VoidPtr),
+                            native_ast.const_bool_expr(fromLeft),
+                            native_ast.const_bool_expr(fromRight)
+                        ).cast(self.layoutType)
+                    )
+                )
+            elif len(args) == 1 and not kwargs:
+                return context.push(
+                    bytes,
+                    lambda ref: ref.expr.store(
+                        runtime_functions.bytes_strip2.call(
+                            instance.nonref_expr.cast(VoidPtr),
+                            args[0].nonref_expr.cast(VoidPtr),
+                            native_ast.const_bool_expr(fromLeft),
+                            native_ast.const_bool_expr(fromRight)
+                        ).cast(self.layoutType)
+                    )
+                )
+
+        if methodname == 'startswith' and len(args) == 1 and not kwargs:
+            return context.call_py_function(bytes_startswith, (instance, args[0]), {})
+        if methodname == 'endswith' and len(args) == 1 and not kwargs:
+            return context.call_py_function(bytes_endswith, (instance, args[0]), {})
+        if methodname == 'expandtabs' and len(args) == 1 and not kwargs:
+            arg0type = args[0].expr_type.typeRepresentation
+            if arg0type != int:
+                return context.pushException(TypeError, f"an integer is required, not '{arg0type}'")
+            return context.call_py_function(bytes_expandtabs, (instance, args[0]), {})
+
+        if methodname in self._find_methods and 1 <= len(args) <= 3 and not kwargs:
+            if len(args) == 3:
+                start = args[1]
+                end = args[2]
+            elif len(args) == 2:
+                start = args[1]
+                end = self.convert_len(context, instance)
+            elif len(args) == 1:
+                start = context.constant(0)
+                end = self.convert_len(context, instance)
+
+            if isInteger(args[0].expr_type.typeRepresentation):
+                py_f = self._find_methods[methodname][1]
+            else:
+                py_f = self._find_methods[methodname][0]
+            return context.call_py_function(py_f, (instance, args[0], start, end), {})
+
+        if methodname == 'maketrans' and len(args) == 2 and not kwargs:
+            for i in [0, 1]:
+                if args[i].expr_type != self:
+                    context.pushException(
+                        TypeError,
+                        f"maketrans() argument {i + 1} must be bytes"
+                    )
+                    return
+            arg0len = args[0].convert_len()
+            arg1len = args[1].convert_len()
+            if arg0len is None or arg1len is None:
+                return None
+            with context.ifelse(arg0len.nonref_expr.eq(arg1len.nonref_expr)) as (ifTrue, ifFalse):
+                with ifFalse:
+                    context.pushException(ValueError, "maketrans arguments must have same length")
+            return context.push(
+                bytes,
+                lambda bytesRef: bytesRef.expr.store(
+                    runtime_functions.bytes_maketrans.call(
+                        args[0].nonref_expr.cast(VoidPtr),
+                        args[1].nonref_expr.cast(VoidPtr)
+                    ).cast(self.layoutType)
+                )
+            )
+
+        if methodname == 'replace':
+            if len(args) in [2, 3]:
+                for i in [0, 1]:
+                    if args[i].expr_type != self:
+                        context.pushException(
+                            TypeError,
+                            f"replace() argument {i + 1} must be bytes"
+                        )
+                        return
+
+                if len(args) == 3 and args[2].expr_type.typeRepresentation != int:
+                    context.pushException(
+                        TypeError,
+                        f"replace() argument 3 must be int, not {args[2].expr_type.typeRepresentation}"
+                    )
+                    return
+
+                arg2 = context.constant(-1) if len(args) == 2 else args[2]
+                return context.call_py_function(bytes_replace, (instance, args[0], args[1], arg2), {})
+                # return context.push(
+                #     bytes,
+                #     lambda bytesRef: bytesRef.expr.store(
+                #         runtime_functions.bytes_replace.call(
+                #             instance.nonref_expr.cast(VoidPtr),
+                #             args[0].nonref_expr.cast(VoidPtr),
+                #             args[1].nonref_expr.cast(VoidPtr),
+                #             args[2].nonref_expr if len(args) == 3 else native_ast.const_int_expr(-1)
+                #         ).cast(self.layoutType)
+                #     )
+                # )
+
+        if methodname == 'join' and not kwargs:
+            if len(args) == 1:
+                # we need to pass the list of bytes objects
+                separator = instance
+                itemsToJoin = args[0]
+
+                if itemsToJoin.expr_type.typeRepresentation is ListOf(bytes):
+                    return context.push(
+                        bytes,
+                        lambda out: runtime_functions.bytes_join.call(
+                            out.expr.cast(VoidPtr),
+                            separator.nonref_expr.cast(VoidPtr),
+                            itemsToJoin.nonref_expr.cast(VoidPtr)
+                        )
+                    )
+                else:
+                    return context.call_py_function(bytesJoinIterable, (separator, itemsToJoin), {})
+
+        if methodname in ['split', 'rsplit'] and not kwargs:
             if len(args) == 0:
                 sepPtr = VoidPtr.zero()
                 maxCount = native_ast.const_int_expr(-1)
-            elif len(args) == 1 and args[0].expr_type.typeRepresentation == bytes:
+            elif len(args) in [1, 2] and args[0].expr_type.typeRepresentation == bytes:
                 sepPtr = args[0].nonref_expr.cast(VoidPtr)
-                maxCount = native_ast.const_int_expr(-1)
-            elif len(args) == 2 and (
-                args[0].expr_type.typeRepresentation == bytes
-                and args[1].expr_type.typeRepresentation == int
-            ):
-                sepPtr = args[0].nonref_expr.cast(VoidPtr)
-                maxCount = args[1].nonref_expr
+                sepLen = args[0].convert_len()
+                if sepLen is None:
+                    return None
+                with context.ifelse(sepLen.nonref_expr.eq(0)) as (ifTrue, ifFalse):
+                    with ifTrue:
+                        context.pushException(ValueError, "empty separator")
+
+                if len(args) == 2:
+                    maxCount = args[1].toInt64()
+                    if maxCount is None:
+                        return None
+                else:
+                    maxCount = native_ast.const_int_expr(-1)
             else:
                 maxCount = None
 
             if maxCount is not None:
+                fn = runtime_functions.bytes_split if methodname == 'split' else runtime_functions.bytes_rsplit
                 return context.push(
                     TypedListMasqueradingAsList(ListOf(bytes)),
                     lambda outBytes: outBytes.expr.store(
-                        runtime_functions.bytes_split.call(
+                        fn.call(
                             instance.nonref_expr.cast(VoidPtr),
                             sepPtr,
                             maxCount
@@ -225,15 +889,128 @@ class BytesWrapper(RefcountedWrapper):
                     )
                 )
 
+        if methodname == 'splitlines' and not kwargs:
+            if len(args) == 0:
+                arg0 = context.constant(False)
+            elif len(args) == 1:
+                arg0 = args[0].toBool()
+                if arg0 is None:
+                    return None
+
+            return context.push(
+                TypedListMasqueradingAsList(ListOf(bytes)),
+                lambda out: out.expr.store(
+                    runtime_functions.bytes_splitlines.call(
+                        instance.nonref_expr.cast(VoidPtr),
+                        arg0
+                    ).cast(out.expr_type.getNativeLayoutType())
+                )
+            )
+
+        if methodname == 'decode' and not kwargs:
+            if len(args) in [0, 1, 2]:
+                return context.push(
+                    str,
+                    lambda ref: ref.expr.store(
+                        runtime_functions.bytes_decode.call(
+                            instance.nonref_expr.cast(VoidPtr),
+                            (args[0] if len(args) >= 1 else context.constant(0)).nonref_expr.cast(VoidPtr),
+                            (args[1] if len(args) >= 2 else context.constant(0)).nonref_expr.cast(VoidPtr),
+                        ).cast(typeWrapper(str).layoutType)
+                    )
+                )
+
+        if methodname == 'translate':
+            if len(args) in [1, 2]:
+                arg0isNone = args[0].expr_type == typeWrapper(None)
+                arg0 = args[0] if not arg0isNone else context.constant(0)
+                if 'delete' in kwargs and len(args) == 1:
+                    arg1 = kwargs['delete']
+                    del kwargs['delete']
+                    no_more_kwargs(context, **kwargs)
+                else:
+                    arg1 = args[1] if len(args) >= 2 else context.constant(0)
+
+                if not arg0isNone:
+                    arg0type = arg0.expr_type.typeRepresentation
+                    if arg0type != bytes:
+                        context.pushException(TypeError, f"a bytes-like object is required, not '{arg0type}'")
+                    arg0len = arg0.convert_len()
+                    if arg0len is None:
+                        return None
+                    with context.ifelse(arg0len.nonref_expr.eq(256)) as (ifTrue, ifFalse):
+                        with ifFalse:
+                            context.pushException(ValueError, "translation table must be 256 characters long")
+
+                return context.push(
+                    bytes,
+                    lambda ref: ref.expr.store(
+                        runtime_functions.bytes_translate.call(
+                            instance.nonref_expr.cast(VoidPtr),
+                            arg0.nonref_expr.cast(VoidPtr),
+                            arg1.nonref_expr.cast(VoidPtr),
+                        ).cast(self.layoutType)
+                    )
+                )
+
+        if methodname in ['partition', 'rpartition'] and len(args) == 1 and not kwargs:
+            arg0type = args[0].expr_type.typeRepresentation
+            if arg0type != bytes:
+                context.pushException(TypeError, f"a bytes-like object is required, not '{arg0type}'")
+            py_f = bytes_partition if methodname == 'partition' else bytes_rpartition
+            return context.call_py_function(py_f, (instance, args[0]), {})
+
+        if methodname in ['center', 'ljust', 'rjust']:
+            if len(args) in [1, 2]:
+                arg0 = args[0].toInt64()
+                if arg0 is None:
+                    return None
+
+                if len(args) == 2:
+                    arg1 = args[1]
+                    arg1type = arg1.expr_type.typeRepresentation
+                    if arg1type != bytes:
+                        context.pushException(TypeError, f"{methodname}() argument 2 must be a byte string of length 1, not '{arg1type}'")
+                    arg1len = arg1.convert_len()
+                    if arg1len is None:
+                        return None
+                    with context.ifelse(arg1len.nonref_expr.eq(1)) as (ifTrue, ifFalse):
+                        with ifFalse:
+                            context.pushException(
+                                TypeError,
+                                f"{methodname}() argument 2 must be a byte string of length 1, not '{arg1type}'"
+                            )
+                else:
+                    arg1 = context.constant(b' ')
+
+            py_f = bytes_center if methodname == 'center' else \
+                bytes_ljust if methodname == 'ljust' else \
+                bytes_rjust if methodname == 'rjust' else None
+            return context.call_py_function(py_f, (instance, arg0, arg1), {})
+
+        if methodname == 'zfill' and len(args) == 1 and not kwargs:
+            arg0 = args[0].toInt64()
+            if arg0 is None:
+                return None
+            return context.call_py_function(bytes_zfill, (instance, arg0), {})
+
         return context.pushException(AttributeError, methodname)
+
+    def convert_getitem_unsafe(self, context, expr, item):
+        return context.push(
+            UInt8,
+            lambda intRef: intRef.expr.store(
+                expr.nonref_expr.ElementPtrIntegers(0, 3)
+                    .elemPtr(item.toInt64().nonref_expr).load()
+            )
+        )
 
     def convert_len_native(self, expr):
         return native_ast.Expression.Branch(
             cond=expr,
             false=native_ast.const_int_expr(0),
             true=(
-                expr.ElementPtrIntegers(0, 1).ElementPtrIntegers(4)
-                .cast(native_ast.Int32.pointer()).load().cast(native_ast.Int64)
+                expr.ElementPtrIntegers(0, 2).load().cast(native_ast.Int64)
             )
         )
 
@@ -285,3 +1062,94 @@ class BytesWrapper(RefcountedWrapper):
 
     def convert_bytes_cast(self, context, expr):
         return expr
+
+    def get_iteration_expressions(self, context, expr):
+        if expr.isConstant:
+            return [context.constant(expr.constantValue[i]) for i in range(len(expr.constantValue))]
+        else:
+            return None
+
+
+class BytesIteratorWrapper(Wrapper):
+    is_pod = False
+    is_empty = False
+    is_pass_by_ref = True
+
+    def __init__(self):
+        super().__init__((bytes, "iterator"))
+
+    def getNativeLayoutType(self):
+        return native_ast.Type.Struct(
+            element_types=(("pos", native_ast.Int64), ("bytes", typeWrapper(bytes).getNativeLayoutType())),
+            name="bytes_iterator"
+        )
+
+    def convert_next(self, context, inst):
+        context.pushEffect(
+            inst.expr.ElementPtrIntegers(0, 0).store(
+                inst.expr.ElementPtrIntegers(0, 0).load().add(1)
+            )
+        )
+        self_len = self.refAs(context, inst, 1).convert_len()
+        canContinue = context.pushPod(
+            bool,
+            inst.expr.ElementPtrIntegers(0, 0).load().lt(self_len.nonref_expr)
+        )
+
+        nextIx = context.pushReference(int, inst.expr.ElementPtrIntegers(0, 0))
+        return self.iteratedItemForReference(context, inst, nextIx), canContinue
+
+    def refAs(self, context, expr, which):
+        assert expr.expr_type == self
+
+        if which == 0:
+            return context.pushReference(int, expr.expr.ElementPtrIntegers(0, 0))
+
+        if which == 1:
+            return context.pushReference(
+                bytes,
+                expr.expr
+                    .ElementPtrIntegers(0, 1)
+                    .cast(typeWrapper(bytes).getNativeLayoutType().pointer())
+            )
+
+    def iteratedItemForReference(self, context, expr, ixExpr):
+        return typeWrapper(bytes).convert_getitem_unsafe(
+            context,
+            self.refAs(context, expr, 1),
+            ixExpr
+        ).heldToRef()
+
+    def convert_assign(self, context, expr, other):
+        assert expr.isReference
+
+        for i in range(2):
+            self.refAs(context, expr, i).convert_assign(self.refAs(context, other, i))
+
+    def convert_copy_initialize(self, context, expr, other):
+        for i in range(2):
+            self.refAs(context, expr, i).convert_copy_initialize(self.refAs(context, other, i))
+
+    def convert_destroy(self, context, expr):
+        self.refAs(context, expr, 1).convert_destroy()
+
+
+_BytesIteratorWrapper = BytesIteratorWrapper()
+
+
+class BytesMaketransWrapper(Wrapper):
+    is_pod = True
+    is_empty = False
+    is_pass_by_ref = False
+
+    def __init__(self):
+        super().__init__(bytes.maketrans)
+
+    def getNativeLayoutType(self):
+        return native_ast.Type.Void()
+
+    def convert_call(self, context, expr, args, kwargs):
+        if len(args) == 2 and not kwargs:
+            return args[0].convert_method_call("maketrans", (args[0], args[1]), {})
+
+        return super().convert_call(context, expr, args, kwargs)

--- a/typed_python/compiler/type_wrappers/runtime_functions.py
+++ b/typed_python/compiler/type_wrappers/runtime_functions.py
@@ -544,6 +544,12 @@ string_getitem_int64 = externalCallTarget(
     Void.pointer(), Int64
 )
 
+string_mult = externalCallTarget(
+    "nativepython_runtime_string_mult",
+    Void.pointer(),
+    Void.pointer(), Int64
+)
+
 string_from_utf8_and_len = externalCallTarget(
     "nativepython_runtime_string_from_utf8_and_len",
     Void.pointer(),
@@ -596,12 +602,6 @@ string_join = externalCallTarget(
 
 string_split = externalCallTarget(
     "nativepython_runtime_string_split",
-    Void.pointer(),
-    Void.pointer(), Void.pointer(), Int64
-)
-
-bytes_split = externalCallTarget(
-    "nativepython_runtime_bytes_split",
     Void.pointer(),
     Void.pointer(), Void.pointer(), Int64
 )
@@ -707,6 +707,117 @@ bytes_from_ptr_and_len = externalCallTarget(
     "nativepython_runtime_bytes_from_ptr_and_len",
     Void.pointer(),
     UInt8Ptr, Int64
+)
+
+bytes_join = externalCallTarget(
+    "nativepython_runtime_bytes_join",
+    Void,
+    Void.pointer(), Void.pointer(), Void.pointer()
+)
+
+bytes_split = externalCallTarget(
+    "nativepython_runtime_bytes_split",
+    Void.pointer(),
+    Void.pointer(), Void.pointer(), Int64
+)
+
+bytes_rsplit = externalCallTarget(
+    "nativepython_runtime_bytes_rsplit",
+    Void.pointer(),
+    Void.pointer(), Void.pointer(), Int64
+)
+
+bytes_lower = externalCallTarget(
+    "nativepython_runtime_bytes_lower",
+    Void.pointer(),
+    Void.pointer()
+)
+
+bytes_upper = externalCallTarget(
+    "nativepython_runtime_bytes_upper",
+    Void.pointer(),
+    Void.pointer()
+)
+
+bytes_capitalize = externalCallTarget(
+    "nativepython_runtime_bytes_capitalize",
+    Void.pointer(),
+    Void.pointer()
+)
+
+bytes_swapcase = externalCallTarget(
+    "nativepython_runtime_bytes_swapcase",
+    Void.pointer(),
+    Void.pointer()
+)
+
+bytes_title = externalCallTarget(
+    "nativepython_runtime_bytes_title",
+    Void.pointer(),
+    Void.pointer()
+)
+
+bytes_splitlines = externalCallTarget(
+    "nativepython_runtime_bytes_splitlines",
+    Void.pointer(),
+    Void.pointer(),
+    Bool
+)
+
+bytes_strip = externalCallTarget(
+    "nativepython_runtime_bytes_strip",
+    Void.pointer(),
+    Void.pointer(),
+    Bool,
+    Bool
+)
+
+bytes_strip2 = externalCallTarget(
+    "nativepython_runtime_bytes_strip2",
+    Void.pointer(),
+    Void.pointer(),
+    Void.pointer(),
+    Bool,
+    Bool
+)
+
+bytes_mult = externalCallTarget(
+    "nativepython_runtime_bytes_mult",
+    Void.pointer(),
+    Void.pointer(),
+    Int64
+)
+
+bytes_replace = externalCallTarget(
+    "nativepython_runtime_bytes_replace",
+    Void.pointer(),
+    Void.pointer(),
+    Void.pointer(),
+    Void.pointer(),
+    Int64
+)
+
+bytes_decode = externalCallTarget(
+    "nativepython_runtime_bytes_decode",
+    Void.pointer(),
+    Void.pointer(),
+    Void.pointer(),
+    Void.pointer()
+)
+
+bytes_translate = externalCallTarget(
+    "nativepython_runtime_bytes_translate",
+    Void.pointer(),
+    Void.pointer(),
+    Void.pointer(),
+    Void.pointer()
+)
+
+bytes_maketrans = externalCallTarget(
+    "nativepython_runtime_bytes_maketrans",
+    Void.pointer(),
+    Void.pointer(),
+    Void.pointer()
 )
 
 print_string = externalCallTarget(


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->

## Motivation and Context
Most 'bytes' methods were uncompiled.

## Approach
- Adjust BytesWrapper layout to be complete.
- Create string iterator.
- Compile string * int operator.
- Comple bytes.isalnum, isalpha, isdigit, islower, isspace, istitle, isupper,
  startswith, endswith, strip, lstrip, rstrip, lower, upper,
  count, find, rfind, index, rindex,
  split, rsplit, join, replace, *, in, decode,
  partition, rpartition, translate, center, ljust, rjust,
  capitalize, expandtabs, splitlines, swapcase, title, zfill.
- Compile bytes.maketrans as a instance method and as a static method.
- Fix bytes slice operation.
- Fix bytes.split edge cases.
- For chr, ord: propagate constants when compiled.
- Also, fix and test for compiling min/max with spurious keyword parameter.
- Incidentally, support compiling chained comparisons.
- NOTE: partition and rpartition return Tuples that are not masqueraded.
- NOTE: where parameters could be 'bytes' or 'bytes-like' objects, only 'bytes' is supported.

## How Has This Been Tested?
- Added tests for each operation, including testing error cases that raise exceptions.
- Improved some existing tests that were missing edge cases (e.g. empty bytes)

## Screenshots or console output (if appropriate)
<!-- if not appropriate, remove this section -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.