### PR TITLE
Compile 'bytes' and 'str' operations. Refs #342, #351, #355, #362.

### DIFF
--- a/typed_python/BytesType.cpp
+++ b/typed_python/BytesType.cpp
@@ -1,5 +1,5 @@
 /******************************************************************************
-   Copyright 2017-2019 typed_python Authors
+   Copyright 2017-2020 typed_python Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -97,76 +97,274 @@ char BytesType::cmpStatic(layout* left, layout* right) {
 }
 
 /* static */
-void BytesType::split(ListOfType::layout *outList, layout* bytesLayout, layout* sep, int64_t max) {
-    static ListOfType* listOfBytes = ListOfType::Make(StringType::Make());
+// assumes outList was initialized to an empty list before calling
+// x.split() with no parameters is not the same thing as x.split(b' ')
+// x.split() combines successive matches (of whitespace) into a single match
+void BytesType::split(ListOfType::layout *outList, layout* in, layout* sep, int64_t max) {
+    static ListOfType* listOfBytes = ListOfType::Make(BytesType::Make());
 
     int64_t cur = 0;
     int64_t count = 0;
 
     listOfBytes->reserve((instance_ptr)&outList, 10);
 
-    uint8_t* bytesData = (uint8_t*)bytesLayout->data;
+    uint8_t* inData = in ? (uint8_t*)in->data : nullptr;
+    int64_t inLen = in ? in->bytecount : 0;
     uint8_t sepChar = sep ? *(uint8_t*)sep->data : 0;
     uint8_t* sepDat = sep ? (uint8_t*)sep->data : 0;
     int64_t sepLen = sep ? sep->bytecount : 1;
 
     if (max == 0) {
-        layout* remainder = createFromPtr((const char*)bytesData, bytesLayout->bytecount);
-        listOfBytes->append((instance_ptr)&outList, (instance_ptr)&remainder);
-        destroyStatic((instance_ptr)&remainder);
+        if (!sep) {
+            while (cur < inLen && std::isspace(inData[cur])) cur++;
+        }
+        if (cur != inLen) {
+            layout* remainder = createFromPtr((const char*)inData + cur, inLen - cur);
+            listOfBytes->append((instance_ptr)&outList, (instance_ptr)&remainder);
+            destroyStatic((instance_ptr)&remainder);
+        }
         return;
     }
 
-    while (cur < bytesLayout->bytecount) {
+    while (cur < inLen) {
         int64_t match = cur;
 
         if (sep) {
             if (sepLen == 1) {
-                while (match < bytesLayout->bytecount && bytesData[match] != sepChar) {
+                while (match < inLen && inData[match] != sepChar) {
                     match++;
                 }
             } else {
-                while (match + sepLen <= bytesLayout->bytecount && strncmp((const char*)bytesData, (const char*)sepDat, match)) {
+                while (match + sepLen <= inLen && memcmp((const char*)inData + match, (const char*)sepDat, sepLen)) {
                     match++;
                 }
             }
         } else {
-            while (match < bytesLayout->bytecount && (
-                    bytesData[match] != '\n'
-                &&  bytesData[match] != '\r'
-                &&  bytesData[match] != '\t'
-                &&  bytesData[match] != ' '
-                &&  bytesData[match] != '\b'
-                &&  bytesData[match] != '\f'
-                )
-            ) {
+            while (match < inLen && !isspace(inData[match])) {
                 match++;
             }
         }
 
-        if (match + sepLen > bytesLayout->bytecount) {
+        if (match + sepLen > inLen) {
             break;
         }
 
-        layout* piece = createFromPtr((const char*)bytesData + cur, match - cur);
+        if (sep || match != cur) {
+            layout* piece = createFromPtr((const char*)inData + cur, match - cur);
+
+            if (outList->count == outList->reserved) {
+                listOfBytes->reserve((instance_ptr)&outList, outList->reserved * 1.5);
+            }
+
+            ((layout**)outList->data)[outList->count++] = piece;
+            cur = match + sepLen;
+            count++;
+            if (max >= 0 && count >= max)
+                break;
+        }
+        else if (!sep) {
+            cur++;
+        }
+    }
+//    if (!sep) {
+//        while (cur < inLen && std::isspace(inData[cur])) cur++;
+//    }
+    if (sep || inLen != cur) {
+        layout* remainder = createFromPtr((const char*)inData + cur, inLen - cur);
+        listOfBytes->append((instance_ptr)&outList, (instance_ptr)&remainder);
+        destroyStatic((instance_ptr)&remainder);
+    }
+}
+
+/* static */
+// assumes outList was initialized to an empty list before calling
+void BytesType::rsplit(ListOfType::layout *outList, layout* in, layout* sep, int64_t max) {
+    static ListOfType* listOfBytes = ListOfType::Make(BytesType::Make());
+
+    listOfBytes->reserve((instance_ptr)&outList, 10);
+
+    uint8_t* inData = in ? (uint8_t*)in->data : nullptr;
+    int64_t inLen = in ? in->bytecount : 0;
+    uint8_t sepChar = sep ? *(uint8_t*)sep->data : 0;
+    uint8_t* sepDat = sep ? (uint8_t*)sep->data : 0;
+    int64_t sepLen = sep ? sep->bytecount : 1;
+
+    int64_t cur = inLen - 1;
+    int64_t count = 0;
+
+    if (max == 0) {
+        if (!sep) {
+            while (cur >= 0 && std::isspace(inData[cur])) cur--;
+        }
+        if (cur >= 0) {
+            layout* remainder = createFromPtr((const char*)inData, cur + 1);
+            listOfBytes->append((instance_ptr)&outList, (instance_ptr)&remainder);
+            destroyStatic((instance_ptr)&remainder);
+        }
+        return;
+    }
+
+    while (cur >= 0) {
+        int64_t match = cur;
+
+        if (sep) {
+            if (sepLen == 1) {
+                while (match >= 0 && inData[match] != sepChar) {
+                    match--;
+                }
+            } else {
+                while (match - sepLen + 1 >= 0 && memcmp((const char*)inData + match - sepLen + 1, (const char*)sepDat, sepLen)) {
+                    match--;
+                }
+            }
+        } else {
+            while (match >= 0 && (
+                    inData[match] != '\n'
+                &&  inData[match] != '\r'
+                &&  inData[match] != '\t'
+                &&  inData[match] != ' '
+                &&  inData[match] != '\x0B'  // note: \x0B is whitespace, but \b is not whitespace
+                &&  inData[match] != '\f'
+                )
+            ) {
+                match--;
+            }
+        }
+
+        if (match - sepLen + 1 < 0) {
+            break;
+        }
+
+        if (sep || match != cur) {
+            layout* piece = createFromPtr((const char*)inData + match + 1, cur - match);
+
+            if (outList->count == outList->reserved) {
+                listOfBytes->reserve((instance_ptr)&outList, outList->reserved * 1.5);
+            }
+
+            ((layout**)outList->data)[outList->count++] = piece;
+            cur = match - sepLen;
+            count++;
+            if (max >= 0 && count >= max) break;
+        }
+        else if (!sep) {
+            cur--;
+        }
+    }
+    if (sep || cur != -1) {
+        layout* remainder = createFromPtr((const char*)inData, cur + 1);
+        listOfBytes->append((instance_ptr)&outList, (instance_ptr)&remainder);
+        destroyStatic((instance_ptr)&remainder);
+    }
+    listOfBytes->reverse((instance_ptr)&outList);
+}
+
+/* static */
+// assumes outList was initialized to an empty list before calling
+void BytesType::splitlines(ListOfType::layout *outList, layout* in, bool keepends) {
+    static ListOfType* listOfBytes = ListOfType::Make(BytesType::Make());
+
+    int64_t cur = 0;
+
+    listOfBytes->reserve((instance_ptr)&outList, 10);
+
+    uint8_t* inData = in ? (uint8_t*)in->data : nullptr;
+    int64_t inLen = in ? in->bytecount : 0;
+    int sepLen = 0;
+
+    while (cur < inLen) {
+        int64_t match = cur;
+
+        while (match < inLen && inData[match] != '\n' &&  inData[match] != '\r') {
+            match++;
+        }
+        sepLen = 0;
+        if (match < inLen) {
+            if (inData[match] == '\r' && match + 1 < inLen && inData[match+1] == '\n') {
+                sepLen = 2;
+            }
+            else {
+                sepLen = 1;
+            }
+        }
+
+        if (match + sepLen > inLen) {
+            break;
+        }
+
+        layout* piece = createFromPtr((const char*)inData + cur, match - cur + (keepends ? sepLen : 0));
 
         if (outList->count == outList->reserved) {
             listOfBytes->reserve((instance_ptr)&outList, outList->reserved * 1.5);
         }
 
         ((layout**)outList->data)[outList->count++] = piece;
-
         cur = match + sepLen;
-
-        count++;
-
-        if (max >= 0 && count >= max)
-            break;
     }
-    layout* remainder = createFromPtr((const char*)bytesData + cur, bytesLayout->bytecount - cur);
-    listOfBytes->append((instance_ptr)&outList, (instance_ptr)&remainder);
-    destroyStatic((instance_ptr)&remainder);
+    if (inLen != cur) {
+        layout* remainder = createFromPtr((const char*)inData + cur, inLen - cur);
+        listOfBytes->append((instance_ptr)&outList, (instance_ptr)&remainder);
+        destroyStatic((instance_ptr)&remainder);
+    }
 }
+
+void BytesType::join(BytesType::layout **out, BytesType::layout *separator, ListOfType::layout *toJoin) {
+    if (!out)
+        throw std::invalid_argument("missing return argument");
+
+    BytesType::Make()->constructor((instance_ptr)out);
+
+    // return empty bytes when there is nothing to join
+    if (toJoin->count == 0)
+    {
+        return;
+    }
+
+    static ListOfType *listOfBytesType = ListOfType::Make(BytesType::Make());
+    int total_bytes = 0;
+
+    for (int64_t i = 0; i < toJoin->count; i++)
+    {
+        instance_ptr item = listOfBytesType->eltPtr(toJoin, i);
+        BytesType::layout** itemLayout = (BytesType::layout**)item;
+        if (*itemLayout != nullptr) {
+            total_bytes += (*itemLayout)->bytecount;
+        }
+    }
+
+    // add the separators size
+    if (separator != nullptr)
+    {
+        total_bytes += separator->bytecount * (toJoin->count - 1);
+    }
+
+    // add all the parts together
+    *out = (layout*)malloc(sizeof(layout) + total_bytes);
+    (*out)->hash_cache = -1;
+    (*out)->refcount = 1;
+    (*out)->bytecount = total_bytes;
+
+    // position in the output data array
+    int position = 0;
+
+    for (int64_t i = 0; i < toJoin->count; i++)
+    {
+        instance_ptr instptr_item = listOfBytesType->eltPtr(toJoin, i);
+        BytesType::layout* item = *(BytesType::layout**)instptr_item;
+        if (item != nullptr)
+        {
+            memcpy((*out)->data + position, item->data, item->bytecount);
+            position += item->bytecount;
+        }
+
+        if (separator != nullptr && i != toJoin->count - 1)
+        {
+            memcpy((*out)->data + position, separator->data, separator->bytecount);
+            position += separator->bytecount;
+        }
+    }
+}
+
 
 BytesType::layout* BytesType::concatenate(layout* lhs, layout* rhs) {
     if (!rhs && !lhs) {
@@ -502,4 +700,314 @@ bool BytesType::to_float64(BytesType::layout* b, double* value) {
         *value = 0.0;
         return false;
     }
+}
+
+BytesType::layout* BytesType::lower(layout *l) {
+    if (!l) {
+        return l;
+    }
+
+    int64_t new_byteCount = sizeof(layout) + l->bytecount;
+    layout* new_layout = (layout*)malloc(new_byteCount);
+    new_layout->refcount = 1;
+    new_layout->hash_cache = -1;
+    new_layout->bytecount = l->bytecount;
+
+    for (uint8_t *src = l->data, *dest = new_layout->data, *end = src + l->bytecount; src < end; ) {
+        *dest++ = (uint8_t)tolower(*src++);
+    }
+    return new_layout;
+}
+
+BytesType::layout* BytesType::upper(layout *l) {
+    if (!l) {
+        return l;
+    }
+
+    int64_t new_byteCount = sizeof(layout) + l->bytecount;
+    layout* new_layout = (layout*)malloc(new_byteCount);
+    new_layout->refcount = 1;
+    new_layout->hash_cache = -1;
+    new_layout->bytecount = l->bytecount;
+
+    for (uint8_t *src = l->data, *dest = new_layout->data, *end = src + l->bytecount; src < end; ) {
+        *dest++ = (uint8_t)toupper(*src++);
+    }
+    return new_layout;
+}
+
+BytesType::layout* BytesType::capitalize(layout *l) {
+    if (!l) {
+        return l;
+    }
+
+    int64_t new_byteCount = sizeof(layout) + l->bytecount;
+    layout* new_layout = (layout*)malloc(new_byteCount);
+    new_layout->refcount = 1;
+    new_layout->hash_cache = -1;
+    new_layout->bytecount = l->bytecount;
+
+    uint8_t *src = l->data, *dest = new_layout->data, *end = src + l->bytecount;
+    if (l->bytecount) {
+        *dest++ = (uint8_t)toupper(*src++);
+        while (src < end) {
+            *dest++ = (uint8_t)tolower(*src++);
+        }
+    }
+    return new_layout;
+}
+
+BytesType::layout* BytesType::swapcase(layout *l) {
+    if (!l) {
+        return l;
+    }
+
+    int64_t new_byteCount = sizeof(layout) + l->bytecount;
+    layout* new_layout = (layout*)malloc(new_byteCount);
+    new_layout->refcount = 1;
+    new_layout->hash_cache = -1;
+    new_layout->bytecount = l->bytecount;
+
+    for (uint8_t *src = l->data, *dest = new_layout->data, *end = src + l->bytecount; src < end; ) {
+        uint8_t c = *src++;
+        if (islower(c))
+            *dest++ = (uint8_t)toupper(c);
+        else if (isupper(c))
+            *dest++ = (uint8_t)tolower(c);
+        else
+            *dest++ = c;
+    }
+    return new_layout;
+}
+
+BytesType::layout* BytesType::title(layout *l) {
+    if (!l) {
+        return l;
+    }
+
+    int64_t new_byteCount = sizeof(layout) + l->bytecount;
+    layout* new_layout = (layout*)malloc(new_byteCount);
+    new_layout->refcount = 1;
+    new_layout->hash_cache = -1;
+    new_layout->bytecount = l->bytecount;
+
+    bool word = false;
+    for (uint8_t *src = l->data, *dest = new_layout->data, *end = src + l->bytecount; src < end; ) {
+        uint8_t c = *src++;
+        if (word) {
+            if (isalpha(c)) {
+                *dest++ = (uint8_t)tolower(c);
+            } else {
+                *dest++ = c;
+                word = false;
+            }
+        } else {
+            if (isalpha(c)) {
+                *dest++ = (uint8_t)toupper(c);
+                word = true;
+            } else {
+                *dest++ = c;
+            }
+        }
+    }
+    return new_layout;
+}
+
+bool matchchar(uint8_t v, bool whiteSpace, BytesType::layout* values) {
+    if (whiteSpace) return isspace(v);
+
+    if (!values) return false;
+
+    for (int i = 0; i < values->bytecount; i++) {
+        if (v == values->data[i]) return true;
+    }
+    return false;
+}
+
+BytesType::layout* BytesType::strip(layout* l, bool whiteSpace, layout* values, bool fromLeft, bool fromRight) {
+    if (!l) {
+        return l;
+    }
+
+    int64_t leftPos = 0;
+    int64_t rightPos = l->bytecount;
+
+    uint8_t* dataPtr = l->data;
+
+    if (fromLeft) {
+        while (leftPos < rightPos && matchchar(dataPtr[leftPos], whiteSpace, values)) {
+            leftPos++;
+        }
+    }
+
+    if (fromRight) {
+        while (leftPos < rightPos && matchchar(dataPtr[rightPos-1], whiteSpace, values)) {
+            rightPos--;
+        }
+    }
+
+    if (leftPos == rightPos) {
+        return nullptr;
+    }
+
+    if (leftPos == 0 && rightPos == l->bytecount) {
+        l->refcount++;
+        return l;
+    }
+
+    size_t datalength = rightPos - leftPos;
+    layout* new_layout = (layout*)malloc(sizeof(layout) + datalength);
+    new_layout->refcount = 1;
+    new_layout->hash_cache = -1;
+    new_layout->bytecount = datalength;
+
+    memcpy(new_layout->data, l->data + leftPos, datalength);
+
+    return new_layout;
+}
+
+BytesType::layout* BytesType::mult(layout* lhs, int64_t rhs) {
+    if (!lhs) {
+        return lhs;
+    }
+    if (rhs <= 0)
+        return 0;
+    int64_t new_length = lhs->bytecount * rhs;
+    int64_t new_byteCount = sizeof(layout) + new_length;
+
+    layout* new_layout = (layout*)malloc(new_byteCount);
+    new_layout->refcount = 1;
+    new_layout->hash_cache = -1;
+    new_layout->bytecount = new_length;
+
+    for (size_t i = 0; i < rhs; i++) {
+        memcpy(new_layout->data + i * lhs->bytecount, lhs->data, lhs->bytecount);
+    }
+
+    return new_layout;
+}
+
+// This 'replace' is slightly faster (5%) than 'bytes_replace' in bytes_wrapper.py.
+// However, this 'replace' needs better memory management.
+// Some notable special cases:
+// 'aa'.replace('','z') = 'zazaz'
+// 'aa'.replace('','z', 5) = 'aa'
+// 'aa'.replace('','z', -1) = 'zazaz'
+// ''.replace('','z') = 'z'
+// ''.replace('','z', 5) = ''
+// ''.replace('','z', -1) = 'z'
+BytesType::layout* BytesType::replace(layout* l, layout* old, layout* repl, int64_t count) {
+    if (!l) {
+        if (old || !repl || count >= 0)
+            return 0;
+        layout *new_layout = (layout*)malloc(sizeof(layout) + repl->bytecount);
+        new_layout->refcount = 1;
+        new_layout->hash_cache = -1;
+        new_layout->bytecount = repl->bytecount;
+        memcpy(new_layout->data, repl->data, repl->bytecount);
+        return new_layout;
+    }
+
+    int64_t c = 0;
+    size_t repl_len = repl ? repl->bytecount : 0;
+    size_t old_len = old ? old->bytecount : 0;
+    size_t max_matches = old_len ? l->bytecount / old_len : l->bytecount + 1;
+    size_t max_increase = repl_len > old_len ? max_matches * (repl_len - old_len) : 0;
+    size_t new_layout_size = sizeof(layout) + l->bytecount + max_increase;
+    layout* new_layout = (layout*)malloc(new_layout_size);
+    new_layout->refcount = 1;
+    new_layout->hash_cache = -1;
+    new_layout->bytecount = l->bytecount;
+
+    if ((!old_len && !repl_len) || old_len > l->bytecount || count == 0) {
+         memcpy(new_layout->data, l->data, l->bytecount);
+         return new_layout;
+    }
+
+    uint8_t* src = l->data;
+    uint8_t* dst = new_layout->data;
+    uint8_t* end_scan = l->data + l->bytecount - old_len + 1;
+    uint8_t* end_src = l->data + l->bytecount;
+    while (src < end_scan) {
+        if (!old_len || 0 == memcmp(src, old->data, old_len)) {
+            if (repl) {
+                memcpy(dst, repl->data, repl_len);
+                dst += repl_len;
+            }
+            if (!old_len) {
+                *dst++ = *src++;
+            }
+            else {
+                src += old_len;
+            }
+            new_layout->bytecount += repl_len - old_len;
+            if (count > 0 && ++c >= count) break;
+        }
+        else {
+            *dst++ = *src++;
+        }
+    }
+    if (src < end_src) memcpy(dst, src, end_src - src);
+
+    if (sizeof(layout) + new_layout->bytecount < new_layout_size) {
+        new_layout = (layout*)realloc(new_layout, sizeof(layout) + new_layout->bytecount);
+    }
+    return new_layout;
+}
+
+
+BytesType::layout* BytesType::translate(layout* l, layout* table, layout* to_delete) {
+    if (!l) return 0;
+
+    if (table && table->bytecount != 256) {
+        throw std::invalid_argument("translation table must be 256 characters long");
+    }
+
+    layout *new_layout = (layout*)malloc(sizeof(layout) + l->bytecount);
+    new_layout->refcount = 1;
+    new_layout->hash_cache = -1;
+
+    uint8_t* dst = new_layout->data;
+    for (int i = 0; i < l->bytecount; i++) {
+        uint8_t c = l->data[i];
+        if (to_delete) {
+            bool delete_this = false;
+            for (int j = 0; j < to_delete->bytecount; j++)
+                if (c == to_delete->data[j]) {
+                    delete_this = true;
+                    break;
+                }
+            if (delete_this) continue;
+        }
+        if (table)
+            *dst++ = table->data[c];
+        else
+            *dst++ = c;
+    }
+    new_layout->bytecount = dst - new_layout->data;
+
+    // might have shrunk
+    if (new_layout->bytecount < l->bytecount) {
+        new_layout = (layout*)realloc(new_layout, sizeof(layout) + new_layout->bytecount);
+    }
+    return new_layout;
+}
+
+// assumes len(from) == len(to) checked before calling
+BytesType::layout* BytesType::maketrans(layout* from, layout* to) {
+    const int table_size = 256;
+    layout* new_layout = (layout*)malloc(sizeof(layout) + table_size);
+    new_layout->refcount = 1;
+    new_layout->hash_cache = -1;
+    new_layout->bytecount = table_size;
+
+    for (int i = 0; i < table_size; i++) {
+        new_layout->data[i] = i;
+    }
+
+    for (int j = 0; j < (from ? from->bytecount : 0); j++) {
+        new_layout->data[from->data[j]] = to->data[j];
+    }
+
+    return new_layout;
 }

--- a/typed_python/BytesType.hpp
+++ b/typed_python/BytesType.hpp
@@ -73,11 +73,6 @@ public:
     //return an increffed bytes object containing a pointer to the requisite bytes
     static layout* createFromPtr(const char* data, int64_t len);
 
-    // split 'bytesLayout' depositing results into a ListOf<Bytes> in 'outList'
-    // if 'sep' is nullptr, split on whitespace
-    // max is the maximum number of splits. If its -1, then split as many times as is necessary
-    static void split(ListOfType::layout *outList, layout* bytesLayout, layout* sep, int64_t max);
-
     template<class visitor_type>
     void _visitReferencedTypes(const visitor_type& v) {}
 
@@ -116,4 +111,24 @@ public:
     static bool to_int64(layout* s, int64_t* value);
 
     static bool to_float64(layout* s, double* value);
+
+    // split 'bytesLayout' depositing results into a ListOf<Bytes> in 'outList'
+    // if 'sep' is nullptr, split on whitespace
+    // max is the maximum number of splits. If its -1, then split as many times as is necessary
+    static void split(ListOfType::layout *outList, layout* bytesLayout, layout* sep, int64_t max);
+    static void rsplit(ListOfType::layout *outList, layout* bytesLayout, layout* sep, int64_t max);
+    static void splitlines(ListOfType::layout *outList, layout* bytesLayout, bool keepends);
+
+    static void join(BytesType::layout **out, BytesType::layout *separator, ListOfType::layout *toJoin);
+
+    static layout* mult(layout* lhs, int64_t rhs);
+    static layout* lower(layout* l);
+    static layout* upper(layout* l);
+    static layout* capitalize(layout* l);
+    static layout* swapcase(layout* l);
+    static layout* title(layout* l);
+    static layout* strip(layout* l, bool whiteSpace, layout* values, bool fromLeft=true, bool fromRight=true);
+    static layout* replace(layout* l, layout* old, layout* the_new, int64_t count);
+    static layout* translate(layout* l, layout* table, layout* to_delete);
+    static layout* maketrans(layout* from, layout* to);
 };

--- a/typed_python/PyTupleOrListOfInstance.cpp
+++ b/typed_python/PyTupleOrListOfInstance.cpp
@@ -737,7 +737,7 @@ PyObject* PyListOfInstance::listPop(PyObject* o, PyObject* args) {
 
 PyObject* PyListOfInstance::listTranspose(PyObject* o, PyObject* args) {
     if (PyTuple_Size(args) != 0) {
-        PyErr_SetString(PyExc_TypeError, "ListOf.trasnpose takes zero arguments");
+        PyErr_SetString(PyExc_TypeError, "ListOf.transpose takes zero arguments");
         return NULL;
     }
 

--- a/typed_python/PyTupleOrListOfInstance.hpp
+++ b/typed_python/PyTupleOrListOfInstance.hpp
@@ -1,5 +1,5 @@
 /******************************************************************************
-   Copyright 2017-2019 typed_python Authors
+   Copyright 2017-2020 typed_python Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/typed_python/StringType.hpp
+++ b/typed_python/StringType.hpp
@@ -62,6 +62,10 @@ public:
 
     //return an increffed uppercase conversion layout of l
     static layout* upper(layout *l);
+    static layout* capitalize(layout* l);
+    static layout* casefold(layout* l);
+    static layout* swapcase(layout* l);
+    static layout* title(layout* l);
 
     static layout* strip(layout *l, bool fromLeft=true, bool fromRight=true);
 
@@ -71,13 +75,16 @@ public:
 
     //return the lowest index in the string where substring sub is found within l[start, end]
     static int64_t find(layout* l, layout* sub, int64_t start, int64_t end);
+    static int64_t rfind(layout* l, layout* sub, int64_t start, int64_t end);
+    static int64_t count(layout* l, layout* sub, int64_t start, int64_t end);
     static void split(ListOfType::layout *outList, layout* l, layout* sep, int64_t max);
-    static void split_3(ListOfType::layout *outList, layout* l, int64_t max);
+    static void rsplit(ListOfType::layout *outList, layout* l, layout* sep, int64_t max);
+    static void splitlines(ListOfType::layout *outList, layout* l, bool keepends);
 
     /**
-     * It should behave like outString = separator.join(toJoin).
+     * It should behave like out = separator.join(toJoin).
      */
-    static void join(StringType::layout **outString, StringType::layout *separator, ListOfType::layout *toJoin);
+    static void join(StringType::layout **out, StringType::layout *separator, ListOfType::layout *toJoin);
 
     static bool isalpha(layout *l);
     static bool isalnum(layout *l);
@@ -89,6 +96,8 @@ public:
     static bool isspace(layout *l);
     static bool istitle(layout *l);
     static bool isupper(layout *l);
+
+    static layout* mult(layout* lhs, int64_t rhs);
 
     //return an increffed string containing the one codepoint at 'offset'. this function
     //will correctly map negative indices, but performs no other boundschecking.
@@ -141,6 +150,9 @@ public:
     }
 
     std::string toUtf8String(instance_ptr self) {
+        if (!self)
+            return std::string();
+
         std::vector<uint8_t> data;
 
         if (bytes_per_codepoint(self) == 1) {
@@ -214,6 +226,7 @@ public:
     bool cmp(instance_ptr left, instance_ptr right, int pyComparisonOp, bool suppressExceptions);
 
     static char cmpStatic(layout* left, layout* right);
+    static char cmpStatic(layout* left, uint8_t* right_data, int right_pointcount, int right_bytes_per_codepoint);
 
     static bool cmpStaticEq(layout* left, layout* right);
 

--- a/typed_python/TupleOrListOfType.cpp
+++ b/typed_python/TupleOrListOfType.cpp
@@ -1,5 +1,5 @@
 /******************************************************************************
-   Copyright 2017-2019 typed_python Authors
+   Copyright 2017-2020 typed_python Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -263,6 +263,23 @@ void TupleOrListOfType::reserve(instance_ptr self, size_t target) {
     self_layout->reserved = target;
 }
 
+void TupleOrListOfType::reverse(instance_ptr self) {
+    layout_ptr& self_layout = *(layout_ptr*)self;
+    if (!self_layout || self_layout->count <= 1) return;
+
+    long elt_size = getEltType()->bytecount();
+
+    // swap memory without caring what the elements are
+    uint8_t* swap = (uint8_t*)malloc(elt_size);
+    for (long k = 0; k < self_layout->count / 2; k++) {
+        uint8_t* ptr1 = (uint8_t*)eltPtr(self_layout, k);
+        uint8_t* ptr2 = (uint8_t*)eltPtr(self_layout, self_layout->count - 1 - k);
+        memcpy(swap, ptr1, elt_size);
+        memcpy(ptr1, ptr2, elt_size);
+        memcpy(ptr2, swap, elt_size);
+    }
+    free(swap);
+}
 
 //static
 void ListOfType::copyListObject(instance_ptr target, instance_ptr src) {

--- a/typed_python/TupleOrListOfType.hpp
+++ b/typed_python/TupleOrListOfType.hpp
@@ -1,5 +1,5 @@
 /******************************************************************************
-   Copyright 2017-2019 typed_python Authors
+   Copyright 2017-2020 typed_python Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -181,6 +181,8 @@ public:
     void assign(instance_ptr self, instance_ptr other);
 
     void reserve(instance_ptr self, size_t count);
+
+    void reverse(instance_ptr self);
 
 protected:
     Type* m_element_type;

--- a/typed_python/_runtime.cpp
+++ b/typed_python/_runtime.cpp
@@ -467,6 +467,23 @@ extern "C" {
         return StringType::upper(l);
     }
 
+    StringType::layout* nativepython_runtime_string_capitalize(StringType::layout* l) {
+        return StringType::capitalize(l);
+    }
+
+    StringType::layout* nativepython_runtime_string_casefold(StringType::layout* l) {
+        return StringType::casefold(l);
+    }
+
+    StringType::layout* nativepython_runtime_string_swapcase(StringType::layout* l) {
+        return StringType::swapcase(l);
+    }
+
+    StringType::layout* nativepython_runtime_string_title(StringType::layout* l) {
+        return StringType::title(l);
+    }
+
+
     StringType::layout* nativepython_runtime_string_strip(StringType::layout* l, bool fromLeft, bool fromRight) {
         return StringType::strip(l, fromLeft, fromRight);
     }
@@ -475,16 +492,44 @@ extern "C" {
         return StringType::find(l, sub, start, end);
     }
 
-    int64_t nativepython_runtime_string_find_2(StringType::layout* l, StringType::layout* sub) {
-        return StringType::find(l, sub, 0, l ? l->pointcount : 0);
+    int64_t nativepython_runtime_string_rfind(StringType::layout* l, StringType::layout* sub, int64_t start, int64_t end) {
+        return StringType::rfind(l, sub, start, end);
     }
 
-    int64_t nativepython_runtime_string_find_3(StringType::layout* l, StringType::layout* sub, int64_t start) {
-        return StringType::find(l, sub, start, l ? l->pointcount : 0);
+    int64_t nativepython_runtime_string_count(StringType::layout* l, StringType::layout* sub, int64_t start, int64_t end) {
+        return StringType::count(l, sub, start, end);
     }
 
-    void nativepython_runtime_string_join(StringType::layout** outString, StringType::layout* separator, ListOfType::layout* toJoin) {
-        StringType::join(outString, separator, toJoin);
+    int64_t nativepython_runtime_string_index(StringType::layout* l, StringType::layout* sub, int64_t start, int64_t end) {
+        int64_t ret =  StringType::find(l, sub, start, end);
+        if (ret == -1) {
+            PyEnsureGilAcquired acquireTheGil;
+            PyErr_Format(
+                PyExc_ValueError, "substring not found"
+            );
+            throw PythonExceptionSet();
+        }
+        return ret;
+    }
+
+    int64_t nativepython_runtime_string_rindex(StringType::layout* l, StringType::layout* sub, int64_t start, int64_t end) {
+        int64_t ret =  StringType::rfind(l, sub, start, end);
+        if (ret == -1) {
+            PyEnsureGilAcquired acquireTheGil;
+            PyErr_Format(
+                PyExc_ValueError, "substring not found"
+            );
+            throw PythonExceptionSet();
+        }
+        return ret;
+    }
+
+    void nativepython_runtime_bytes_join(BytesType::layout** out, BytesType::layout* separator, ListOfType::layout* toJoin) {
+        BytesType::join(out, separator, toJoin);
+    }
+
+    void nativepython_runtime_string_join(StringType::layout** out, StringType::layout* separator, ListOfType::layout* toJoin) {
+        StringType::join(out, separator, toJoin);
     }
 
     ListOfType::layout* nativepython_runtime_bytes_split(BytesType::layout* l, BytesType::layout* sep, int64_t max) {
@@ -499,18 +544,53 @@ extern "C" {
         return outList;
     }
 
+    ListOfType::layout* nativepython_runtime_bytes_rsplit(BytesType::layout* l, BytesType::layout* sep, int64_t max) {
+        static ListOfType* listOfBytesT = ListOfType::Make(BytesType::Make());
+
+        ListOfType::layout* outList;
+
+        listOfBytesT->constructor((instance_ptr)&outList);
+
+        BytesType::rsplit(outList, l, sep, max);
+
+        return outList;
+    }
+
+    ListOfType::layout* nativepython_runtime_bytes_splitlines(BytesType::layout* l, bool keepends) {
+        static ListOfType* listOfBytesT = ListOfType::Make(BytesType::Make());
+
+        ListOfType::layout* outList;
+
+        listOfBytesT->constructor((instance_ptr)&outList);
+
+        BytesType::splitlines(outList, l, keepends);
+
+        return outList;
+    }
+
     ListOfType::layout* nativepython_runtime_string_split(StringType::layout* l, StringType::layout* sep, int64_t max) {
         static ListOfType* listOfStringT = ListOfType::Make(StringType::Make());
 
         ListOfType::layout* outList;
 
         listOfStringT->constructor((instance_ptr)&outList);
-
         StringType::split(outList, l, sep, max);
 
         return outList;
     }
 
+    ListOfType::layout* nativepython_runtime_string_rsplit(StringType::layout* l, StringType::layout* sep, int64_t max) {
+        static ListOfType* listOfStringT = ListOfType::Make(StringType::Make());
+
+        ListOfType::layout* outList;
+
+        listOfStringT->constructor((instance_ptr)&outList);
+
+        StringType::rsplit(outList, l, sep, max);
+
+        return outList;
+    }
+/*
     ListOfType::layout* nativepython_runtime_string_split_2(StringType::layout* l) {
         static ListOfType* listOfStringT = ListOfType::Make(StringType::Make());
 
@@ -546,6 +626,19 @@ extern "C" {
 
         return outList;
     }
+    */
+
+    ListOfType::layout* nativepython_runtime_string_splitlines(StringType::layout* l, bool keepends) {
+        static ListOfType* listOfStringT = ListOfType::Make(StringType::Make());
+
+        ListOfType::layout* outList;
+
+        listOfStringT->constructor((instance_ptr)&outList);
+
+        StringType::splitlines(outList, l, keepends);
+
+        return outList;
+    }
 
     bool nativepython_runtime_string_isalpha(StringType::layout* l) {
         return StringType::isalpha(l);
@@ -561,6 +654,23 @@ extern "C" {
 
     bool nativepython_runtime_string_isdigit(StringType::layout* l) {
         return StringType::isdigit(l);
+    }
+
+    bool nativepython_runtime_string_isidentifier(StringType::layout* l) {
+        // Not bothering to implement this myself...
+        PyEnsureGilAcquired getTheGil;
+        PyObject* s = PyInstance::extractPythonObject((instance_ptr)&l, StringType::Make());
+        if (!s) {
+            throw PythonExceptionSet();
+        }
+
+        int ret = PyUnicode_IsIdentifier(s);
+        decref(s);
+        if (ret == -1) {
+            throw PythonExceptionSet();
+        }
+
+        return ret;
     }
 
     bool nativepython_runtime_string_islower(StringType::layout* l) {
@@ -589,6 +699,10 @@ extern "C" {
 
     StringType::layout* nativepython_runtime_string_getitem_int64(StringType::layout* lhs, int64_t index) {
         return StringType::getitem(lhs, index);
+    }
+
+    StringType::layout* nativepython_runtime_string_mult(StringType::layout* lhs, int64_t rhs) {
+        return StringType::mult(lhs, rhs);
     }
 
     StringType::layout* nativepython_runtime_string_chr(int64_t code) {
@@ -668,6 +782,237 @@ extern "C" {
 
     BytesType::layout* nativepython_runtime_bytes_from_ptr_and_len(const char* utf8_str, int64_t len) {
         return BytesType::createFromPtr(utf8_str, len);
+    }
+
+    BytesType::layout* nativepython_runtime_bytes_lower(BytesType::layout* l) {
+        return BytesType::lower(l);
+    }
+
+    BytesType::layout* nativepython_runtime_bytes_upper(BytesType::layout* l) {
+        return BytesType::upper(l);
+    }
+
+    BytesType::layout* nativepython_runtime_bytes_capitalize(BytesType::layout* l) {
+        return BytesType::capitalize(l);
+    }
+
+    BytesType::layout* nativepython_runtime_bytes_swapcase(BytesType::layout* l) {
+        return BytesType::swapcase(l);
+    }
+
+    BytesType::layout* nativepython_runtime_bytes_title(BytesType::layout* l) {
+        return BytesType::title(l);
+    }
+
+    BytesType::layout* nativepython_runtime_bytes_strip(BytesType::layout* l, bool fromLeft, bool fromRight) {
+        return BytesType::strip(l, true, nullptr, fromLeft, fromRight);
+    }
+
+    BytesType::layout* nativepython_runtime_bytes_strip2(BytesType::layout* l, BytesType::layout* values, bool fromLeft, bool fromRight) {
+        return BytesType::strip(l, false, values, fromLeft, fromRight);
+    }
+
+    BytesType::layout* nativepython_runtime_bytes_mult(BytesType::layout* lhs, int64_t rhs) {
+        return BytesType::mult(lhs, rhs);
+    }
+
+    BytesType::layout* nativepython_runtime_bytes_replace(
+            BytesType::layout* l,
+            BytesType::layout* old,
+            BytesType::layout* the_new,
+            int64_t count
+    ) {
+        return BytesType::replace(l, old, the_new, count);
+    }
+
+    enum Codec { CODEC_UNKNOWN = 0, CODEC_UTF8 };
+    Codec CodecFromStr(const char *s) {
+        if (!s || !strcmp(s, "utf-8")
+                || !strcmp(s, "utf_8")
+                || !strcmp(s, "utf8")) {
+            return CODEC_UTF8;
+        }
+        return CODEC_UNKNOWN;
+    }
+
+    enum ErrHandler { ERH_UNKNOWN = 0, ERH_STRICT = 1, ERH_IGNORE = 2, ERH_REPLACE = 3 };
+    ErrHandler ErrHandlerFromStr(const char *s) {
+        if (!s || !strcmp(s, "strict")) {
+            return ERH_STRICT;
+        } else if (!strcmp(s, "ignore")) {
+            return ERH_IGNORE;
+        } else if (!strcmp(s, "replace")) {
+            return ERH_IGNORE;
+        } else {
+            return ERH_UNKNOWN;
+        }
+    }
+
+    StringType::layout* nativepython_runtime_bytes_decode(
+            BytesType::layout* l,
+            StringType::layout* encoding,
+            StringType::layout* errors
+    ) {
+        const char* c_encoding = 0;
+        std::string sEncoding;
+        if (encoding) {
+            sEncoding = StringType::Make()->toUtf8String((instance_ptr)&encoding);
+            c_encoding = sEncoding.c_str();
+        }
+
+        const char* c_errors = 0;
+        std::string sErrors;
+        if (errors) {
+            sErrors = StringType::Make()->toUtf8String((instance_ptr)&errors);
+            c_errors = sErrors.c_str();
+        }
+
+        Codec codec = CodecFromStr(c_encoding);
+        if (codec) {
+            ErrHandler errhandler = ErrHandlerFromStr(c_errors);
+            if (errhandler) {
+                if (codec == CODEC_UTF8) {
+                    uint8_t* data = l ? (uint8_t*)(l->data) : 0;
+                    // TODO: combine countUtf8Codepoints and createFromUtf8 into a single function with a single loop
+                    size_t pointCount = l ? StringType::countUtf8Codepoints(data, l->bytecount) : 0;
+                    return StringType::createFromUtf8((const char*)data, pointCount);
+                }
+            }
+        }
+
+        PyEnsureGilAcquired getTheGil;
+
+        PyObject* b = PyInstance::extractPythonObject((instance_ptr)&l, BytesType::Make());
+        if (!b) {
+            throw PythonExceptionSet();
+        }
+
+        PyObject* s = PyUnicode_FromEncodedObject(b, c_encoding, c_errors);
+        decref(b);
+        if (!s) {
+            throw PythonExceptionSet();
+        }
+
+        StringType::layout* ret = 0;
+        PyInstance::copyConstructFromPythonInstance(StringType::Make(), (instance_ptr)&ret, s, true);
+        decref(s);
+
+        return ret;
+    }
+
+
+    BytesType::layout* encodeUtf8(StringType::layout *l, ErrHandler err) {
+        int64_t max_ret_bytes_per_codepoint = l ? (l->bytes_per_codepoint < 4 ? l->bytes_per_codepoint + 1 : 4) : 0;
+        int64_t max_ret_size = l ? l->pointcount * max_ret_bytes_per_codepoint : 0;
+
+        BytesType::layout* out = (BytesType::layout*)malloc(sizeof(BytesType::layout) + max_ret_size);
+        out->refcount = 1;
+        out->hash_cache = -1;
+        out->bytecount = 0;
+        if (!l || !l->pointcount) return out;
+
+        int64_t cur = 0;
+        for (int64_t i = 0; i < l->pointcount; i++) {
+            uint32_t c = StringType::getpoint(l, i);
+            if (c < 0x80) {
+                out->data[cur++] = (uint8_t)c;
+            } else if (c < 0x800) {
+                out->data[cur++] = 0xC0 | (c >> 6);
+                out->data[cur++] = 0x80 | (c & 0x3F);
+            } else if (c < 0x10000) {
+                out->data[cur++] = 0xE0 | (c >> 12);
+                out->data[cur++] = 0x80 | ((c >> 6) & 0x3F);
+                out->data[cur++] = 0x80 | (c & 0x3F);
+            } else if (c < 0x110000) {
+                out->data[cur++] = 0xF0 | (c >> 18);
+                out->data[cur++] = 0x80 | ((c >> 12) & 0x3F);
+                out->data[cur++] = 0x80 | ((c >> 6) & 0x3F);
+                out->data[cur++] = 0x80 | (c & 0x3F);
+            } else if (err == ERH_REPLACE) {
+                const uint32_t rc = 0xFFFD;
+                out->data[cur++] = 0xE0 | (rc >> 12);
+                out->data[cur++] = 0x80 | ((rc >> 6) & 0x3F);
+                out->data[cur++] = 0x80 | (rc & 0x3F);
+            } else if (err == ERH_STRICT) {
+                PyEnsureGilAcquired getTheGil;
+                PyErr_Format(
+                    PyExc_UnicodeError,
+                    "illegal Unicode character"
+                    );
+                throw PythonExceptionSet();
+            } // else err == ERH_IGNORE
+        }
+
+        out->bytecount = cur;
+        if (out->bytecount < max_ret_size) {
+            out = (BytesType::layout*)realloc(out, sizeof(BytesType::layout) + out->bytecount);
+        }
+
+        return out;
+    }
+
+    BytesType::layout* nativepython_runtime_str_encode(
+            StringType::layout* l,
+            StringType::layout* encoding,
+            StringType::layout* errors
+    ) {
+        const char* c_encoding = 0;
+        std::string sEncoding;
+        if (encoding) {
+            sEncoding = StringType::Make()->toUtf8String((instance_ptr)&encoding);
+            c_encoding = sEncoding.c_str();
+        }
+
+        const char* c_errors = 0;
+        std::string sErrors;
+        if (errors) {
+            sErrors = StringType::Make()->toUtf8String((instance_ptr)&errors);
+            c_errors = sErrors.c_str();
+        }
+
+        Codec codec = CodecFromStr(c_encoding);
+        if (codec) {
+            ErrHandler errhandler = ErrHandlerFromStr(c_errors);
+            if (errhandler) {
+                if (codec == CODEC_UTF8) {
+                    return encodeUtf8(l, errhandler);
+                }
+            }
+        }
+
+        PyEnsureGilAcquired getTheGil;
+
+        PyObject* s = PyInstance::extractPythonObject((instance_ptr)&l, StringType::Make());
+        if (!s) {
+            throw PythonExceptionSet();
+        }
+
+        PyObject* b = PyUnicode_AsEncodedString(s, c_encoding, c_errors);
+        decref(s);
+        if (!b) {
+            throw PythonExceptionSet();
+        }
+
+        BytesType::layout* ret = 0;
+        PyInstance::copyConstructFromPythonInstance(BytesType::Make(), (instance_ptr)&ret, b, true);
+        decref(b);
+
+        return ret;
+    }
+
+    BytesType::layout* nativepython_runtime_bytes_translate(
+            BytesType::layout* l,
+            BytesType::layout* table,
+            BytesType::layout* to_delete
+    ) {
+        return BytesType::translate(l, table, to_delete);
+    }
+
+    BytesType::layout* nativepython_runtime_bytes_maketrans(
+            BytesType::layout* from,
+            BytesType::layout* to
+    ) {
+        return BytesType::maketrans(from, to);
     }
 
     PythonObjectOfType::layout_type* nativepython_runtime_create_pyobj(PyObject* p) {
@@ -944,7 +1289,11 @@ extern "C" {
     uint64_t nativepython_pyobj_len(PythonObjectOfType::layout_type* layout) {
         PyEnsureGilAcquired getTheGil;
 
-        return PyObject_Length(layout->pyObj);
+        int ret = PyObject_Length(layout->pyObj);
+        if (ret == -1) {
+            throw PythonExceptionSet();
+        }
+        return ret;
     }
 
     // call a Function object from the interpreter
@@ -1143,8 +1492,10 @@ extern "C" {
     }
 
     double nativepython_runtime_pow_float64_float64(double l, double r) {
-        if (l == 0.0 && r < 0.0) {
+        if (l == 0.0 && r < 0.0)
+        {
             PyEnsureGilAcquired acquireTheGil;
+
             PyErr_Format(PyExc_ZeroDivisionError, "0.0 cannot be raised to a negative power");
             throw PythonExceptionSet();
         }
@@ -1190,7 +1541,7 @@ extern "C" {
 
         if ((l == 0 && r > SSIZE_MAX) || (l != 0 && r >= 1024)) { // 1024 is arbitrary
             PyEnsureGilAcquired acquireTheGil;
-            PyErr_Format(PyExc_ValueError, "shift count too large");
+            PyErr_Format(PyExc_OverflowError, "shift count too large");
             throw PythonExceptionSet();
         }
 
@@ -1201,7 +1552,7 @@ extern "C" {
     uint64_t nativepython_runtime_lshift_uint64_uint64(uint64_t l, uint64_t r) {
         if ((l == 0 && r > SSIZE_MAX) || (l != 0 && r >= 1024)) { // 1024 is arbitrary
             PyEnsureGilAcquired acquireTheGil;
-            PyErr_Format(PyExc_ValueError, "shift count too large");
+            PyErr_Format(PyExc_OverflowError, "shift count too large");
             throw PythonExceptionSet();
         }
         return l << r;
@@ -1211,7 +1562,7 @@ extern "C" {
     uint64_t nativepython_runtime_rshift_uint64_uint64(uint64_t l, uint64_t r) {
         if (r > SSIZE_MAX) {
             PyEnsureGilAcquired acquireTheGil;
-            PyErr_Format(PyExc_ValueError, "shift count too large");
+            PyErr_Format(PyExc_OverflowError, "shift count too large");
             throw PythonExceptionSet();
         }
         if (r == 0)
@@ -1230,7 +1581,7 @@ extern "C" {
         }
         if (r > SSIZE_MAX) {
             PyEnsureGilAcquired acquireTheGil;
-            PyErr_Format(PyExc_ValueError, "shift count too large");
+            PyErr_Format(PyExc_OverflowError, "shift count too large");
             throw PythonExceptionSet();
         }
         if (r == 0)
@@ -1249,7 +1600,7 @@ extern "C" {
     int64_t nativepython_runtime_floordiv_int64_int64(int64_t l, int64_t r) {
         if (r == 0) {
             PyEnsureGilAcquired acquireTheGil;
-            PyErr_Format(PyExc_ZeroDivisionError, "integer division or modulo by zero");
+            PyErr_Format(PyExc_ZeroDivisionError, "integer floordiv by zero");
             throw PythonExceptionSet();
         }
         if (l < 0 && l == -l && r == -1) {
@@ -1268,7 +1619,7 @@ extern "C" {
     double nativepython_runtime_floordiv_float64_float64(double l, double r) {
         if (r == 0.0) {
             PyEnsureGilAcquired acquireTheGil;
-            PyErr_Format(PyExc_ZeroDivisionError, "integer division or modulo by zero");
+            PyErr_Format(PyExc_ZeroDivisionError, "floating point floordiv by zero");
             throw PythonExceptionSet();
         }
 

--- a/typed_python/compiler/expression_conversion_context.py
+++ b/typed_python/compiler/expression_conversion_context.py
@@ -1734,20 +1734,41 @@ class ExpressionConversionContext(object):
             return lhs.convert_call(args, kwargs)
 
         if ast.matches.Compare:
-            assert len(ast.comparators) == 1, "multi-comparison not implemented yet"
-            assert len(ast.ops) == 1
+            if len(ast.ops) == 1:
+                lhs = self.convert_expression_ast(ast.left)
 
-            lhs = self.convert_expression_ast(ast.left)
+                if lhs is None:
+                    return None
 
-            if lhs is None:
-                return None
+                r = self.convert_expression_ast(ast.comparators[0])
 
-            r = self.convert_expression_ast(ast.comparators[0])
+                if r is None:
+                    return None
 
-            if r is None:
-                return None
+                return lhs.convert_bin_op(ast.ops[0], r)
+            else:
+                result = self.allocateUninitializedSlot(bool)
+                result.convert_copy_initialize(self.constant(True))
+                self.markUninitializedSlotInitialized(result)
+                left = self.convert_expression_ast(ast.left)
+                if left is None:
+                    return None
+                for i in range(len(ast.comparators)):
+                    with self.ifelse(result) as (ifTrue, ifFalse):
+                        with ifTrue:
+                            t = self.convert_expression_ast(ast.comparators[i])
+                            if t is None:
+                                return None
+                            right = self.allocateUninitializedSlot(t.expr_type.typeRepresentation)
+                            right.convert_copy_initialize(t)
+                            self.markUninitializedSlotInitialized(right)
+                            cond = left.convert_bin_op(ast.ops[i], right)
+                            if cond is None:
+                                return None
+                            result.convert_copy_initialize(cond)
+                            left = right
 
-            return lhs.convert_bin_op(ast.ops[0], r)
+                return result
 
         if ast.matches.IfExp:
             test = self.convert_expression_ast(ast.test)

--- a/typed_python/compiler/python_object_representation.py
+++ b/typed_python/compiler/python_object_representation.py
@@ -1,4 +1,4 @@
-#   Copyright 2017-2019 typed_python Authors
+#   Copyright 2017-2020 typed_python Authors
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
@@ -54,8 +54,8 @@ from typed_python.compiler.type_wrappers.math_wrappers import MathFunctionWrappe
 from typed_python.compiler.type_wrappers.builtin_wrappers import BuiltinWrapper
 from typed_python.compiler.type_wrappers.bytecount_wrapper import BytecountWrapper
 from typed_python.compiler.type_wrappers.arithmetic_wrapper import IntWrapper, FloatWrapper, BoolWrapper
-from typed_python.compiler.type_wrappers.string_wrapper import StringWrapper
-from typed_python.compiler.type_wrappers.bytes_wrapper import BytesWrapper
+from typed_python.compiler.type_wrappers.string_wrapper import StringWrapper, StringMaketransWrapper
+from typed_python.compiler.type_wrappers.bytes_wrapper import BytesWrapper, BytesMaketransWrapper
 from typed_python.compiler.type_wrappers.python_object_of_type_wrapper import PythonObjectOfTypeWrapper
 from typed_python.compiler.type_wrappers.abs_wrapper import AbsWrapper
 from typed_python.compiler.type_wrappers.min_max_wrapper import MinWrapper, MaxWrapper
@@ -218,6 +218,12 @@ def pythonObjectRepresentation(context, f, owningGlobalScopeAndName=None):
 
     if f is range:
         return TypedExpression(context, native_ast.nullExpr, _RangeWrapper, False)
+
+    if f is bytes.maketrans:
+        return TypedExpression(context, native_ast.nullExpr, BytesMaketransWrapper(), False)
+
+    if f is str.maketrans:
+        return TypedExpression(context, native_ast.nullExpr, StringMaketransWrapper(), False)
 
     if f is isinstance:
         return TypedExpression(context, native_ast.nullExpr, IsinstanceWrapper(), False)

--- a/typed_python/compiler/tests/arithmetic_compilation_test.py
+++ b/typed_python/compiler/tests/arithmetic_compilation_test.py
@@ -643,7 +643,7 @@ class TestArithmeticCompilation(unittest.TestCase):
         with self.assertRaises(ValueError):
             callShift(1, -2)
 
-        with self.assertRaises(ValueError):
+        with self.assertRaises(OverflowError):
             callShift(1, 2048)
 
     def test_formatting_with_format_strings_works(self):

--- a/typed_python/compiler/tests/builtin_compilation_test.py
+++ b/typed_python/compiler/tests/builtin_compilation_test.py
@@ -264,6 +264,23 @@ class TestBuiltinCompilation(unittest.TestCase):
                 self.assertEqual(r1, r2)
                 self.assertEqual(type(r1), type(r2))
 
+        def f_min3(*v):
+            return min(v, spuriousparam="x")
+
+        def f_max3(*v):
+            return min(v, spuriousparam="x")
+
+        def f_min4(*v):
+            return min(v, key=f_key2, spuriousparam="x")
+
+        def f_max4(*v):
+            return min(v, key=f_key2, spuriousparam="x")
+
+        for f in [f_min3, f_max3, f_min4, f_max4]:
+            v = [3, 1, 2]
+            with self.assertRaises(TypeError):
+                Entrypoint(f)(v)
+
     def test_min_max_iterable(self):
         def f_min(v):
             return min(v)

--- a/typed_python/compiler/tests/bytes_compilation_test.py
+++ b/typed_python/compiler/tests/bytes_compilation_test.py
@@ -1,4 +1,4 @@
-#   Copyright 2017-2019 typed_python Authors
+#   Copyright 2017-2020 typed_python Authors
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
@@ -12,7 +12,14 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-from typed_python import Compiled, Entrypoint, ListOf
+from typed_python import Compiled, Entrypoint, ListOf, TupleOf, Dict, ConstDict
+from typed_python.compiler.type_wrappers.bytes_wrapper import bytesJoinIterable, \
+    bytes_isalnum, bytes_isalpha, \
+    bytes_isdigit, bytes_islower, bytes_isspace, bytes_istitle, bytes_isupper, bytes_replace, \
+    bytes_startswith, bytes_endswith, bytes_count, bytes_count_single, bytes_find, bytes_find_single, \
+    bytes_rfind, bytes_rfind_single, bytes_index, bytes_index_single, bytes_rindex, bytes_rindex_single, \
+    bytes_partition, bytes_rpartition, bytes_center, bytes_ljust, bytes_rjust, bytes_expandtabs, \
+    bytes_zfill
 from typed_python.test_util import compilerPerformanceComparison
 import flaky
 
@@ -27,6 +34,13 @@ someBytes = [
     b"\x00\x01",
     b"\x00\x01\x02\x00\x01",
 ]
+
+
+def result_or_exception(f, *p):
+    try:
+        return f(*p)
+    except Exception as e:
+        return type(e)
 
 
 class TestBytesCompilation(unittest.TestCase):
@@ -205,19 +219,35 @@ class TestBytesCompilation(unittest.TestCase):
         self.assertLess(time.time() - t0, 1e-4)
 
     def test_bytes_split(self):
-        def split(someBytes, *args):
-            return someBytes.split(*args)
+        def split(someBytes, *args, **kwargs):
+            return someBytes.split(*args, **kwargs)
+
+        def rsplit(someBytes, *args, **kwargs):
+            return someBytes.rsplit(*args, **kwargs)
 
         compiledSplit = Entrypoint(split)
+        compiledRsplit = Entrypoint(rsplit)
 
         for args in [
+            (b'',),
+            (b'', b'a'),
+            (b'', b'ab'),
             (b'asdf',),
             (b'asdf', b'blahblah'),
             (b'asdf', b'a'),
             (b'asdf', b's'),
             (b'asdf', b'K'),
             (b'asdf', b's', 0),
+            (b'asdf', b's', -1),
+            (b' asdf ', None, 0),
+            (b' asdf ', None, -1),
+            (b'as df', None, 0),
+            (b'     ', None, 0),
+            (b'', None, 0),
             (b'a aaa bababa a',),
+            (b'a  aaa  bababa  a',),
+            (b'  a   ',),
+            (b' \t\n\r\x0b\f ',),
             (b'a aaa bababa a', b'b'),
             (b'a aaa bababa a', b'b', 1),
             (b'a aaa bababa a', b'b', 2),
@@ -225,9 +255,30 @@ class TestBytesCompilation(unittest.TestCase):
             (b'a aaa bababa a', b'b', 4),
             (b'a aaa bababa a', b'b', 5),
             (b'a aaa bababa a', b'a', 5),
+            (b'a aaa bababa a', b'a', 500),
             (b'a aaa bababa a', b'K', 5),
+            (b'A B\tC\nD\rE\x0bF\fG',),
+            (b'AxyBxyCxyxyxyDEFxyGxyxy', b'xy'),
+            (b'AxyBxy\x00CxyDEFxyGxy', b'xy'),
+            (b'A\x00B\x00C\x00DEF\x00G\x00', b'\x00'),
+            (b'A\x00BA\x00C', b'A\x00B'),
+            (b'A\x00b\x00C\x00DEF\x00G\x00', b'\x00b'),
+            (b'Ax\x00yBx\x00Cx\x00yDEFx\x00yGx\x00y', b'x\x00y')
         ]:
-            assert split(*args) == compiledSplit(*args)
+            self.assertEqual(split(*args), compiledSplit(*args), args)
+            self.assertEqual(rsplit(*args), compiledRsplit(*args), args)
+
+        with self.assertRaises(ValueError):
+            compiledSplit(b'', b'')
+
+        with self.assertRaises(ValueError):
+            compiledRsplit(b'', b'')
+
+        with self.assertRaises(ValueError):
+            compiledSplit(b'abc', b'')
+
+        with self.assertRaises(ValueError):
+            compiledRsplit(b'abc', b'')
 
     @flaky.flaky(max_runs=3, min_passes=1)
     def test_bytes_split_perf(self):
@@ -252,3 +303,636 @@ class TestBytesCompilation(unittest.TestCase):
             f"Expected compiled time {compiled} to be not much slower than uncompiled time {uncompiled}. "
             f"Compiler was {compiled / uncompiled} times slower."
         )
+
+    def test_bytes_iteration(self):
+        def iter(x: bytes):
+            r = ListOf(int)()
+            for a in x:
+                r.append(a)
+            return r
+
+        def iter_constant():
+            r = ListOf(int)()
+            for a in b'constant':
+                r.append(a)
+            return r
+
+        def contains_space(x: bytes):
+            for i in x:
+                if i == 32:
+                    return True
+            return False
+
+        def f_index(x: bytes, i: int):
+            return x[i]
+
+        r1 = iter_constant()
+        r2 = Compiled(iter_constant)()
+        self.assertEqual(type(r1), type(r2))
+        self.assertEqual(r1, r2)
+
+        for v in [b'whatever', b'o', b'']:
+            r1 = iter(v)
+            r2 = Compiled(iter)(v)
+            self.assertEqual(type(r1), type(r2))
+            self.assertEqual(r1, r2)
+
+        for v in [b'', b'a', b' ', b'abc ', b'x' * 1000 + b' ' + b'x' * 1000, b'y' * 1000]:
+            r1 = contains_space(v)
+            r2 = Compiled(contains_space)(v)
+            self.assertEqual(r1, r2)
+
+    def test_bytes_bool_fns(self):
+        def f_isalnum(x):
+            return x.isalnum()
+
+        def f_isalpha(x):
+            return x.isalpha()
+
+        def f_isdigit(x):
+            return x.isdigit()
+
+        def f_islower(x):
+            return x.islower()
+
+        def f_isspace(x):
+            return x.isspace()
+
+        def f_istitle(x):
+            return x.istitle()
+
+        def f_isupper(x):
+            return x.isupper()
+
+        cases = [b'abc' + bytes([i]) + b'abc' for i in range(256)]
+        cases += [b'ABC' + bytes([i]) + b'ABC' for i in range(256)]
+        cases += [b'123' + bytes([i]) for i in range(256)]
+        cases += [b'  \t\r\n\f' + bytes([i]) for i in range(256)]
+        cases += [bytes([i]) + b'123' for i in range(256)]
+        cases += [bytes([i]) + b'   'for i in range(256)]
+        cases += [b'', b'A' * 1000, b'9' * 1000]
+        cases += [b'Title Case', b'NotTitleCase']
+        for f in [f_isalnum, f_isalpha, f_isdigit, f_islower, f_isspace, f_istitle, f_isupper]:
+            for v in cases:
+                r1 = f(v)
+                r2 = Entrypoint(f)(v)
+                self.assertEqual(r1, r2, (f, v))
+
+    def test_bytes_startswith_endswith(self):
+        def f_startswith(x, y):
+            return x.startswith(y)
+
+        def f_endswith(x, y):
+            return x.endswith(y)
+
+        xcases = [b'abaabaaabaaaaabaaaabaaabaabab', b'']
+        ycases = [b'a', b'ab', b'ba', b'abaabaaabaaaaabaaaabaaabaabab', b'abaabaaabaaaaabaaaabaaabaababa', b'']
+        for f in [f_startswith, f_endswith]:
+            for x in xcases:
+                for y in ycases:
+                    r1 = f(x, y)
+                    r2 = Entrypoint(f)(x, y)
+                    self.assertEqual(r1, r2, (f, x, y))
+
+    def test_bytes_case(self):
+        def f_lower(x):
+            return x.lower()
+
+        def f_upper(x):
+            return x.upper()
+
+        def f_capitalize(x):
+            return x.capitalize()
+
+        def f_swapcase(x):
+            return x.swapcase()
+
+        def f_title(x):
+            return x.title()
+
+        cases = [b'abc'*10, b'ABC'*10, b'aBc'*10, b'1@=.,z', b'']
+        cases += [x + b' ' + y for x in cases for y in cases]
+        for f in [f_lower, f_upper, f_capitalize, f_swapcase, f_title]:
+            for v in cases:
+                r1 = f(v)
+                r2 = Entrypoint(f)(v)
+                self.assertEqual(r1, r2, (f, v))
+
+    def test_bytes_strip(self):
+        def f_strip(x):
+            return x.strip()
+
+        def f_lstrip(x):
+            return x.lstrip()
+
+        def f_rstrip(x):
+            return x.rstrip()
+
+        pieces = [b'', b' ', b'\t\n\r\x0B\f', b'abc']
+        cases = [a + b + c for a in pieces for b in pieces for c in pieces]
+
+        for f in [f_strip, f_lstrip, f_rstrip]:
+            for v in cases:
+                r1 = f(v)
+                r2 = Entrypoint(f)(v)
+                self.assertEqual(r1, r2, (f, v))
+
+        def f_strip2(x, y):
+            return x.strip(y)
+
+        def f_lstrip2(x, y):
+            return x.lstrip(y)
+
+        def f_rstrip2(x, y):
+            return x.rstrip(y)
+
+        for f in [f_strip2, f_lstrip2, f_rstrip2]:
+            for y in [b'', b'a', b'ab', b'Z']:
+                for v in cases:
+                    r1 = f(v, y)
+                    r2 = Entrypoint(f)(v, y)
+                    self.assertEqual(r1, r2, (f, v, y))
+
+    def test_bytes_count(self):
+        def f_count(x, sub):
+            return x.count(sub)
+
+        def f_count2(x, sub, start):
+            return x.count(sub, start)
+
+        def f_count3(x, sub, start, end):
+            return x.count(sub, start, end)
+
+        cases = [b'ababcab', b'ababcabcab', b'aabbabbbaaabbaaba']
+        subs = [b'a', b'ab', b'ba', b'abc', b'']
+        for v in cases:
+            for sub in subs:
+                f = f_count
+                r1 = f(v, sub)
+                r2 = Entrypoint(f)(v, sub)
+                self.assertEqual(r1, r2, (v, sub))
+
+                for start in range(-10, 11, 2):
+                    f = f_count2
+                    r1 = f(v, sub, start)
+                    r2 = Entrypoint(f)(v, sub, start)
+                    self.assertEqual(r1, r2, (v, sub, start))
+                    for end in range(-10, 11, 2):
+                        f = f_count3
+                        r1 = f(v, sub, start, end)
+                        r2 = Entrypoint(f)(v, sub, start, end)
+                        self.assertEqual(r1, r2, (v, sub, start, end))
+
+    def test_bytes_find(self):
+        def f_find(x, sub):
+            return x.find(sub)
+
+        def f_find2(x, sub, start):
+            return x.find(sub, start)
+
+        def f_find3(x, sub, start, end):
+            return x.find(sub, start, end)
+
+        def f_rfind(x, sub):
+            return x.rfind(sub)
+
+        def f_rfind2(x, sub, start):
+            return x.rfind(sub, start)
+
+        def f_rfind3(x, sub, start, end):
+            return x.rfind(sub, start, end)
+
+        def f_index(x, sub):
+            return x.index(sub)
+
+        def f_index2(x, sub, start):
+            return x.index(sub, start)
+
+        def f_index3(x, sub, start, end):
+            return x.index(sub, start, end)
+
+        def f_rindex(x, sub):
+            return x.rindex(sub)
+
+        def f_rindex2(x, sub, start):
+            return x.rindex(sub, start)
+
+        def f_rindex3(x, sub, start, end):
+            return x.rindex(sub, start, end)
+
+        cases = [b'ababcab', b'ababcabcab', b'aabbabbbaaabbaaba']
+        subs = [97, 98, b'a', b'c', b'X', b'ab', b'ba', b'abc', b'']
+        for v in cases:
+            for sub in subs:
+                for f in [f_find, f_rfind]:
+                    r1 = f(v, sub)
+                    r2 = Entrypoint(f)(v, sub)
+                    self.assertEqual(r1, r2, (f, v, sub))
+                    g = f_index if f == f_find else f_rindex
+                    if r1 != -1:
+                        r3 = Entrypoint(g)(v, sub)
+                        self.assertEqual(r1, r3, (g, v, sub))
+                    else:
+                        with self.assertRaises(ValueError):
+                            Entrypoint(g)(v, sub)
+
+                for start in range(-10, 11, 2):
+                    for f in [f_find2, f_rfind2]:
+                        r1 = f(v, sub, start)
+                        r2 = Entrypoint(f)(v, sub, start)
+                        self.assertEqual(r1, r2, (f, v, sub, start))
+                        g = f_index2 if f == f_find2 else f_rindex2
+                        if r1 != -1:
+                            r3 = Entrypoint(g)(v, sub, start)
+                            self.assertEqual(r1, r3, (g, v, sub, start))
+                        else:
+                            with self.assertRaises(ValueError):
+                                Entrypoint(g)(v, sub, start)
+                    for end in range(-10, 11, 2):
+                        for f in [f_find3, f_rfind3]:
+                            r1 = f(v, sub, start, end)
+                            r2 = Entrypoint(f)(v, sub, start, end)
+                            self.assertEqual(r1, r2, (f, v, sub, start, end))
+
+                            g = f_index3 if f == f_find3 else f_rindex3
+                            if r1 != -1:
+                                r3 = Entrypoint(g)(v, sub, start, end)
+                                self.assertEqual(r1, r3, (g, v, sub, start, end))
+                            else:
+                                with self.assertRaises(ValueError):
+                                    Entrypoint(g)(v, sub, start, end)
+
+    def test_bytes_mult(self):
+        def f_mult(x, n):
+            return x * n
+
+        v = b'XyZ'
+        for n in [1, 5, 100, 0, -1]:
+            r1 = f_mult(v, n)
+            r2 = Entrypoint(f_mult)(v, n)
+            self.assertEqual(r1, r2, n)
+
+    def test_bytes_contains_bytes(self):
+        @Entrypoint
+        def f_contains(x, y):
+            return x in y
+
+        @Entrypoint
+        def f_not_contains(x, y):
+            return x not in y
+
+        self.assertTrue(f_contains(b'a', b'asfd'))
+        self.assertFalse(f_contains(b'b', b'asfd'))
+        self.assertFalse(f_contains(b'b', ListOf(bytes)([b'asfd'])))
+        self.assertTrue(f_contains(b'asdf', ListOf(bytes)([b'asdf'])))
+
+        self.assertFalse(f_not_contains(b'a', b'asfd'))
+        self.assertTrue(f_not_contains(b'b', b'asfd'))
+        self.assertTrue(f_not_contains(b'b', ListOf(bytes)([b'asfd'])))
+        self.assertFalse(f_not_contains(b'asdf', ListOf(bytes)([b'asdf'])))
+
+    def test_bytes_replace(self):
+        def replace(x: bytes, y: bytes, z: bytes):
+            return x.replace(y, z)
+
+        def replace2(x: bytes, y: bytes, z: bytes, i: int):
+            return x.replace(y, z, i)
+
+        replaceCompiled = Compiled(replace)
+        replace2Compiled = Compiled(replace2)
+
+        values = {b'', b'ba', b'abc'}
+        for _ in range(2):
+            for y in [b'ab', b'ba'*100]:
+                values = values.union({x + y for x in values})
+
+        for s1 in values:
+            for s2 in values:
+                for s3 in values:
+                    r1 = replace(s1, s2, s3)
+                    r2 = replaceCompiled(s1, s2, s3)
+                    self.assertEqual(r1, r2)
+
+                    for i in [-1, 0, 1, 2]:
+                        r1 = replace2(s1, s2, s3, i)
+                        r2 = replace2Compiled(s1, s2, s3, i)
+                        self.assertEqual(r1, r2, (s1, s2, s3, i))
+
+    def validate_joining_bytes(self, function, make_obj):
+        # Test data, the fields are: description, separator, items, expected output
+        test_data = [
+            ["simple data",
+             b",", [b"1", b"2", b"3"], b"1,2,3"],
+
+            ["longer separator",
+             b"---", [b"1", b"2", b"3"], b"1---2---3"],
+
+            ["longer items",
+             b"---", [b"aaa", b"bb", b"c"], b"aaa---bb---c"],
+
+            ["empty separator",
+             b"", [b"1", b"2", b"3"], b"123"],
+
+            ["everything empty",
+             b"", [], b""],
+
+            ["empty list",
+             b"a", [], b""],
+
+            ["empty bytes in the items",
+             b"--", [b"", b"1", b"3"], b"--1--3"],
+
+            ["blank bytes in the items",
+             b"--", [b" ", b"1", b"3"], b" --1--3"],
+        ]
+
+        for description, separator, items, expected in test_data:
+            res = function(separator, make_obj(items))
+            self.assertEqual(expected, res, description)
+
+    def test_bytes_join_for_tuple_of_bytes(self):
+        # test passing tuple of bytes
+        @Compiled
+        def f(sep: bytes, items: TupleOf(bytes)) -> bytes:
+            return sep.join(items)
+
+        self.validate_joining_bytes(f, lambda items: TupleOf(bytes)(items))
+
+    def test_bytes_join_for_list_of_bytes(self):
+        # test passing list of bytes
+        @Compiled
+        def f(sep: bytes, items: ListOf(bytes)) -> bytes:
+            return sep.join(items)
+
+        self.validate_joining_bytes(f, lambda items: ListOf(bytes)(items))
+
+    def test_bytes_join_for_dict_of_bytes(self):
+        # test passing list of bytes
+        @Compiled
+        def f(sep: bytes, items: Dict(bytes, bytes)) -> bytes:
+            return sep.join(items)
+
+        self.validate_joining_bytes(f, lambda items: Dict(bytes, bytes)({i: b"a" for i in items}))
+
+    def test_bytes_join_for_const_dict_of_bytes(self):
+        # test passing list of bytes
+        @Compiled
+        def f(sep: bytes, items: ConstDict(bytes, bytes)) -> bytes:
+            return sep.join(items)
+
+        self.validate_joining_bytes(f, lambda items: ConstDict(bytes, bytes)({i: b"a" for i in items}))
+
+    def test_bytes_join_for_bad_types(self):
+        """bytes.join supports only joining iterables of bytes."""
+
+        # test passing tuple of ints
+        @Compiled
+        def f_tup_int(sep: bytes, items: TupleOf(int)) -> bytes:
+            return sep.join(items)
+
+        with self.assertRaisesRegex(TypeError, ""):
+            f_tup_int(b",", ListOf(int)([1, 2, 3]))
+
+        # test passing list of other types than bytes
+        @Compiled
+        def f_int(sep: bytes, items: ListOf(str)) -> bytes:
+            return sep.join(items)
+
+        with self.assertRaisesRegex(TypeError, ""):
+            f_int(b",", ListOf(int)(["1", "2", "3"]))
+
+    def test_bytes_decode(self):
+        def f_decode1(x, _i1, _i2):
+            return x.decode()
+
+        def f_decode2(x, enc, _i2):
+            return x.decode(enc)
+
+        def f_decode3(x, enc, err):
+            return x.decode(enc, err)
+
+        for v in [b'quarter'*1000, b'25\xC2\xA2', b'\xE2\x82\xAC100', b'\xF0\x9F\x98\x80', b'']:
+            for f in [f_decode1, f_decode2, f_decode3]:
+                for enc in ["utf-8", "ascii", "cp863", "hz"]:
+                    for err in ["strict", "ignore", "replace"]:
+                        r1 = result_or_exception(f, v, enc, err)
+                        r2 = result_or_exception(Entrypoint(f), v, enc, err)
+                        self.assertEqual(r1, r2)
+
+    def test_bytes_translate(self):
+        def f_translate1(x, table):
+            return x.translate(table)
+
+        def f_translate2(x, table, to_delete):
+            return x.translate(table, to_delete)
+
+        def f_translate3(x, table, to_delete):
+            return x.translate(table, delete=to_delete)
+
+        t1 = b'0123456789abcdef'*16
+        t2 = b'ABCDEFGHIJKLMNOP'*16
+        t3 = bytes.maketrans(b'abc123', b'XYZijk')
+
+        for v in [b'Abc', b'1234\r\n\f\x00ABCDabcd'*256, b'']:
+            for t in [None, t1, t2, t3]:
+                r1 = f_translate1(v, t)
+                r2 = Entrypoint(f_translate1)(v, t)
+                self.assertEqual(r1, r2, (v, t))
+
+                for d in [b'a', b'Bb', b'']:
+                    r1 = f_translate2(v, t, d)
+                    r2 = Entrypoint(f_translate2)(v, t, d)
+                    self.assertEqual(r1, r2, (v, t, d))
+
+                    r1 = f_translate3(v, t, d)
+                    r2 = Entrypoint(f_translate3)(v, t, d)
+                    self.assertEqual(r1, r2, (v, t, d))
+
+        with self.assertRaises(ValueError):
+            Entrypoint(f_translate1)(b'Abc', b'too short')
+
+        with self.assertRaises(ValueError):
+            Entrypoint(f_translate1)(b'Abc', b'too long'*100)
+
+        with self.assertRaises(TypeError):
+            Entrypoint(f_translate1)(b'Abc', 'wrong type')
+
+        def f_maketrans1(x, y):
+            return b''.maketrans(x, y)
+
+        def f_maketrans2(x, y):
+            return bytes.maketrans(x, y)
+
+        def f_maketrans3(t, x, y):
+            return t.maketrans(x, y)  # convincing myself that I'm recognizing maketrans properly
+
+        cases = (
+            (b'', b''),
+            (b'abc123', b'XYZijk'),
+            (b' ', b'-'),
+            (b' '*500, b'-'*500),
+            (b'a', b'ab'),
+            (b'ab', b'a'),
+            (b'wrong', 'type '),
+            (b'wrong', 123),
+        )
+        for f in [f_maketrans1, f_maketrans2]:
+            for x, y in cases:
+                r1 = result_or_exception(f, x, y)
+                r2 = result_or_exception(Entrypoint(f), x, y)
+                self.assertEqual(r1, r2, (f, x, y))
+        for x, y in cases:
+            r1 = result_or_exception(f_maketrans3, bytes, x, y)
+            r2 = result_or_exception(Entrypoint(f_maketrans3), bytes, x, y)
+            self.assertEqual(r1, r2, (f_maketrans3, x, y))
+
+    def test_bytes_partition(self):
+        def f_partition(x, sep):
+            return x.partition(sep)
+
+        def f_rpartition(x, sep):
+            return x.rpartition(sep)
+
+        for f in [f_partition, f_rpartition]:
+            for v in [b' beginning', b'end ', b'mid dle', b'wind', b'spin', b'']:
+                for sep in [b' ', b'in']:
+                    r1 = f(v, sep)
+                    r2 = Entrypoint(f)(v, sep)
+                    self.assertEqual(r1, r2, (f, v, sep))
+
+                with self.assertRaises(ValueError):
+                    Entrypoint(f)(v, b'')
+
+                with self.assertRaises(TypeError):
+                    Entrypoint(f)(v, 'abc')
+
+    def test_bytes_just(self):
+        def f_center(x, w, fill):
+            if fill == ' ':
+                return x.center(w)
+            else:
+                return x.center(w, fill)
+
+        def f_ljust(x, w, fill):
+            if fill == ' ':
+                return x.ljust(w)
+            else:
+                return x.ljust(w, fill)
+
+        def f_rjust(x, w, fill):
+            if fill == ' ':
+                return x.rjust(w)
+            else:
+                return x.rjust(w, fill)
+
+        for f in [f_center, f_ljust, f_rjust]:
+            for v in [b'short', b'long'*100, b'']:
+                for w in [0, 8, 16, 100]:
+                    for fill in [b' ', b'X']:
+                        r1 = f(v, w, fill)
+                        r2 = Entrypoint(f)(v, w, fill)
+                        self.assertEqual(r1, r2, (f, v, w, fill))
+
+                    with self.assertRaises(TypeError):
+                        Entrypoint(f)(v, w, b'22')
+                    with self.assertRaises(TypeError):
+                        Entrypoint(f)(v, w, b'')
+                    with self.assertRaises(TypeError):
+                        Entrypoint(f)(v, w, 'X')
+
+    def test_bytes_tabs(self):
+        def f_expandtabs(x, t):
+            return x.expandtabs(t)
+
+        def f_splitlines(x, *a):
+            return x.splitlines(*a)
+
+        words = {b'one\ttwo\tthree', b'eleven\ttwelve\t', b'\tseveral words in a row\t', b'', b'\t', b'\n', b'\x00'}
+        words = words.union({x + y + z for x in words for y in words for z in words})
+        for v in words:
+            for t in [8, 3, 1, 0, -1]:
+                r1 = f_expandtabs(v, t)
+                r2 = Entrypoint(f_expandtabs)(v, t)
+                self.assertEqual(r1, r2, (v, t))
+
+        segments = {b'one\ntwo\rthree', b'\nseveral words on a line\r\n', b'', b'\t', b'\n', b'\r', b'\r\n', b'\n\r', b'\x00'}
+        segments = segments.union({x + y + z for x in segments for y in segments for z in segments})
+        for v in segments:
+            r1 = f_splitlines(v)
+            r2 = Entrypoint(f_splitlines)(v)
+            self.assertEqual(r1, r2, (v,))
+            for k in [True, False]:
+                r1 = f_splitlines(v, k)
+                r2 = Entrypoint(f_splitlines)(v, k)
+                self.assertEqual(r1, r2, (v, k))
+
+    def test_bytes_zfill(self):
+        def f_zfill(x, w):
+            return x.zfill(w)
+
+        for v in [b'123', b'-9876', b'+1', b'testing', b'+', b'-', b'']:
+            for w in [0, 1, 5, 10, 100, -1]:
+                r1 = f_zfill(v, w)
+                r2 = Entrypoint(f_zfill)(v, w)
+                self.assertEqual(r1, r2, (v, w))
+
+    def test_bytes_internal_fns(self):
+        """
+        These are functions that are normally not called directly.
+        They are called here in order to improve codecov coverage.
+        """
+        lst = [b'a', b'b', b'c']
+        sep = b','
+        self.assertEqual(bytesJoinIterable(sep, lst), sep.join(lst))
+        with self.assertRaises(TypeError):
+            bytesJoinIterable(sep, [b'a', 'b', b'c'])
+
+        for v in [b'', b'abc', b'ABC', b'123', b'a1A', b' \t\n', b'Abc', b'Abc Def']:
+            self.assertEqual(bytes_isalnum(v), v.isalnum())
+            self.assertEqual(bytes_isalpha(v), v.isalpha())
+            self.assertEqual(bytes_isdigit(v), v.isdigit())
+            self.assertEqual(bytes_islower(v), v.islower())
+            self.assertEqual(bytes_isspace(v), v.isspace())
+            self.assertEqual(bytes_istitle(v), v.istitle())
+            self.assertEqual(bytes_isupper(v), v.isupper())
+
+        v = b'a1A\ta1A\n1A'
+        self.assertEqual(bytes_replace(v, b'a', b'xyz', 1), v.replace(b'a', b'xyz', 1))
+        self.assertEqual(bytes_replace(v, b'a', b'xyz', 0), v.replace(b'a', b'xyz', 0))
+        self.assertEqual(bytes_replace(v, b'', b'xyz', 2), v.replace(b'', b'xyz', 2))
+        self.assertEqual(bytes_startswith(v, b'a'), v.startswith(b'a'))
+        self.assertEqual(bytes_startswith(v, b'A'), v.startswith(b'A'))
+        self.assertEqual(bytes_endswith(v, b'a'), v.endswith(b'a'))
+        self.assertEqual(bytes_endswith(v, b'A'), v.endswith(b'A'))
+        for start, end in [(0, 10), (-2, -1), (-20, 10), (0, -20)]:
+            self.assertEqual(bytes_count(v, b'a1', start, end), v.count(b'a1', start, end))
+            self.assertEqual(bytes_count(v, b'A1', start, end), v.count(b'A1', start, end))
+            self.assertEqual(bytes_count(v, b'', start, end), v.count(b'', start, end))
+            self.assertEqual(bytes_count_single(v, 97, start, end), v.count(97, start, end))
+            self.assertEqual(bytes_find(v, b'a1', start, end), v.find(b'a1', start, end))
+            self.assertEqual(bytes_find(v, b'A1', start, end), v.find(b'A1', start, end))
+            self.assertEqual(bytes_find(v, b'', start, end), v.find(b'', start, end))
+            self.assertEqual(bytes_find_single(v, 97, start, end), v.find(97, start, end))
+            self.assertEqual(bytes_rfind(v, b'a1', start, end), v.rfind(b'a1', start, end))
+            self.assertEqual(bytes_rfind(v, b'A1', start, end), v.rfind(b'A1', start, end))
+            self.assertEqual(bytes_rfind(v, b'', start, end), v.rfind(b'', start, end))
+            self.assertEqual(bytes_rfind_single(v, 97, start, end), v.rfind(97, start, end))
+            self.assertEqual(result_or_exception(bytes_index, v, b'a1', start, end), result_or_exception(v.index, b'a1', start, end))
+            self.assertEqual(result_or_exception(bytes_index, v, b'A1', start, end), result_or_exception(v.index, b'A1', start, end))
+            self.assertEqual(result_or_exception(bytes_index, v, b'', start, end), result_or_exception(v.index, b'', start, end))
+            self.assertEqual(result_or_exception(bytes_index_single, v, 97, start, end), result_or_exception(v.index, 97, start, end))
+            self.assertEqual(result_or_exception(bytes_rindex, v, b'a1', start, end), result_or_exception(v.rindex, b'a1', start, end))
+            self.assertEqual(result_or_exception(bytes_rindex, v, b'A1', start, end), result_or_exception(v.rindex, b'A1', start, end))
+            self.assertEqual(result_or_exception(bytes_rindex, v, b'', start, end), result_or_exception(v.rindex, b'', start, end))
+            self.assertEqual(result_or_exception(bytes_rindex_single, v, 97, start, end), result_or_exception(v.rindex, 97, start, end))
+        self.assertEqual(bytes_partition(v, b'1'), v.partition(b'1'))
+        self.assertEqual(bytes_rpartition(v, b'1'), v.rpartition(b'1'))
+        self.assertEqual(bytes_center(v, 20, b'X'), v.center(20, b'X'))
+        self.assertEqual(bytes_center(v, 2, b'X'), v.center(2, b'X'))
+        self.assertEqual(bytes_rjust(v, 20, b'X'), v.rjust(20, b'X'))
+        self.assertEqual(bytes_rjust(v, 2, b'X'), v.rjust(2, b'X'))
+        self.assertEqual(bytes_ljust(v, 20, b'X'), v.ljust(20, b'X'))
+        self.assertEqual(bytes_ljust(v, 2, b'X'), v.ljust(2, b'X'))
+        self.assertEqual(bytes_expandtabs(v, 8), v.expandtabs(8))
+        self.assertEqual(bytes_zfill(v, 20), v.zfill(20))
+        self.assertEqual(bytes_zfill(b'+123', 20), b'+123'.zfill(20))

--- a/typed_python/compiler/tests/conversion_test.py
+++ b/typed_python/compiler/tests/conversion_test.py
@@ -3113,3 +3113,53 @@ class TestCompilationStructures(unittest.TestCase):
         assert speedup > 5
 
         print("speedup is ", speedup)
+
+    def test_chained_comparisons(self):
+        def f1(x, y, z):
+            return x < y < z
+
+        def f2(x, y, z):
+            return x > y > z
+
+        def f3(x, y, z):
+            return x <= y < z
+
+        def f4(x, y, z):
+            return 1 <= x <= y <= 2 <= z
+
+        def f5(x, y, z):
+            return x < y > z
+
+        def f6(x, y, z):
+            return x > y < z
+
+        for f in [f1, f2, f3, f4, f5, f6]:
+            for x in range(3):
+                for y in range(3):
+                    for z in range(3):
+                        r1 = f(x, y, z)
+                        r2 = Entrypoint(f)(x, y, z)
+                        self.assertEqual(r1, r2)
+
+        # Now verify that each expression in the chained comparison is evaluated at most once
+        # and verify that normal short-circuit evaluation occurs.
+        def f7(w, x, y, z):
+            accumulator = []
+
+            def side_effect(x, accumulator):
+                accumulator.append(x)
+                return x
+
+            if side_effect(w, accumulator) < side_effect(x, accumulator) < side_effect(y, accumulator) < side_effect(z, accumulator):
+                return (True, accumulator)
+            else:
+                return (False, accumulator)
+
+        for w in range(4):
+            for x in range(4):
+                for y in range(4):
+                    for z in range(4):
+                        r1 = f7(w, x, y, z)
+                        r2 = Entrypoint(f7)(w, x, y, z)
+
+                        self.assertEqual(r1, r2)

--- a/typed_python/compiler/tests/one_of_compilation_test.py
+++ b/typed_python/compiler/tests/one_of_compilation_test.py
@@ -589,3 +589,22 @@ class TestOneOfCompilation(unittest.TestCase):
 
         with self.assertRaisesRegex(TypeError, "Can't take instance of type 'NoneType'"):
             assert index([1, 2, 3], None) == 3
+
+    def test_check_if_oneof_is_none(self):
+        @Entrypoint
+        def strTranslate(x: str, table):
+            accumulator = ListOf(str)()
+            for c in x:
+                t = c
+
+                try:
+                    t = table.__getitem__(ord(c))
+                except LookupError:
+                    pass
+
+                if t is not None:
+                    accumulator.append(t)
+
+            return ''.join(accumulator)
+
+        strTranslate("hi", {})

--- a/typed_python/compiler/tests/one_of_compilation_test.py
+++ b/typed_python/compiler/tests/one_of_compilation_test.py
@@ -579,3 +579,13 @@ class TestOneOfCompilation(unittest.TestCase):
             return str(x)
 
         assert callStr(ZeroDivisionError()) == str(ZeroDivisionError())
+
+    def test_convert_oneof_or_none_to_index(self):
+        @Entrypoint
+        def index(l: ListOf(int), y: OneOf(None, int)):
+            return l[y]
+
+        assert index([1, 2, 3], 2) == 3
+
+        with self.assertRaisesRegex(TypeError, "Can't take instance of type 'NoneType'"):
+            assert index([1, 2, 3], None) == 3

--- a/typed_python/compiler/tests/string_compilation_test.py
+++ b/typed_python/compiler/tests/string_compilation_test.py
@@ -1,4 +1,4 @@
-#   Copyright 2017-2019 typed_python Authors
+#   Copyright 2017-2020 typed_python Authors
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
@@ -13,8 +13,12 @@
 #   limitations under the License.
 
 from typed_python import _types, ListOf, TupleOf, Dict, ConstDict, Compiled, Entrypoint, OneOf
+from typed_python.compiler.type_wrappers.string_wrapper import strJoinIterable, \
+    strStartswith, strEndswith, strReplace, \
+    strPartition, strRpartition, strCenter, strRjust, strLjust, strExpandtabs, strZfill
 from typed_python.test_util import currentMemUsageMb, compilerPerformanceComparison
 from typed_python.compiler.runtime import PrintNewFunctionVisitor
+import pytest
 import unittest
 import time
 import flaky
@@ -170,28 +174,91 @@ class TestStringCompilation(unittest.TestCase):
         for i in range(0, 0x10ffff + 1):
             self.assertEqual(ord(callChr(i)), i)
 
-    def test_string_start_and_endswith(self):
+    def test_string_startswith_endswith(self):
         def startswith(x: str, y: str):
             return x.startswith(y)
 
         def endswith(x: str, y: str):
             return x.endswith(y)
 
-        compiledSW = Compiled(startswith)
-        compiledEW = Compiled(endswith)
+        def startswith_range(x: str, y: str, start: int, end: int):
+            return x.startswith(y, start, end)
 
-        strings = ["", "a", "ab", "b", "abc", "bc", "ac", "ab", "bc", "bca"]
+        def endswith_range(x: str, y: str, start: int, end: int):
+            return x.endswith(y, start, end)
+
+        c_startswith = Compiled(startswith)
+        c_endswith = Compiled(endswith)
+        c_startswith_range = Compiled(startswith_range)
+        c_endswith_range = Compiled(endswith_range)
+
+        strings = ["", "a", "aβ", "β", "aβc", "βc", "ac", "aβ", "βc", "βca"]
 
         for s1 in strings:
             for s2 in strings:
-                self.assertEqual(startswith(s1, s2), compiledSW(s1, s2))
-                self.assertEqual(endswith(s1, s2), compiledEW(s1, s2))
+                self.assertEqual(startswith(s1, s2), c_startswith(s1, s2))
+                self.assertEqual(endswith(s1, s2), c_endswith(s1, s2))
+                for start in range(-5, 5):
+                    for end in range(-5, 5):
+                        self.assertEqual(
+                            startswith_range(s1, s2, start, end),
+                            c_startswith_range(s1, s2, start, end),
+                            (s1, s2, start, end)
+                        )
+                        self.assertEqual(
+                            endswith_range(s1, s2, start, end),
+                            c_endswith_range(s1, s2, start, end),
+                            (s1, s2, start, end)
+                        )
+
+    def test_string_tuple_startswith_endswith(self):
+        def startswith(x, y):
+            return x.startswith(y)
+
+        def endswith(x, y):
+            return x.endswith(y)
+
+        def startswith_range(x, y, start, end):
+            return x.startswith(y, start, end)
+
+        def endswith_range(x, y, start, end):
+            return x.endswith(y, start, end)
+
+        c_startswith = Entrypoint(startswith)
+        c_endswith = Entrypoint(endswith)
+        c_startswith_range = Entrypoint(startswith_range)
+        c_endswith_range = Entrypoint(endswith_range)
+
+        with self.assertRaises(TypeError):
+            c_startswith('abc', ['a', 'b'])
+
+        with self.assertRaises(TypeError):
+            c_startswith('abc', (1, 3))
+
+        strings = ["", "a", "ab", "b", "ab汉", "b汉", "a汉", "ab", "b汉", "b汉a"]
+        tuples = [(a, b) for a in strings for b in strings]
+        for s in strings:
+            for t in tuples:
+                self.assertEqual(startswith(s, t), c_startswith(s, t))
+                self.assertEqual(startswith(s, t), c_startswith(s, TupleOf(str)(t)))
+                self.assertEqual(endswith(s, t), c_endswith(s, t))
+                self.assertEqual(endswith(s, t), c_endswith(s, TupleOf(str)(t)))
+                for start in range(-5, 5):
+                    for end in range(-5, 5):
+                        self.assertEqual(
+                            startswith_range(s, t, start, end),
+                            c_startswith_range(s, t, start, end),
+                            (s, t, start, end)
+                        )
+                        self.assertEqual(
+                            endswith_range(s, t, start, end),
+                            c_endswith_range(s, t, start, end),
+                            (s, t, start, end)
+                        )
 
     def test_string_replace(self):
         def replace(x: str, y: str, z: str):
             return x.replace(y, z)
-
-        replaceCompiled = Compiled(replace)
 
         def replace2(x: str, y: str, z: str, i: int):
             return x.replace(y, z, i)
@@ -199,18 +266,18 @@ class TestStringCompilation(unittest.TestCase):
         replaceCompiled = Compiled(replace)
         replace2Compiled = Compiled(replace2)
 
-        strings = [""]
-        for _ in range(6):
-            for s in ["ab"]:
-                strings = [x + s for x in strings]
+        strings = {""}
+        for _ in range(2):
+            for s in ["ab", "汉", "ba"*100]:
+                strings |= {x + s for x in strings}
 
         for s1 in strings:
             for s2 in strings:
                 for s3 in strings:
-                    self.assertEqual(replace(s1, s2, s3), replaceCompiled(s1, s2, s3))
+                    self.assertEqual(replace(s1, s2, s3), replaceCompiled(s1, s2, s3), (s1, s2, s3))
 
                     for i in [-1, 0, 1, 2]:
-                        self.assertEqual(replace2(s1, s2, s3, i), replace2Compiled(s1, s2, s3, i))
+                        self.assertEqual(replace2(s1, s2, s3, i), replace2Compiled(s1, s2, s3, i), (s1, s2, s3, i))
 
     def test_string_getitem_slice(self):
         def getitem1(x: str, y: int):
@@ -263,15 +330,22 @@ class TestStringCompilation(unittest.TestCase):
             "\u00CA\u00F1\u011A\u1E66\u3444\u1E67\u1EEA\1F04" * 10000,
             "XyZ\U0001D471",
             "XyZ\U0001D471" * 10000,
-            "\u007F\u0080\u0081\u07FF\u0800\u0801\uFFFF\U00010000\U00010001\U0010FFFF"
+            "\u007F\u0080\u0081\u07FF\u0800\u0801\uFFFF\U00010000\U00010001\U0010FFFF",
+            "ß",
+            "ﬁß",
+            "ß\u1EEa",
+            "ﬁß\u1EEa",
+            "ß\U0001D471",
+            "ﬁß\U0001D471",
+            "ßİŉǰΐΰևẖẗẘẙẚẞὐὒὔὖᾀᾁᾂᾃᾄᾅᾆᾇᾈᾉᾊᾋᾌᾍᾎᾏᾐᾑᾒᾓᾔᾕᾖᾗᾘᾙᾚᾛᾜᾝᾞᾟᾠᾡᾢᾣᾤᾥᾦᾧᾨᾩᾪᾫᾬᾭᾮᾯᾲᾳᾴᾶᾷᾼῂῃῄῆῇῌῒΐῖῗῢΰῤῦῧῲῳῴῶῷῼﬀﬁﬂﬃﬄﬅﬆﬓﬔﬕﬖﬗ"
         ]
         for s in some_lu_strings:
-            self.assertEqual(c_lower(s), s.lower())
-            self.assertEqual(c_upper(s), s.upper())
+            self.assertEqual(c_lower(s), s.lower(), s)
+            self.assertEqual(c_upper(s), s.upper(), s)
 
         for s in some_lu_strings:
-            self.assertEqual(callOrExceptType(c_lower2, s, s), callOrExceptType(s.lower, s))
-            self.assertEqual(callOrExceptType(c_upper2, s, s), callOrExceptType(s.upper, s))
+            self.assertEqual(callOrExceptType(c_lower2, s, s), callOrExceptType(s.lower, s), s)
+            self.assertEqual(callOrExceptType(c_upper2, s, s), callOrExceptType(s.upper, s), s)
 
     def test_string_find(self):
 
@@ -341,6 +415,114 @@ class TestStringCompilation(unittest.TestCase):
             self.assertEqual(callOrExceptType(c_find_5, s, s, 0, 1, 2), callOrExceptType(s.find, s, 0, 1, 2))
             self.assertEqual(callOrExceptType(c_find_1, s), callOrExceptType(s.find))
 
+    def test_string_find2(self):
+        def f_find(x, sub):
+            return x.find(sub)
+
+        def f_find2(x, sub, start):
+            return x.find(sub, start)
+
+        def f_find3(x, sub, start, end):
+            return x.find(sub, start, end)
+
+        def f_rfind(x, sub):
+            return x.rfind(sub)
+
+        def f_rfind2(x, sub, start):
+            return x.rfind(sub, start)
+
+        def f_rfind3(x, sub, start, end):
+            return x.rfind(sub, start, end)
+
+        def f_index(x, sub):
+            return x.index(sub)
+
+        def f_index2(x, sub, start):
+            return x.index(sub, start)
+
+        def f_index3(x, sub, start, end):
+            return x.index(sub, start, end)
+
+        def f_rindex(x, sub):
+            return x.rindex(sub)
+
+        def f_rindex2(x, sub, start):
+            return x.rindex(sub, start)
+
+        def f_rindex3(x, sub, start, end):
+            return x.rindex(sub, start, end)
+
+        cases = ['ababcab', 'ababcabcab', 'aabbabbbaaabbaaba', '\u00CA\u00CB', '\u1EEa\u1EEb', '\U0001D471\U0001D472']
+        subs = ['a', 'c', 'X', 'ab', 'ba', 'abc', '', '\u00C9', '\u00CA', '\u1EE9', '\u1EEb', '\U0001D470', 'ab\U0001D471']
+        # for a larger test:
+        # subs += [x + y for x in subs for y in subs] + cases + [c[1:] for c in cases] + [c[:-1] for c in cases]
+        # cases += [x + y for x in cases for y in cases]
+        for v in cases:
+            for sub in subs:
+                for (f, g) in [(f_find, f_index), (f_rfind, f_rindex)]:
+                    r1 = f(v, sub)
+                    r2 = Entrypoint(f)(v, sub)
+                    self.assertEqual(r1, r2, (f, v, sub))
+                    if r1 != -1:
+                        r3 = Entrypoint(g)(v, sub)
+                        self.assertEqual(r1, r3, (g, v, sub))
+                    else:
+                        with self.assertRaises(ValueError):
+                            Entrypoint(g)(v, sub)
+                for start in range(-10, 11, 2):
+                    for (f, g) in [(f_find2, f_index2), (f_rfind2, f_rindex2)]:
+                        r1 = f(v, sub, start)
+                        r2 = Entrypoint(f)(v, sub, start)
+                        self.assertEqual(r1, r2, (f, v, sub, start))
+                        if r1 != -1:
+                            r3 = Entrypoint(g)(v, sub, start)
+                            self.assertEqual(r1, r3, (g, v, sub, start))
+                        else:
+                            with self.assertRaises(ValueError):
+                                Entrypoint(g)(v, sub, start)
+                    for end in range(-10, 11, 2):
+                        for (f, g) in [(f_find3, f_index3), (f_rfind3, f_rindex3)]:
+                            r1 = f(v, sub, start, end)
+                            r2 = Entrypoint(f)(v, sub, start, end)
+                            self.assertEqual(r1, r2, (f, v, sub, start, end))
+                            if r1 != -1:
+                                r3 = Entrypoint(g)(v, sub, start, end)
+                                self.assertEqual(r1, r3, (g, v, sub, start, end))
+                            else:
+                                with self.assertRaises(ValueError):
+                                    Entrypoint(g)(v, sub, start, end)
+
+    def test_string_count(self):
+        def f_count(x, sub):
+            return x.count(sub)
+
+        def f_count2(x, sub, start):
+            return x.count(sub, start)
+
+        def f_count3(x, sub, start, end):
+            return x.count(sub, start, end)
+
+        cases = ['ababcab', 'ababcabcab', 'aabbabbbaaabbaaba', '\u00CA\u00CB', '\u1EEa\u1EEb', '\U0001D471\U0001D472']
+        subs = ['a', 'c', 'X', 'ab', 'ba', 'abc', '', '\u00C9', '\u00CA', '\u1EE9', '\u1EEb', '\U0001D470', 'ab\U0001D471']
+        for v in cases:
+            for sub in subs:
+                f = f_count
+                r1 = f(v, sub)
+                r2 = Entrypoint(f)(v, sub)
+                self.assertEqual(r1, r2, (v, sub))
+
+                for start in range(-10, 11, 2):
+                    f = f_count2
+                    r1 = f(v, sub, start)
+                    subs = ['a', 'ab', 'ba', 'abc', '']
+                    r2 = Entrypoint(f)(v, sub, start)
+                    self.assertEqual(r1, r2, (v, sub, start))
+                    for end in range(-10, 11, 2):
+                        f = f_count3
+                        r1 = f(v, sub, start, end)
+                        r2 = Entrypoint(f)(v, sub, start, end)
+                        self.assertEqual(r1, r2, (v, sub, start, end))
+
     def test_string_from_float(self):
         @Compiled
         def toString(f: float):
@@ -391,6 +573,10 @@ class TestStringCompilation(unittest.TestCase):
         def c_isupper(s: str):
             return s.isupper()
 
+        @Compiled
+        def c_isidentifier(s: str):
+            return s.isidentifier()
+
         def perform_comparison(s: str):
             self.assertEqual(c_isalpha(s), s.isalpha(), [hex(ord(c)) for c in s])
             self.assertEqual(c_isalnum(s), s.isalnum(), [hex(ord(c)) for c in s])
@@ -402,6 +588,7 @@ class TestStringCompilation(unittest.TestCase):
             self.assertEqual(c_isspace(s), s.isspace(), [hex(ord(c)) for c in s])
             self.assertEqual(c_istitle(s), s.istitle(), [hex(ord(c)) for c in s])
             self.assertEqual(c_isupper(s), s.isupper(), [hex(ord(c)) for c in s])
+            self.assertEqual(c_isidentifier(s), s.isidentifier(), [hex(ord(c)) for c in s])
 
         perform_comparison("")
         for i in range(0, 0x1000):
@@ -415,6 +602,7 @@ class TestStringCompilation(unittest.TestCase):
             perform_comparison(chr(i) + "/")
             perform_comparison(chr(i) + " ")
             perform_comparison(chr(i) + "\u01C5")
+            perform_comparison(chr(i) + "\u0FFF")
             perform_comparison(chr(i) + "\x00")
             perform_comparison(chr(i) + "\U00010401")
             perform_comparison(chr(i) + "\U00010428")
@@ -428,6 +616,45 @@ class TestStringCompilation(unittest.TestCase):
         ]
         for s in titlestrings:
             self.assertEqual(c_istitle(s), s.istitle(), s)
+
+    def test_string_case(self):
+        def f_lower(x):
+            return x.lower()
+
+        def f_upper(x):
+            return x.upper()
+
+        def f_capitalize(x):
+            return x.capitalize()
+
+        def f_swapcase(x):
+            return x.swapcase()
+
+        def f_title(x):
+            return x.title()
+
+        def f_casefold(x):
+            return x.casefold()
+
+        cases = [
+            'ﬁ',
+            'abc'*10,
+            '\xE1\u1F11c'*10,
+            'ABC'*10,
+            '\xC1\u1F19c'*10,
+            'aBc\u2D1E\U0001D73D\U0001D792'*10,
+            '1@=.,z中',
+            'straße',
+            'ﬁ',
+            '',
+            "ßİŉǰΐΰևẖẗẘẙẚẞὐὒὔὖᾀᾁᾂᾃᾄᾅᾆᾇᾈᾉᾊᾋᾌᾍᾎᾏᾐᾑᾒᾓᾔᾕᾖᾗᾘᾙᾚᾛᾜᾝᾞᾟᾠᾡᾢᾣᾤᾥᾦᾧᾨᾩᾪᾫᾬᾭᾮᾯᾲᾳᾴᾶᾷᾼῂῃῄῆῇῌῒΐῖῗῢΰῤῦῧῲῳῴῶῷῼﬀﬁﬂﬃﬄﬅﬆﬓﬔﬕﬖﬗ",
+        ]
+        cases += [x + ' ' + y for x in cases for y in cases]
+        for f in [f_capitalize, f_lower, f_upper, f_capitalize, f_swapcase, f_title, f_casefold]:
+            for v in cases:
+                r1 = f(v)
+                r2 = Entrypoint(f)(v)
+                self.assertEqual(r1, r2, (f, v))
 
     def test_string_strip(self):
         @Compiled
@@ -446,6 +673,26 @@ class TestStringCompilation(unittest.TestCase):
             self.assertEqual(s.strip(), strip(s), s)
             self.assertEqual(s.rstrip(), rstrip(s), s)
             self.assertEqual(s.lstrip(), lstrip(s), s)
+
+    @pytest.mark.skip(reason='just for comparing performance when changing implementation')
+    def test_string_find_perf(self):
+        @Compiled
+        def c_find(c: str, s: str) -> int:
+            return c.find(s)
+
+        cases = ["ab" * 1000 + "c", 'x' * 2000 + 'yxx', "abc"*1000]
+        subs = ["ab", "abc", "xy", "ca"]
+        total = 0
+        t0 = time.time()
+        for _ in range(10000):
+            for c in cases:
+                for s in subs:
+                    total += c_find(c, s)
+        t1 = time.time()
+
+        print(total)
+        print(f"total time {t1-t0}")
+        self.assertTrue(False)
 
     @flaky.flaky(max_runs=3, min_passes=1)
     def test_string_strip_perf(self):
@@ -476,65 +723,63 @@ class TestStringCompilation(unittest.TestCase):
             self.assertLess(ratio, expectedRatio)
 
     def test_string_split(self):
-        @Compiled
-        def c_split(s: str, sep: str, max: int) -> ListOf(str):
-            return s.split(sep, max)
+        def f_split(s: str, *args) -> ListOf(str):
+            return s.split(*args)
 
-        @Compiled
-        def c_split_2(s: str) -> ListOf(str):
-            return s.split()
-
-        @Compiled
-        def c_split_3(s: str, sep: str) -> ListOf(str):
-            return s.split(sep)
-
-        @Compiled
-        def c_split_3max(s: str, max: int) -> ListOf(str):
-            return s.split(max)
+        def f_rsplit(s: str, *args) -> ListOf(str):
+            return s.rsplit(*args)
 
         # unexpected standard behavior:
-        #   "   abc   ".split(maxsplit=0) = "abc   "  *** not "abc" nor "   abc   " ***
+        #   "   abc   ".split(maxsplit=0) = "abc   " not "abc" nor "   abc   "
         split_strings = [
             "  abc  ",
-            "ahjdfashjkdfsj ksdjkhsfhjdkf",
+            "  abc",
+            "abc  ",
+            "ßahjdfßashjkdfsj ksdjkhsfhjdßa",
             "ahjdfashjkdfsj ksdjkhsfhjdkf" * 100,
             "",
-            "a",
+            "ß",
             " one two  three   \tfour    \n\nfive\r\rsix\n",
-            " one two  three   \tfour    \n\nfive\r\rsix\n" * 100
+            "\u2029one\u2003two  three   \tfour汉   \n\nfive\r\rsix\xA0" * 100
         ]
-        for s in split_strings:
-            result = callOrExceptNoType(c_split_2, s)
-            if result[0] == "Normal":
-                self.assertEqual(_types.refcount(result[1]), 1)
-            baseline = callOrExceptNoType(lambda: s.split())
-            self.assertEqual(result, baseline, f"{s} -> {result}")
-            self.assertEqual(result, baseline, "{} -> {}".format(s, result))
-            for m in range(-2, 10):
-                result = callOrExceptNoType(c_split_3max, s, m)
-                if result[0] == "Normal":
-                    self.assertEqual(_types.refcount(result[1]), 1)
-                baseline = callOrExceptNoType(lambda: s.split(maxsplit=m))
-                self.assertEqual(result, baseline, f"{s},{m}-> {result}")
 
-            for sep in ["", "j", "s", "d", "t", " ", "as", "jks"]:
-                result = callOrExceptNoType(c_split_3, s, sep)
-                if result[0] == "Normal":
-                    self.assertEqual(_types.refcount(result[1]), 1)
-                baseline = callOrExceptNoType(lambda: s.split(sep))
-                self.assertEqual(result, baseline, f"{s},{sep}-> {result}")
-                for m in range(-2, 10):
-                    result = callOrExceptNoType(c_split, s, sep, m)
-                    if result[0] == "Normal":
-                        self.assertEqual(_types.refcount(result[1]), 1)
-                    baseline = callOrExceptNoType(lambda: s.split(sep, m))
-                    self.assertEqual(result, baseline, f"{s},{sep},{m}-> {result}")
-
-        startusage = currentMemUsageMb()
-        for i in range(100000):
+        for f in [f_split, f_rsplit]:
+            c_f = Entrypoint(f)
             for s in split_strings:
-                result = c_split_2(s)
-                result = c_split(s, " ", 9)
+                result = callOrExceptNoType(c_f, s)
+                if result[0] == 'Normal':
+                    self.assertEqual(_types.refcount(result[1]), 1)
+                baseline = callOrExceptNoType(f, s)
+                self.assertEqual(result, baseline, f"{s} -> {result}")
+                for m in range(-2, 10):
+                    result = callOrExceptNoType(c_f, s, None, m)
+                    if result[0] == 'Normal':
+                        self.assertEqual(_types.refcount(result[1]), 1)
+                    baseline = callOrExceptNoType(f, s, None, m)
+                    self.assertEqual(result, baseline, f"{s},{m}-> {result}")
+
+                for sep in ['', 'j', 's', 'd', 'ßa', ' ', 'as', 'jks', '汉']:
+                    result = callOrExceptNoType(c_f, s, sep)
+                    if result[0] == 'Normal':
+                        self.assertEqual(_types.refcount(result[1]), 1)
+                    baseline = callOrExceptNoType(f, s, sep)
+                    self.assertEqual(result, baseline, f"{s},'{sep}'-> {result}")
+                    for m in range(-2, 10):
+                        result = callOrExceptNoType(c_f, s, sep, m)
+                        if result[0] == 'Normal':
+                            self.assertEqual(_types.refcount(result[1]), 1)
+                        baseline = callOrExceptNoType(f, s, sep, m)
+                        self.assertEqual(result, baseline, f"{s},'{sep}',{m}-> {result}")
+
+        total = 0
+        c_split = Entrypoint(f_split)
+        startusage = currentMemUsageMb()
+        for i in range(1000):
+            for s in split_strings:
+                result = c_split(s)
+                total += len(result)
+                result = c_split(s, ' ', 9)
+                total += len(result)
         endusage = currentMemUsageMb()
         self.assertLess(endusage, startusage + 1)
 
@@ -806,3 +1051,352 @@ class TestStringCompilation(unittest.TestCase):
             return int(x)
 
         assert f("1") == 1
+
+    def test_string_iteration(self):
+        def iter(x: str):
+            r = ListOf(str)()
+            for a in x:
+                r.append(a)
+            return r
+
+        def iter_constant():
+            r = ListOf(str)()
+            for a in "constant":
+                r.append(a)
+            return r
+
+        def contains_space(x: str):
+            for c in x:
+                if c == ' ':
+                    return True
+            return False
+
+        r1 = iter_constant()
+        r2 = Compiled(iter_constant)()
+        self.assertEqual(type(r1), type(r2))
+        self.assertEqual(r1, r2)
+
+        for v in ['whatever', 'o', '']:
+            r1 = iter(v)
+            r2 = Compiled(iter)(v)
+            self.assertEqual(type(r1), type(r2))
+            self.assertEqual(r1, r2)
+
+        for v in ['', 'a', ' ', 'abc ', 'x'*1000+' '+'x'*1000, 'y'*1000]:
+            r1 = contains_space(v)
+            r2 = Compiled(contains_space)(v)
+            self.assertEqual(r1, r2)
+
+    def test_string_mult(self):
+        def f_mult(x, n):
+            return x * n
+
+        v = "XyZ"
+        for n in [1, 5, 100, 0, -1]:
+            r1 = f_mult(v, n)
+            r2 = Entrypoint(f_mult)(v, n)
+            self.assertEqual(r1, r2)
+
+    def test_string_decode(self):
+        # various permutation of parameters (positional, keyword, missing)
+        def f_1(x, enc, err):
+            return str(x, enc, err)
+
+        def f_2(x, enc, err):
+            return str(x, encoding=enc, errors=err)
+
+        def f_3(x, enc, _err):
+            return (str(x, enc), str(x))
+
+        def f_4(x, enc, err):
+            return (str(x, encoding=enc), str(x, errors=err))
+
+        for v in [b'quarter'*1000, b'25\xC2\xA2', b'\xE2\x82\xAC100', b'\xF0\x9F\x98\x80', b'']:
+            for f in [f_1, f_2, f_3, f_4]:
+                for enc in ["utf-8", "utf-16", "ascii", "cp863", "hz"]:
+                    for err in ["strict", "ignore", "replace"]:
+                        r1 = callOrExceptType(f, v, enc, err)
+                        r2 = callOrExceptType(Entrypoint(f), v, enc, err)
+                        self.assertEqual(r1, r2)
+
+    def test_string_encode(self):
+        # various permutation of parameters (positional, keyword, missing)
+        def f_1(x, enc, err):
+            return x.encode(enc, err)
+
+        def f_2(x, enc, err):
+            return x.encode(encoding=enc, errors=err)
+
+        def f_3(x, enc, _err):
+            return (x.encode(enc), x.encode())
+
+        def f_4(x, enc, err):
+            return (x.encode(encoding=enc), (x.encode(errors=err)))
+
+        for v in ['quarter'*1000, '25¢', '€100', '汉字', '']:
+            for f in [f_1, f_2, f_3, f_4]:
+                for enc in ["utf-8", "utf-16", "ascii", "cp863", "hz"]:
+                    for err in ["strict", "ignore", "replace"]:
+                        r1 = callOrExceptType(f, v, enc, err)
+                        r2 = callOrExceptType(Entrypoint(f), v, enc, err)
+                        self.assertEqual(r1, r2, (f, v, enc, err))
+
+    @pytest.mark.skip(reason='not performant')
+    def test_string_codec(self):
+        s1 = ''.join([chr(i) for i in range(0, 0x10ffff, 13) if i < 0xD800 or i > 0xDFFF])
+        s2 = ''.join([chr(i) for i in range(1, 0x10ffff, 17) if i < 0xD800 or i > 0xDFFF])
+        s3 = ''.join([chr(i) for i in range(2, 0x10ffff, 11) if i < 0xD800 or i > 0xDFFF])
+        cases = [s1, s2, s3]
+        for i in [2 ** n for n in range(16)]:
+            cases += [s1[1:i], s2[1:i], s3[1:i]]
+
+        def f_encode(s: str) -> bytes:
+            return s.encode('utf-8', 'strict')
+
+        def f_decode(s: bytes) -> str:
+            return s.decode('utf-8', 'strict')
+
+        def f_endecode(s: str) -> bool:
+            s2 = s.encode('utf-8', 'strict').decode('utf-8', 'strict')
+            return s == s2
+
+        # c_encode = Compiled(f_encode)
+        # c_decode = Compiled(f_decode)
+        c_endecode = Compiled(f_endecode)
+
+        for v in cases:
+            self.assertTrue(f_endecode(v))
+            self.assertTrue(c_endecode(v))
+
+    @pytest.mark.skip(reason='not performant')
+    def test_string_codec_perf(self):
+        repeat = 500
+        s1 = ''.join([chr(i) for i in range(0, 0x10ffff, 13) if i < 0xD800 or i > 0xDFFF])
+        s2 = ''.join([chr(i) for i in range(1, 0x10ffff, 17) if i < 0xD800 or i > 0xDFFF])
+        s3 = ''.join([chr(i) for i in range(2, 0x10ffff, 11) if i < 0xD800 or i > 0xDFFF])
+        cases = [s1, s2, s3]
+        for i in [2**n for n in range(16)]:
+            cases += [s1[1:i], s2[1:i], s3[1:i]]
+        Cases = ListOf(str)(cases)
+
+        def f_endecode(s: str) -> bool:
+            # s2 = s.encode('utf-8', 'strict').decode('utf-8', 'strict')
+            s2 = s.encode('utf-8', 'strict')
+            return s == s2
+
+        def f_endecode2(cases: ListOf(str)) -> bool:
+            # s2 = s.encode('utf-8', 'strict').decode('utf-8', 'strict')
+            ret = True
+            for _ in range(1000):
+                for s in cases:
+                    s2 = s.encode('utf-8', 'strict')
+                    ret &= (s == s2)
+            return ret
+
+        verify = True
+        t0 = time.time()
+        for _ in range(repeat):
+            for v in cases:
+                verify &= f_endecode(v)
+        t1 = time.time()
+        print("baseline ", t1 - t0)
+        # self.assertTrue(verify)
+
+        c_endecode = Compiled(f_endecode)
+        verify = True
+        t2 = time.time()
+        for _ in range(repeat):
+            for v in Cases:
+                verify &= c_endecode(v)
+        t3 = time.time()
+        print("compiled ", t3 - t2)
+        # self.assertTrue(verify)
+
+        t0 = time.time()
+        f_endecode2(Cases)
+        t1 = time.time()
+        print("baseline2 ", t1 - t0)
+
+        c_endecode2 = Compiled(f_endecode2)
+        t2 = time.time()
+        c_endecode2(Cases)
+        t3 = time.time()
+        print("compiled2 ", t3 - t2)
+
+    def test_string_partition(self):
+        def f_partition(x, sep):
+            return x.partition(sep)
+
+        def f_rpartition(x, sep):
+            return x.rpartition(sep)
+
+        for f in [f_partition, f_rpartition]:
+            for v in [' beginning', 'end ', 'mid dle', 'wind', 'spin', '', 'ab¢de', '汉字', 'gamma𝛤epsilon']:
+                for sep in [' ', 'in', '¢', '¢d', '字', '𝛤', 'a𝛤']:
+                    r1 = f(v, sep)
+                    r2 = Entrypoint(f)(v, sep)
+                    self.assertEqual(r1, r2, (f, v, sep))
+
+                with self.assertRaises(ValueError):
+                    Entrypoint(f)(v, '')
+
+                with self.assertRaises(TypeError):
+                    Entrypoint(f)(v, b'abc')
+
+    def test_string_just(self):
+        def f_center(x, w, fill):
+            if fill == ' ':
+                return x.center(w)
+            else:
+                return x.center(w, fill)
+
+        def f_ljust(x, w, fill):
+            if fill == ' ':
+                return x.ljust(w)
+            else:
+                return x.ljust(w, fill)
+
+        def f_rjust(x, w, fill):
+            if fill == ' ':
+                return x.rjust(w)
+            else:
+                return x.rjust(w, fill)
+
+        for f in [f_center, f_ljust, f_rjust]:
+            for v in ['short', 'long'*100, '𝛤'*10, '']:
+                for w in [0, 8, 16, 100]:
+                    for fill in [' ', 'X', '¢', '字', '𝛤']:
+                        r1 = f(v, w, fill)
+                        r2 = Entrypoint(f)(v, w, fill)
+                        self.assertEqual(r1, r2, (f, v, w, fill))
+
+                    with self.assertRaises(TypeError):
+                        Entrypoint(f)(v, w, '22')
+                    with self.assertRaises(TypeError):
+                        Entrypoint(f)(v, w, '')
+                    with self.assertRaises(TypeError):
+                        Entrypoint(f)(v, w, b'X')
+
+    def test_string_tabs(self):
+        def f_expandtabs(x, t):
+            return x.expandtabs(t)
+
+        def f_splitlines(x, *a):
+            return x.splitlines(*a)
+
+        words = {'one\ttwo\tthree', 'eleven\ttwelve\t字字字字', '\tseveral words in a row¢¢¢\t', '', '\t', '\n', '\x00'}
+        words = words.union({x + y + z for x in words for y in words for z in words})
+        for v in words:
+            for t in [8, 3, 1, 0, -1]:
+                r1 = f_expandtabs(v, t)
+                r2 = Entrypoint(f_expandtabs)(v, t)
+                self.assertEqual(r1, r2, (v, t))
+
+        segments = {'one\ntwo\rthree', '\nseveral words on a line(𝛤)\r\n', '', '\t', '\n', '\r', '\r\n', '\n\r', '\x00'}
+        segments = segments.union({x + y + z for x in segments for y in segments for z in segments})
+        for v in segments:
+            r1 = f_splitlines(v)
+            r2 = Entrypoint(f_splitlines)(v)
+            self.assertEqual(r1, r2, (v,))
+            for k in [True, False]:
+                r1 = f_splitlines(v, k)
+                r2 = Entrypoint(f_splitlines)(v, k)
+                self.assertEqual(r1, r2, (v, k))
+
+    def test_string_zfill(self):
+        def f_zfill(x, w):
+            return x.zfill(w)
+
+        for v in ['123', '-9876', '+1', 'testing', '+', '-', 'ß', '']:
+            for w in [0, 1, 5, 10, 100, -1]:
+                r1 = f_zfill(v, w)
+                r2 = Entrypoint(f_zfill)(v, w)
+                self.assertEqual(r1, r2, (v, w))
+
+    def test_string_translate(self):
+        def f_translate(s, t):
+            return s.translate(t)
+
+        c_translate = Entrypoint(f_translate)
+
+        cases = ['', 'abc', 'c', 'aad'*100, 'baβca'*100]
+        dicts = [
+            dict(),
+            dict(a='A', b='B'),
+            dict(a='b', b='β', β='B', c=None),
+        ]
+        tables = [str.maketrans(d) for d in dicts]
+        for s in cases:
+            for t in tables:
+                r1 = f_translate(s, t)
+                r2 = c_translate(s, t)
+                self.assertEqual(r1, r2, s)
+
+    def test_string_maketrans(self):
+        def f_maketrans(*args):
+            return str.maketrans(*args)
+
+        c_maketrans = Entrypoint(f_maketrans)
+
+        cases = [
+            ({'a': 'A', 'b': 'B'},),
+            ({'a': 'A', 'b': '', 'c': 'CC', 'd': None},),
+            ({'a': 1234, 'b': 'β', 'β': 'B', 'd': None},),
+            (dict(),),
+            ({'a': 1234, 'bb': 'β', 'β': 'B', 'd': None},),  # Error
+            ({'a': 1234, None: 'β', 'β': 'B', 'd': None},),  # Error
+            ([1, 2, 3, 4],),  # Error
+            (set(),),  # Error
+            ('ab', 'AB'),
+            ('', ''),
+            ('ab', 'Aβ'),
+            ('aβ', 'Ab'),
+            ('ab', 'ABC'),  # Error
+            ('ab', 'AB', 'c'),
+            ('ab', 'AB', 'cβ'),
+            ('', '', ''),
+            ('', '', 'a'),
+            ('', '', 'abcdβ'),
+            ('', '', 123),  # Error
+        ]
+
+        s = 'abacadβ'
+        for args in cases:
+            r1 = callOrExceptType(f_maketrans, *args)
+            r2 = callOrExceptType(c_maketrans, *args)
+            self.assertEqual(r1, r2, args)
+            if r1[0] == 'Normal':
+                r3 = s.translate(r1[1])
+                r4 = s.translate(r2[1])
+                self.assertEqual(r3, r4, args)
+
+    def test_string_internal_fns(self):
+        """
+        These are functions that are normally not called directly.
+        They are called here in order to improve codecov coverage.
+        """
+        lst = ['a', 'b', 'c']
+        sep = ','
+        self.assertEqual(strJoinIterable(sep, lst), sep.join(lst))
+        with self.assertRaises(TypeError):
+            strJoinIterable(sep, ['a', b'b', 'c'])
+
+        v = 'a1A\ta1A\n1A'
+        self.assertEqual(strReplace(v, 'a', 'xyz', 1), v.replace('a', 'xyz', 1))
+        self.assertEqual(strReplace(v, 'a', 'xyz', 0), v.replace('a', 'xyz', 0))
+        self.assertEqual(strReplace(v, '', 'xyz', 2), v.replace('', 'xyz', 2))
+        self.assertEqual(strStartswith(v, 'a'), v.startswith('a'))
+        self.assertEqual(strStartswith(v, 'A'), v.startswith('A'))
+        self.assertEqual(strEndswith(v, 'a'), v.endswith('a'))
+        self.assertEqual(strEndswith(v, 'A'), v.endswith('A'))
+        self.assertEqual(strPartition(v, '1'), v.partition('1'))
+        self.assertEqual(strRpartition(v, '1'), v.rpartition('1'))
+        self.assertEqual(strCenter(v, 20, 'X'), v.center(20, 'X'))
+        self.assertEqual(strCenter(v, 2, 'X'), v.center(2, 'X'))
+        self.assertEqual(strRjust(v, 20, 'X'), v.rjust(20, 'X'))
+        self.assertEqual(strRjust(v, 2, 'X'), v.rjust(2, 'X'))
+        self.assertEqual(strLjust(v, 20, 'X'), v.ljust(20, 'X'))
+        self.assertEqual(strLjust(v, 2, 'X'), v.ljust(2, 'X'))
+        self.assertEqual(strExpandtabs(v, 8), v.expandtabs(8))
+        self.assertEqual(strZfill(v, 20), v.zfill(20))
+        self.assertEqual(strZfill('+123', 20), '+123'.zfill(20))

--- a/typed_python/compiler/tests/string_compilation_test.py
+++ b/typed_python/compiler/tests/string_compilation_test.py
@@ -14,8 +14,9 @@
 
 from typed_python import _types, ListOf, TupleOf, Dict, ConstDict, Compiled, Entrypoint, OneOf
 from typed_python.compiler.type_wrappers.string_wrapper import strJoinIterable, \
-    strStartswith, strEndswith, strReplace, \
-    strPartition, strRpartition, strCenter, strRjust, strLjust, strExpandtabs, strZfill
+    strStartswith, strRangeStartswith, strStartswithTuple, strRangeStartswithTuple, \
+    strEndswith, strRangeEndswith, strEndswithTuple, strRangeEndswithTuple, \
+    strReplace, strPartition, strRpartition, strCenter, strRjust, strLjust, strExpandtabs, strZfill
 from typed_python.test_util import currentMemUsageMb, compilerPerformanceComparison
 from typed_python.compiler.runtime import PrintNewFunctionVisitor
 import pytest
@@ -1387,8 +1388,20 @@ class TestStringCompilation(unittest.TestCase):
         self.assertEqual(strReplace(v, '', 'xyz', 2), v.replace('', 'xyz', 2))
         self.assertEqual(strStartswith(v, 'a'), v.startswith('a'))
         self.assertEqual(strStartswith(v, 'A'), v.startswith('A'))
+        self.assertEqual(strRangeStartswith(v, 'a', 0, 10), v.startswith('a', 0, 10))
+        self.assertEqual(strRangeStartswith(v, '', 0, 10), v.startswith('', 0, 10))
+        self.assertEqual(strRangeStartswith(v, '', -5, -3), v.startswith('', -5, -3))
+        self.assertEqual(strStartswithTuple(v, ('A', 'a')), v.startswith(('A', 'a')))
+        self.assertEqual(strRangeStartswithTuple(v, ('A', 'a'), 0, 10), v.startswith(('A', 'a'), 0, 10))
+        self.assertEqual(strRangeStartswithTuple(v, ('A', 'a'), -5, -3), v.startswith(('A', 'a'), -5, -3))
         self.assertEqual(strEndswith(v, 'a'), v.endswith('a'))
         self.assertEqual(strEndswith(v, 'A'), v.endswith('A'))
+        self.assertEqual(strRangeEndswith(v, 'a', 0, 10), v.endswith('a', 0, 10))
+        self.assertEqual(strRangeEndswith(v, '', 0, 10), v.endswith('', 0, 10))
+        self.assertEqual(strRangeEndswith(v, '', -5, -3), v.endswith('', -5, -3))
+        self.assertEqual(strEndswithTuple(v, ('A', 'a')), v.endswith(('A', 'a')))
+        self.assertEqual(strRangeEndswithTuple(v, ('A', 'a'), 0, 10), v.endswith(('A', 'a'), 0, 10))
+        self.assertEqual(strRangeEndswithTuple(v, ('A', 'a'), -5, -3), v.endswith(('A', 'a'), -5, -3))
         self.assertEqual(strPartition(v, '1'), v.partition('1'))
         self.assertEqual(strRpartition(v, '1'), v.rpartition('1'))
         self.assertEqual(strCenter(v, 20, 'X'), v.center(20, 'X'))

--- a/typed_python/compiler/type_wrappers/arithmetic_wrapper.py
+++ b/typed_python/compiler/type_wrappers/arithmetic_wrapper.py
@@ -306,6 +306,9 @@ class IntWrapper(ArithmeticTypeWrapper):
 
     def convert_builtin(self, f, context, expr, a1=None):
         if f is chr and a1 is None:
+            if expr.isConstant:
+                return context.constant(chr(expr.constantValue))
+
             return context.push(
                 str,
                 lambda strRef: strRef.expr.store(

--- a/typed_python/compiler/type_wrappers/bytes_wrapper.py
+++ b/typed_python/compiler/type_wrappers/bytes_wrapper.py
@@ -1,4 +1,4 @@
-#   Copyright 2017-2019 typed_python Authors
+#   Copyright 2017-2020 typed_python Authors
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
@@ -14,19 +14,459 @@
 
 from typed_python import sha_hash
 from typed_python.compiler.global_variable_definition import GlobalVariableMetadata
+from typed_python.compiler.type_wrappers.wrapper import Wrapper
 from typed_python.compiler.type_wrappers.refcounted_wrapper import RefcountedWrapper
 from typed_python.compiler.type_wrappers.bound_method_wrapper import BoundMethodWrapper
 import typed_python.compiler.type_wrappers.runtime_functions as runtime_functions
 from typed_python.compiler.type_wrappers.typed_list_masquerading_as_list_wrapper import TypedListMasqueradingAsList
 
-from typed_python import Int32, ListOf
+from typed_python import UInt8, Int32, ListOf, Tuple
+from typed_python.type_promotion import isInteger
 
 import typed_python.compiler.native_ast as native_ast
 import typed_python.compiler
 
 from typed_python.compiler.native_ast import VoidPtr
 
+
 typeWrapper = lambda t: typed_python.compiler.python_object_representation.typedPythonTypeToTypeWrapper(t)
+
+
+def bytesJoinIterable(sep, iterable):
+    """Converts the iterable container to list of bytes objects and call sep.join(iterable).
+
+    If any of the values in the container is not bytes type, an exception is thrown.
+
+    :param sep: string to separate the items
+    :param iterable: iterable container with strings only
+    :return: string with joined values
+    """
+    items = ListOf(bytes)()
+
+    for item in iterable:
+        if isinstance(item, bytes):
+            items.append(item)
+        else:
+            raise TypeError("expected str instance")
+    return sep.join(items)
+
+
+def bytes_replace(x, old, new, maxCount):
+    if maxCount == 0 or (maxCount >= 0 and len(x) == 0 and len(old) == 0):
+        return x
+
+    accumulator = ListOf(bytes)()
+
+    pos = 0
+    seen = 0
+    inc = 0 if len(old) else 1
+    if len(old) == 0:
+        accumulator.append(b'')
+        seen += 1
+
+    while True:
+        if maxCount >= 0 and seen >= maxCount:
+            nextLoc = -1
+        else:
+            nextLoc = x.find(old, pos)
+
+        if nextLoc >= 0 and nextLoc < len(x):
+            accumulator.append(x[pos:nextLoc + inc])
+
+            if len(old):
+                pos = nextLoc + len(old)
+            else:
+                pos += 1
+
+            seen += 1
+        else:
+            accumulator.append(x[pos:])
+            return new.join(accumulator)
+
+
+def bytes_isalnum(x):
+    if len(x) == 0:
+        return False
+    for i in x:
+        if not (ord('0') <= i <= ord('9') or ord('A') <= i <= ord('Z') or ord('a') <= i <= ord('z')):
+            return False
+    return True
+
+
+def bytes_isalpha(x):
+    if len(x) == 0:
+        return False
+    for i in x:
+        if not (ord('A') <= i <= ord('Z') or ord('a') <= i <= ord('z')):
+            return False
+    return True
+
+
+def bytes_isdigit(x):
+    if len(x) == 0:
+        return False
+    for i in x:
+        if not (ord('0') <= i <= ord('9')):
+            return False
+    return True
+
+
+def bytes_islower(x):
+    found_lower = False
+    for i in x:
+        if ord('a') <= i <= ord('z'):
+            found_lower = True
+        elif ord('A') <= i <= ord('Z'):
+            return False
+    return found_lower
+
+
+def bytes_isspace(x):
+    if len(x) == 0:
+        return False
+    for i in x:
+        if i != ord(' ') and i != ord('\t') and i != ord('\n') and i != ord('\r') and i != 0x0b and i != ord('\f'):
+            return False
+    return True
+
+
+def bytes_istitle(x):
+    if len(x) == 0:
+        return False
+    last_cased = False
+    found_one = False
+    for i in x:
+        upper = ord('A') <= i <= ord('Z')
+        lower = ord('a') <= i <= ord('z')
+        if upper and last_cased:
+            return False
+        if lower and not last_cased:
+            return False
+        last_cased = upper or lower
+        if last_cased:
+            found_one = True
+    return found_one
+
+
+def bytes_isupper(x):
+    found_upper = False
+    for i in x:
+        if ord('A') <= i <= ord('Z'):
+            found_upper = True
+        elif ord('a') <= i <= ord('z'):
+            return False
+    return found_upper
+
+
+def bytes_startswith(x, prefix):
+    if len(x) < len(prefix):
+        return False
+    index = 0
+    for i in prefix:
+        if x[index] != i:
+            return False
+        index += 1
+    return True
+
+
+def bytes_endswith(x, suffix):
+    index = len(x) - len(suffix)
+    if index < 0:
+        return False
+    for i in suffix:
+        if x[index] != i:
+            return False
+        index += 1
+    return True
+
+
+# sub is a bytes-like object
+def bytes_count(x, sub, start, end):
+    if start < 0:
+        start += len(x)
+    if start < 0:
+        start = 0
+    if end < 0:
+        end += len(x)
+    if end < 0:
+        end = 0
+    if end > len(x):
+        end = len(x)
+
+    len_sub = len(sub)
+    if len_sub == 0:
+        if start > len(x):
+            return 0
+        count = end - start + 1
+        if count < 0:
+            count = 0
+        return count
+
+    count = 0
+    index = start
+    while index < end - len_sub + 1:
+        subindex = 0
+        while subindex < len_sub:
+            if x[index+subindex] != sub[subindex]:
+                break
+            subindex += 1
+            if subindex == len_sub:
+                count += 1
+                index += len_sub - 1
+        index += 1
+    return count
+
+
+# sub is an integer
+def bytes_count_single(x, sub, start, end):
+    if sub < 0 or sub > 255:
+        raise ValueError("byte must be in range(0, 256)")
+    if start < 0:
+        start += len(x)
+    if start < 0:
+        start = 0
+    if end < 0:
+        end += len(x)
+    if end < 0:
+        end = 0
+    if end > len(x):
+        end = len(x)
+
+    count = 0
+    index = start
+    while index < end:
+        if x[index] == sub:
+            count += 1
+        index += 1
+    return count
+
+
+# sub is a bytes-like object
+def bytes_find(x, sub, start, end):
+    if start < 0:
+        start += len(x)
+    if start < 0:
+        start = 0
+    if end < 0:
+        end += len(x)
+    if end < 0:
+        end = 0
+    if end > len(x):
+        end = len(x)
+
+    len_sub = len(sub)
+    if len_sub == 0:
+        if start > len(x) or start > end:
+            return -1
+        return start
+
+    index = start
+    while index < end - len_sub + 1:
+        subindex = 0
+        while subindex < len_sub:
+            if x[index+subindex] != sub[subindex]:
+                break
+            subindex += 1
+            if subindex == len_sub:
+                return index
+        index += 1
+    return -1
+
+
+# sub is an integer
+def bytes_find_single(x, sub, start, end):
+    if sub < 0 or sub > 255:
+        raise ValueError("byte must be in range(0, 256)")
+    if start < 0:
+        start += len(x)
+    if start < 0:
+        start = 0
+    if end < 0:
+        end += len(x)
+    if end < 0:
+        end = 0
+    if end > len(x):
+        end = len(x)
+
+    index = start
+    while index < end:
+        if x[index] == sub:
+            return index
+        index += 1
+    return -1
+
+
+# sub is a bytes-like object
+def bytes_rfind(x, sub, start, end):
+    if start < 0:
+        start += len(x)
+    if start < 0:
+        start = 0
+    if end < 0:
+        end += len(x)
+    if end < 0:
+        end = 0
+    if end > len(x):
+        end = len(x)
+
+    len_sub = len(sub)
+    if len_sub == 0:
+        if start > len(x) or start > end:
+            return -1
+        return end
+
+    index = end - len_sub
+    while index >= start:
+        subindex = 0
+        while subindex < len_sub:
+            if x[index+subindex] != sub[subindex]:
+                break
+            subindex += 1
+            if subindex == len_sub:
+                return index
+        index -= 1
+    return -1
+
+
+# sub is an integer
+def bytes_rfind_single(x, sub, start, end):
+    if sub < 0 or sub > 255:
+        raise ValueError("byte must be in range(0, 256)")
+    if start < 0:
+        start += len(x)
+    if start < 0:
+        start = 0
+    if end < 0:
+        end += len(x)
+    if end < 0:
+        end = 0
+    if end > len(x):
+        end = len(x)
+
+    index = end - 1
+    while index >= start:
+        if x[index] == sub:
+            return index
+        index -= 1
+    return -1
+
+
+def bytes_index(x, sub, start, end):
+    ret = bytes_find(x, sub, start, end)
+    if ret == -1:
+        raise ValueError("subsection not found")
+    return ret
+
+
+def bytes_index_single(x, sub, start, end):
+    ret = bytes_find_single(x, sub, start, end)
+    if ret == -1:
+        raise ValueError("subsection not found")
+    return ret
+
+
+def bytes_rindex(x, sub, start, end):
+    ret = bytes_rfind(x, sub, start, end)
+    if ret == -1:
+        raise ValueError("subsection not found")
+    return ret
+
+
+def bytes_rindex_single(x, sub, start, end):
+    ret = bytes_rfind_single(x, sub, start, end)
+    if ret == -1:
+        raise ValueError("subsection not found")
+    return ret
+
+
+def bytes_partition(x, sep):
+    if len(sep) == 0:
+        raise ValueError("empty separator")
+
+    pos = x.find(sep)
+    if pos == -1:
+        return Tuple(bytes, bytes, bytes)((x, b'', b''))
+    return Tuple(bytes, bytes, bytes)((x[0:pos], sep, x[pos+len(sep):]))
+
+
+def bytes_rpartition(x, sep):
+    if len(sep) == 0:
+        raise ValueError("empty separator")
+
+    pos = x.rfind(sep)
+    if pos == -1:
+        return Tuple(bytes, bytes, bytes)((b'', b'', x))
+    return Tuple(bytes, bytes, bytes)((x[0:pos], sep, x[pos+len(sep):]))
+
+
+def bytes_center(x, width, fill):
+    if width <= len(x):
+        return x
+
+    left = (width - len(x)) // 2
+    right = (width - len(x)) - left
+    return fill * left + x + fill * right
+
+
+def bytes_ljust(x, width, fill):
+    if width <= len(x):
+        return x
+
+    return x + fill * (width - len(x))
+
+
+def bytes_rjust(x, width, fill):
+    if width <= len(x):
+        return x
+
+    return fill * (width - len(x)) + x
+
+
+def bytes_expandtabs(x, tabsize):
+    accumulator = ListOf(bytes)()
+
+    col = 0  # column mod tabsize, not necessarily actual column
+    last = 0
+    for i in range(len(x)):
+        c = x[i]
+        if c == ord('\t'):
+            accumulator.append(x[last:i])
+            spaces = tabsize - (col % tabsize) if tabsize > 0 else 0
+            accumulator.append(b' ' * spaces)
+            last = i + 1
+            col = 0
+        elif c == ord('\n') or c == ord('\r'):
+            col = 0
+        else:
+            col += 1
+    accumulator.append(x[last:])
+    return b''.join(accumulator)
+
+
+def bytes_zfill(x, width):
+    accumulator = ListOf(bytes)()
+
+    sign = False
+    if len(x):
+        c = x[0]
+        if c == ord('+') or c == ord('-'):
+            accumulator.append(x[0:1])
+            sign = True
+
+    fill = width - len(x)
+    if fill > 0:
+        accumulator.append(b'0' * fill)
+
+    accumulator.append(x[1:] if sign else x)
+
+    return b''.join(accumulator)
+
+
+def no_more_kwargs(context, **kwargs):
+    for e in kwargs:
+        context.pushException(TypeError, f"'{e}' is an invalid keyword argument for this function")
+        # just need to generate the first exception
+        break
 
 
 class BytesWrapper(RefcountedWrapper):
@@ -39,6 +479,8 @@ class BytesWrapper(RefcountedWrapper):
 
         self.layoutType = native_ast.Type.Struct(element_types=(
             ('refcount', native_ast.Int64),
+            ('hash_cache', native_ast.Int32),
+            ('bytecount', native_ast.Int32),
             ('data', native_ast.UInt8)
         ), name='BytesLayout').pointer()
 
@@ -58,6 +500,20 @@ class BytesWrapper(RefcountedWrapper):
         return super().convert_builtin(f, context, expr, a1)
 
     def convert_bin_op(self, context, left, op, right, inplace):
+        if op.matches.Mult and isInteger(right.expr_type.typeRepresentation):
+            if left.isConstant and right.isConstant:
+                return context.constant(left.constantValue * right.constantValue)
+
+            return context.push(
+                bytes,
+                lambda bytesRef: bytesRef.expr.store(
+                    runtime_functions.bytes_mult.call(
+                        left.nonref_expr.cast(VoidPtr),
+                        right.nonref_expr
+                    ).cast(self.layoutType)
+                )
+            )
+
         if right.expr_type == left.expr_type:
             if op.matches.Eq or op.matches.NotEq or op.matches.Lt or op.matches.LtE or op.matches.GtE or op.matches.Gt:
                 if left.isConstant and right.isConstant:
@@ -112,6 +568,15 @@ class BytesWrapper(RefcountedWrapper):
                         cmp_res.nonref_expr.gte(0)
                     )
 
+            if op.matches.In:
+                if left.isConstant and right.isConstant:
+                    return context.constant(left.constantValue in right.constantValue)
+
+                find_converted = right.convert_method_call("find", (left,), {})
+                if find_converted is None:
+                    return None
+                return find_converted >= 0
+
             if op.matches.Add:
                 if left.isConstant and right.isConstant:
                     return context.constant(left.constantValue + right.constantValue)
@@ -137,10 +602,14 @@ class BytesWrapper(RefcountedWrapper):
 
         if lower is None and upper is not None:
             lower = context.constant(0)
+        else:
+            lower = lower.toIndex()
 
-        lower = lower.toIndex()
-        if lower is None:
-            return
+            if lower is None:
+                return
+
+        if lower is not None and upper is None:
+            upper = expr.convert_len()
 
         upper = upper.toIndex()
         if upper is None:
@@ -178,46 +647,246 @@ class BytesWrapper(RefcountedWrapper):
 
         return context.pushPod(
             int,
-            expr.nonref_expr.ElementPtrIntegers(0, 1).elemPtr(
+            expr.nonref_expr.ElementPtrIntegers(0, 3).elemPtr(
                 native_ast.Expression.Branch(
                     cond=item.nonref_expr.lt(native_ast.const_int_expr(0)),
                     false=item.nonref_expr,
                     true=item.nonref_expr.add(len_expr.nonref_expr)
-                ).add(native_ast.const_int_expr(8))
+                )
             ).load().cast(native_ast.Int64)
         )
 
+    # these map to py functions
+    _bool_methods = dict(
+        isalnum=bytes_isalnum,
+        isalpha=bytes_isalpha,
+        isdigit=bytes_isdigit,
+        islower=bytes_islower,
+        isspace=bytes_isspace,
+        istitle=bytes_istitle,
+        isupper=bytes_isupper
+    )
+
+    # these map to py functions
+    _find_methods = dict(
+        count=(bytes_count, bytes_count_single),
+        find=(bytes_find, bytes_find_single),
+        rfind=(bytes_rfind, bytes_rfind_single),
+        index=(bytes_index, bytes_index_single),
+        rindex=(bytes_rindex, bytes_rindex_single),
+    )
+
+    # these map to c++ functions
+    _bytes_methods = dict(
+        lower=runtime_functions.bytes_lower,
+        upper=runtime_functions.bytes_upper,
+        capitalize=runtime_functions.bytes_capitalize,
+        swapcase=runtime_functions.bytes_swapcase,
+        title=runtime_functions.bytes_title,
+    )
+
+    _methods = ['decode', 'translate', 'maketrans', 'split', 'rsplit', 'join', 'partition', 'rpartition',
+                'strip', 'rstrip', 'lstrip', 'startswith', 'endswith', 'replace',
+                '__iter__', 'center', 'ljust', 'rjust', 'expandtabs', 'splitlines', 'zfill'] \
+        + list(_bool_methods) + list(_bytes_methods) + list(_find_methods)
+
     def convert_attribute(self, context, instance, attr):
-        if attr in ("split",):
+        if attr in self._methods:
             return instance.changeType(BoundMethodWrapper.Make(self, attr))
 
         return super().convert_attribute(context, instance, attr)
 
-    def convert_method_call(self, context, instance, methodname, args, kwargs):
-        if kwargs:
-            return super().convert_method_call(context, instance, methodname, args, kwargs)
+    def convert_method_call(self, context, instance, methodname, args, kwargs0):
+        if methodname not in self._methods:
+            return context.pushException(AttributeError, methodname)
 
-        if methodname == "split":
+        kwargs = kwargs0.copy()
+        if methodname == '__iter__' and not args and not kwargs:
+            res = context.push(
+                _BytesIteratorWrapper,
+                lambda instance:
+                instance.expr.ElementPtrIntegers(0, 0).store(-1)
+            )
+
+            context.pushReference(
+                self,
+                res.expr.ElementPtrIntegers(0, 1)
+            ).convert_copy_initialize(instance)
+
+            return res
+
+        if methodname in self._bool_methods and not args and not kwargs:
+            return context.call_py_function(self._bool_methods[methodname], (instance,), {})
+
+        if methodname in self._bytes_methods and not args and not kwargs:
+            return context.push(
+                bytes,
+                lambda ref: ref.expr.store(
+                    self._bytes_methods[methodname].call(
+                        instance.nonref_expr.cast(VoidPtr)
+                    ).cast(self.layoutType)
+                )
+            )
+
+        if methodname in ['strip', 'lstrip', 'rstrip']:
+            fromLeft = methodname in ['strip', 'lstrip']
+            fromRight = methodname in ['strip', 'rstrip']
+            if len(args) == 0 and not kwargs:
+                return context.push(
+                    bytes,
+                    lambda ref: ref.expr.store(
+                        runtime_functions.bytes_strip.call(
+                            instance.nonref_expr.cast(VoidPtr),
+                            native_ast.const_bool_expr(fromLeft),
+                            native_ast.const_bool_expr(fromRight)
+                        ).cast(self.layoutType)
+                    )
+                )
+            elif len(args) == 1 and not kwargs:
+                return context.push(
+                    bytes,
+                    lambda ref: ref.expr.store(
+                        runtime_functions.bytes_strip2.call(
+                            instance.nonref_expr.cast(VoidPtr),
+                            args[0].nonref_expr.cast(VoidPtr),
+                            native_ast.const_bool_expr(fromLeft),
+                            native_ast.const_bool_expr(fromRight)
+                        ).cast(self.layoutType)
+                    )
+                )
+
+        if methodname == 'startswith' and len(args) == 1 and not kwargs:
+            return context.call_py_function(bytes_startswith, (instance, args[0]), {})
+        if methodname == 'endswith' and len(args) == 1 and not kwargs:
+            return context.call_py_function(bytes_endswith, (instance, args[0]), {})
+        if methodname == 'expandtabs' and len(args) == 1 and not kwargs:
+            arg0type = args[0].expr_type.typeRepresentation
+            if arg0type != int:
+                return context.pushException(TypeError, f"an integer is required, not '{arg0type}'")
+            return context.call_py_function(bytes_expandtabs, (instance, args[0]), {})
+
+        if methodname in self._find_methods and 1 <= len(args) <= 3 and not kwargs:
+            if len(args) == 3:
+                start = args[1]
+                end = args[2]
+            elif len(args) == 2:
+                start = args[1]
+                end = self.convert_len(context, instance)
+            elif len(args) == 1:
+                start = context.constant(0)
+                end = self.convert_len(context, instance)
+
+            if isInteger(args[0].expr_type.typeRepresentation):
+                py_f = self._find_methods[methodname][1]
+            else:
+                py_f = self._find_methods[methodname][0]
+            return context.call_py_function(py_f, (instance, args[0], start, end), {})
+
+        if methodname == 'maketrans' and len(args) == 2 and not kwargs:
+            for i in [0, 1]:
+                if args[i].expr_type != self:
+                    context.pushException(
+                        TypeError,
+                        f"maketrans() argument {i + 1} must be bytes"
+                    )
+                    return
+            arg0len = args[0].convert_len()
+            arg1len = args[1].convert_len()
+            if arg0len is None or arg1len is None:
+                return None
+            with context.ifelse(arg0len.nonref_expr.eq(arg1len.nonref_expr)) as (ifTrue, ifFalse):
+                with ifFalse:
+                    context.pushException(ValueError, "maketrans arguments must have same length")
+            return context.push(
+                bytes,
+                lambda bytesRef: bytesRef.expr.store(
+                    runtime_functions.bytes_maketrans.call(
+                        args[0].nonref_expr.cast(VoidPtr),
+                        args[1].nonref_expr.cast(VoidPtr)
+                    ).cast(self.layoutType)
+                )
+            )
+
+        if methodname == 'replace':
+            if len(args) in [2, 3]:
+                for i in [0, 1]:
+                    if args[i].expr_type != self:
+                        context.pushException(
+                            TypeError,
+                            f"replace() argument {i + 1} must be bytes"
+                        )
+                        return
+
+                if len(args) == 3 and args[2].expr_type.typeRepresentation != int:
+                    context.pushException(
+                        TypeError,
+                        f"replace() argument 3 must be int, not {args[2].expr_type.typeRepresentation}"
+                    )
+                    return
+
+                arg2 = context.constant(-1) if len(args) == 2 else args[2]
+                return context.call_py_function(bytes_replace, (instance, args[0], args[1], arg2), {})
+                # return context.push(
+                #     bytes,
+                #     lambda bytesRef: bytesRef.expr.store(
+                #         runtime_functions.bytes_replace.call(
+                #             instance.nonref_expr.cast(VoidPtr),
+                #             args[0].nonref_expr.cast(VoidPtr),
+                #             args[1].nonref_expr.cast(VoidPtr),
+                #             args[2].nonref_expr if len(args) == 3 else native_ast.const_int_expr(-1)
+                #         ).cast(self.layoutType)
+                #     )
+                # )
+
+        if methodname == 'join' and not kwargs:
+            if len(args) == 1:
+                # we need to pass the list of bytes objects
+                separator = instance
+                itemsToJoin = args[0]
+
+                if itemsToJoin.expr_type.typeRepresentation is ListOf(bytes):
+                    return context.push(
+                        bytes,
+                        lambda out: runtime_functions.bytes_join.call(
+                            out.expr.cast(VoidPtr),
+                            separator.nonref_expr.cast(VoidPtr),
+                            itemsToJoin.nonref_expr.cast(VoidPtr)
+                        )
+                    )
+                else:
+                    return context.call_py_function(bytesJoinIterable, (separator, itemsToJoin), {})
+
+        if methodname in ['split', 'rsplit'] and not kwargs:
             if len(args) == 0:
                 sepPtr = VoidPtr.zero()
                 maxCount = native_ast.const_int_expr(-1)
-            elif len(args) == 1 and args[0].expr_type.typeRepresentation == bytes:
-                sepPtr = args[0].nonref_expr.cast(VoidPtr)
-                maxCount = native_ast.const_int_expr(-1)
-            elif len(args) == 2 and (
-                args[0].expr_type.typeRepresentation == bytes
-                and args[1].expr_type.typeRepresentation == int
-            ):
-                sepPtr = args[0].nonref_expr.cast(VoidPtr)
-                maxCount = args[1].nonref_expr
+            elif len(args) in [1, 2] and args[0].expr_type.typeRepresentation in [bytes, type(None)]:
+                if args[0].expr_type == typeWrapper(None):
+                    sepPtr = VoidPtr.zero()
+                else:
+                    sepPtr = args[0].nonref_expr.cast(VoidPtr)
+                    sepLen = args[0].convert_len()
+                    if sepLen is None:
+                        return None
+                    with context.ifelse(sepLen.nonref_expr.eq(0)) as (ifTrue, ifFalse):
+                        with ifTrue:
+                            context.pushException(ValueError, "empty separator")
+
+                if len(args) == 2:
+                    maxCount = args[1].toInt64()
+                    if maxCount is None:
+                        return None
+                else:
+                    maxCount = native_ast.const_int_expr(-1)
             else:
                 maxCount = None
 
             if maxCount is not None:
+                fn = runtime_functions.bytes_split if methodname == 'split' else runtime_functions.bytes_rsplit
                 return context.push(
                     TypedListMasqueradingAsList(ListOf(bytes)),
                     lambda outBytes: outBytes.expr.store(
-                        runtime_functions.bytes_split.call(
+                        fn.call(
                             instance.nonref_expr.cast(VoidPtr),
                             sepPtr,
                             maxCount
@@ -225,15 +894,128 @@ class BytesWrapper(RefcountedWrapper):
                     )
                 )
 
+        if methodname == 'splitlines' and not kwargs:
+            if len(args) == 0:
+                arg0 = context.constant(False)
+            elif len(args) == 1:
+                arg0 = args[0].toBool()
+                if arg0 is None:
+                    return None
+
+            return context.push(
+                TypedListMasqueradingAsList(ListOf(bytes)),
+                lambda out: out.expr.store(
+                    runtime_functions.bytes_splitlines.call(
+                        instance.nonref_expr.cast(VoidPtr),
+                        arg0
+                    ).cast(out.expr_type.getNativeLayoutType())
+                )
+            )
+
+        if methodname == 'decode' and not kwargs:
+            if len(args) in [0, 1, 2]:
+                return context.push(
+                    str,
+                    lambda ref: ref.expr.store(
+                        runtime_functions.bytes_decode.call(
+                            instance.nonref_expr.cast(VoidPtr),
+                            (args[0] if len(args) >= 1 else context.constant(0)).nonref_expr.cast(VoidPtr),
+                            (args[1] if len(args) >= 2 else context.constant(0)).nonref_expr.cast(VoidPtr),
+                        ).cast(typeWrapper(str).layoutType)
+                    )
+                )
+
+        if methodname == 'translate':
+            if len(args) in [1, 2]:
+                arg0isNone = args[0].expr_type == typeWrapper(None)
+                arg0 = args[0] if not arg0isNone else context.constant(0)
+                if 'delete' in kwargs and len(args) == 1:
+                    arg1 = kwargs['delete']
+                    del kwargs['delete']
+                    no_more_kwargs(context, **kwargs)
+                else:
+                    arg1 = args[1] if len(args) >= 2 else context.constant(0)
+
+                if not arg0isNone:
+                    arg0type = arg0.expr_type.typeRepresentation
+                    if arg0type != bytes:
+                        context.pushException(TypeError, f"a bytes-like object is required, not '{arg0type}'")
+                    arg0len = arg0.convert_len()
+                    if arg0len is None:
+                        return None
+                    with context.ifelse(arg0len.nonref_expr.eq(256)) as (ifTrue, ifFalse):
+                        with ifFalse:
+                            context.pushException(ValueError, "translation table must be 256 characters long")
+
+                return context.push(
+                    bytes,
+                    lambda ref: ref.expr.store(
+                        runtime_functions.bytes_translate.call(
+                            instance.nonref_expr.cast(VoidPtr),
+                            arg0.nonref_expr.cast(VoidPtr),
+                            arg1.nonref_expr.cast(VoidPtr),
+                        ).cast(self.layoutType)
+                    )
+                )
+
+        if methodname in ['partition', 'rpartition'] and len(args) == 1 and not kwargs:
+            arg0type = args[0].expr_type.typeRepresentation
+            if arg0type != bytes:
+                context.pushException(TypeError, f"a bytes-like object is required, not '{arg0type}'")
+            py_f = bytes_partition if methodname == 'partition' else bytes_rpartition
+            return context.call_py_function(py_f, (instance, args[0]), {})
+
+        if methodname in ['center', 'ljust', 'rjust']:
+            if len(args) in [1, 2]:
+                arg0 = args[0].toInt64()
+                if arg0 is None:
+                    return None
+
+                if len(args) == 2:
+                    arg1 = args[1]
+                    arg1type = arg1.expr_type.typeRepresentation
+                    if arg1type != bytes:
+                        context.pushException(TypeError, f"{methodname}() argument 2 must be a byte string of length 1, not '{arg1type}'")
+                    arg1len = arg1.convert_len()
+                    if arg1len is None:
+                        return None
+                    with context.ifelse(arg1len.nonref_expr.eq(1)) as (ifTrue, ifFalse):
+                        with ifFalse:
+                            context.pushException(
+                                TypeError,
+                                f"{methodname}() argument 2 must be a byte string of length 1, not '{arg1type}'"
+                            )
+                else:
+                    arg1 = context.constant(b' ')
+
+            py_f = bytes_center if methodname == 'center' else \
+                bytes_ljust if methodname == 'ljust' else \
+                bytes_rjust if methodname == 'rjust' else None
+            return context.call_py_function(py_f, (instance, arg0, arg1), {})
+
+        if methodname == 'zfill' and len(args) == 1 and not kwargs:
+            arg0 = args[0].toInt64()
+            if arg0 is None:
+                return None
+            return context.call_py_function(bytes_zfill, (instance, arg0), {})
+
         return context.pushException(AttributeError, methodname)
+
+    def convert_getitem_unsafe(self, context, expr, item):
+        return context.push(
+            UInt8,
+            lambda intRef: intRef.expr.store(
+                expr.nonref_expr.ElementPtrIntegers(0, 3)
+                    .elemPtr(item.toInt64().nonref_expr).load()
+            )
+        )
 
     def convert_len_native(self, expr):
         return native_ast.Expression.Branch(
             cond=expr,
             false=native_ast.const_int_expr(0),
             true=(
-                expr.ElementPtrIntegers(0, 1).ElementPtrIntegers(4)
-                .cast(native_ast.Int32.pointer()).load().cast(native_ast.Int64)
+                expr.ElementPtrIntegers(0, 2).load().cast(native_ast.Int64)
             )
         )
 
@@ -285,3 +1067,94 @@ class BytesWrapper(RefcountedWrapper):
 
     def convert_bytes_cast(self, context, expr):
         return expr
+
+    def get_iteration_expressions(self, context, expr):
+        if expr.isConstant:
+            return [context.constant(expr.constantValue[i]) for i in range(len(expr.constantValue))]
+        else:
+            return None
+
+
+class BytesIteratorWrapper(Wrapper):
+    is_pod = False
+    is_empty = False
+    is_pass_by_ref = True
+
+    def __init__(self):
+        super().__init__((bytes, "iterator"))
+
+    def getNativeLayoutType(self):
+        return native_ast.Type.Struct(
+            element_types=(("pos", native_ast.Int64), ("bytes", typeWrapper(bytes).getNativeLayoutType())),
+            name="bytes_iterator"
+        )
+
+    def convert_next(self, context, inst):
+        context.pushEffect(
+            inst.expr.ElementPtrIntegers(0, 0).store(
+                inst.expr.ElementPtrIntegers(0, 0).load().add(1)
+            )
+        )
+        self_len = self.refAs(context, inst, 1).convert_len()
+        canContinue = context.pushPod(
+            bool,
+            inst.expr.ElementPtrIntegers(0, 0).load().lt(self_len.nonref_expr)
+        )
+
+        nextIx = context.pushReference(int, inst.expr.ElementPtrIntegers(0, 0))
+        return self.iteratedItemForReference(context, inst, nextIx), canContinue
+
+    def refAs(self, context, expr, which):
+        assert expr.expr_type == self
+
+        if which == 0:
+            return context.pushReference(int, expr.expr.ElementPtrIntegers(0, 0))
+
+        if which == 1:
+            return context.pushReference(
+                bytes,
+                expr.expr
+                    .ElementPtrIntegers(0, 1)
+                    .cast(typeWrapper(bytes).getNativeLayoutType().pointer())
+            )
+
+    def iteratedItemForReference(self, context, expr, ixExpr):
+        return typeWrapper(bytes).convert_getitem_unsafe(
+            context,
+            self.refAs(context, expr, 1),
+            ixExpr
+        ).heldToRef()
+
+    def convert_assign(self, context, expr, other):
+        assert expr.isReference
+
+        for i in range(2):
+            self.refAs(context, expr, i).convert_assign(self.refAs(context, other, i))
+
+    def convert_copy_initialize(self, context, expr, other):
+        for i in range(2):
+            self.refAs(context, expr, i).convert_copy_initialize(self.refAs(context, other, i))
+
+    def convert_destroy(self, context, expr):
+        self.refAs(context, expr, 1).convert_destroy()
+
+
+_BytesIteratorWrapper = BytesIteratorWrapper()
+
+
+class BytesMaketransWrapper(Wrapper):
+    is_pod = True
+    is_empty = False
+    is_pass_by_ref = False
+
+    def __init__(self):
+        super().__init__(bytes.maketrans)
+
+    def getNativeLayoutType(self):
+        return native_ast.Type.Void()
+
+    def convert_call(self, context, expr, args, kwargs):
+        if len(args) == 2 and not kwargs:
+            return args[0].convert_method_call("maketrans", (args[0], args[1]), {})
+
+        return super().convert_call(context, expr, args, kwargs)

--- a/typed_python/compiler/type_wrappers/one_of_wrapper.py
+++ b/typed_python/compiler/type_wrappers/one_of_wrapper.py
@@ -499,6 +499,18 @@ class OneOfWrapper(Wrapper):
             ("oneof", self, "bytes_cast")
         )
 
+    def convert_index_cast(self, context, expr):
+        return context.expressionAsFunctionCall(
+            "oneof_convert_index",
+            (expr,),
+            lambda expr: self.unwrap(
+                expr.context,
+                expr,
+                lambda exprUnwrapped: exprUnwrapped.toIndex()
+            ),
+            ("oneof", self, "index_cast")
+        )
+
     def convert_str_cast(self, context, expr):
         return context.expressionAsFunctionCall(
             "oneof_convert_str",

--- a/typed_python/compiler/type_wrappers/python_object_of_type_wrapper.py
+++ b/typed_python/compiler/type_wrappers/python_object_of_type_wrapper.py
@@ -380,7 +380,7 @@ class PythonObjectOfTypeWrapper(RefcountedWrapper):
         return super().convert_to_type_with_target(context, e, targetVal, explicit)
 
     def convert_to_self_with_target(self, context, targetVal, sourceVal, explicit):
-        if not explicit:
+        if not explicit and self.typeRepresentation is not object:
             return super().convert_to_self_with_target(context, targetVal, sourceVal, explicit)
 
         t = sourceVal.expr_type.typeRepresentation

--- a/typed_python/compiler/type_wrappers/runtime_functions.py
+++ b/typed_python/compiler/type_wrappers/runtime_functions.py
@@ -550,6 +550,12 @@ string_getitem_int64 = externalCallTarget(
     Void.pointer(), Int64
 )
 
+string_mult = externalCallTarget(
+    "nativepython_runtime_string_mult",
+    Void.pointer(),
+    Void.pointer(), Int64
+)
+
 string_from_utf8_and_len = externalCallTarget(
     "nativepython_runtime_string_from_utf8_and_len",
     Void.pointer(),
@@ -576,22 +582,58 @@ string_upper = externalCallTarget(
     Void.pointer()
 )
 
+string_capitalize = externalCallTarget(
+    "nativepython_runtime_string_capitalize",
+    Void.pointer(),
+    Void.pointer()
+)
+
+string_casefold = externalCallTarget(
+    "nativepython_runtime_string_casefold",
+    Void.pointer(),
+    Void.pointer()
+)
+
+string_swapcase = externalCallTarget(
+    "nativepython_runtime_string_swapcase",
+    Void.pointer(),
+    Void.pointer()
+)
+
+string_title = externalCallTarget(
+    "nativepython_runtime_string_title",
+    Void.pointer(),
+    Void.pointer()
+)
+
 string_find = externalCallTarget(
     "nativepython_runtime_string_find",
     Int64,
     Void.pointer(), Void.pointer(), Int64, Int64
 )
 
-string_find_2 = externalCallTarget(
-    "nativepython_runtime_string_find_2",
+string_rfind = externalCallTarget(
+    "nativepython_runtime_string_rfind",
     Int64,
-    Void.pointer(), Void.pointer()
+    Void.pointer(), Void.pointer(), Int64, Int64
 )
 
-string_find_3 = externalCallTarget(
-    "nativepython_runtime_string_find_3",
+string_index = externalCallTarget(
+    "nativepython_runtime_string_index",
     Int64,
-    Void.pointer(), Void.pointer(), Int64
+    Void.pointer(), Void.pointer(), Int64, Int64
+)
+
+string_rindex = externalCallTarget(
+    "nativepython_runtime_string_rindex",
+    Int64,
+    Void.pointer(), Void.pointer(), Int64, Int64
+)
+
+string_count = externalCallTarget(
+    "nativepython_runtime_string_count",
+    Int64,
+    Void.pointer(), Void.pointer(), Int64, Int64
 )
 
 string_join = externalCallTarget(
@@ -606,28 +648,17 @@ string_split = externalCallTarget(
     Void.pointer(), Void.pointer(), Int64
 )
 
-bytes_split = externalCallTarget(
-    "nativepython_runtime_bytes_split",
+string_rsplit = externalCallTarget(
+    "nativepython_runtime_string_rsplit",
     Void.pointer(),
     Void.pointer(), Void.pointer(), Int64
 )
 
-string_split_2 = externalCallTarget(
-    "nativepython_runtime_string_split_2",
+string_splitlines = externalCallTarget(
+    "nativepython_runtime_string_splitlines",
     Void.pointer(),
-    Void.pointer()
-)
-
-string_split_3 = externalCallTarget(
-    "nativepython_runtime_string_split_3",
     Void.pointer(),
-    Void.pointer(), Void.pointer()
-)
-
-string_split_3max = externalCallTarget(
-    "nativepython_runtime_string_split_3max",
-    Void.pointer(),
-    Void.pointer(), Int64
+    Bool
 )
 
 string_isalpha = externalCallTarget(
@@ -650,6 +681,12 @@ string_isdecimal = externalCallTarget(
 
 string_isdigit = externalCallTarget(
     "nativepython_runtime_string_isdigit",
+    Bool,
+    Void.pointer()
+)
+
+string_isidentifier = externalCallTarget(
+    "nativepython_runtime_string_isidentifier",
     Bool,
     Void.pointer()
 )
@@ -713,6 +750,125 @@ bytes_from_ptr_and_len = externalCallTarget(
     "nativepython_runtime_bytes_from_ptr_and_len",
     Void.pointer(),
     UInt8Ptr, Int64
+)
+
+bytes_join = externalCallTarget(
+    "nativepython_runtime_bytes_join",
+    Void,
+    Void.pointer(), Void.pointer(), Void.pointer()
+)
+
+bytes_split = externalCallTarget(
+    "nativepython_runtime_bytes_split",
+    Void.pointer(),
+    Void.pointer(), Void.pointer(), Int64
+)
+
+bytes_rsplit = externalCallTarget(
+    "nativepython_runtime_bytes_rsplit",
+    Void.pointer(),
+    Void.pointer(), Void.pointer(), Int64
+)
+
+bytes_lower = externalCallTarget(
+    "nativepython_runtime_bytes_lower",
+    Void.pointer(),
+    Void.pointer()
+)
+
+bytes_upper = externalCallTarget(
+    "nativepython_runtime_bytes_upper",
+    Void.pointer(),
+    Void.pointer()
+)
+
+bytes_capitalize = externalCallTarget(
+    "nativepython_runtime_bytes_capitalize",
+    Void.pointer(),
+    Void.pointer()
+)
+
+bytes_swapcase = externalCallTarget(
+    "nativepython_runtime_bytes_swapcase",
+    Void.pointer(),
+    Void.pointer()
+)
+
+bytes_title = externalCallTarget(
+    "nativepython_runtime_bytes_title",
+    Void.pointer(),
+    Void.pointer()
+)
+
+bytes_splitlines = externalCallTarget(
+    "nativepython_runtime_bytes_splitlines",
+    Void.pointer(),
+    Void.pointer(),
+    Bool
+)
+
+bytes_strip = externalCallTarget(
+    "nativepython_runtime_bytes_strip",
+    Void.pointer(),
+    Void.pointer(),
+    Bool,
+    Bool
+)
+
+bytes_strip2 = externalCallTarget(
+    "nativepython_runtime_bytes_strip2",
+    Void.pointer(),
+    Void.pointer(),
+    Void.pointer(),
+    Bool,
+    Bool
+)
+
+bytes_mult = externalCallTarget(
+    "nativepython_runtime_bytes_mult",
+    Void.pointer(),
+    Void.pointer(),
+    Int64
+)
+
+bytes_replace = externalCallTarget(
+    "nativepython_runtime_bytes_replace",
+    Void.pointer(),
+    Void.pointer(),
+    Void.pointer(),
+    Void.pointer(),
+    Int64
+)
+
+bytes_decode = externalCallTarget(
+    "nativepython_runtime_bytes_decode",
+    Void.pointer(),
+    Void.pointer(),
+    Void.pointer(),
+    Void.pointer()
+)
+
+str_encode = externalCallTarget(
+    "nativepython_runtime_str_encode",
+    Void.pointer(),
+    Void.pointer(),
+    Void.pointer(),
+    Void.pointer()
+)
+
+bytes_translate = externalCallTarget(
+    "nativepython_runtime_bytes_translate",
+    Void.pointer(),
+    Void.pointer(),
+    Void.pointer(),
+    Void.pointer()
+)
+
+bytes_maketrans = externalCallTarget(
+    "nativepython_runtime_bytes_maketrans",
+    Void.pointer(),
+    Void.pointer(),
+    Void.pointer()
 )
 
 print_string = externalCallTarget(

--- a/typed_python/compiler/type_wrappers/string_wrapper.py
+++ b/typed_python/compiler/type_wrappers/string_wrapper.py
@@ -309,9 +309,10 @@ def strTranslate(x, table):
     return ''.join(accumulator)
 
 
-def strMaketransFromDict(x: Dict(OneOf(int, str), OneOf(int, str, None))) -> Dict(int, OneOf(int, str, None)):
+def strMaketransFromDict(xArg: Dict(OneOf(int, str), OneOf(int, str, None))) -> Dict(int, OneOf(int, str, None)):
     # The line below is somehow necessary.  Without it, 'isinstance' type inference fails for elements of the dict key.
-    x = Dict(OneOf(int, str), OneOf(int, str, None))(x)  # this shouldn't be necessary, but it is
+    x = Dict(OneOf(int, str), OneOf(int, str, None))(xArg)  # this shouldn't be necessary, but it is
+
     ret = Dict(int, OneOf(int, str, None))()
     for c in x:
         if isinstance(c, str):


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Motivation and Context
Most 'bytes' and 'str' methods were uncompiled.

## Approach
- Adjust BytesWrapper and StringWrapper layout to be complete.
- Create string iterator.
- Compile string * int operator.
- Comple bytes.isalnum, isalpha, isdigit, islower, isspace, istitle, isupper,
  startswith, endswith, strip, lstrip, rstrip, lower, upper,
  count, find, rfind, index, rindex,
  split, rsplit, join, replace, *, in, decode,
  partition, rpartition, translate, center, ljust, rjust,
  capitalize, expandtabs, splitlines, swapcase, title, zfill.
- Compile bytes.maketrans and str.maketrans as a instance method and as a static method.
- Fix bytes slice operation.
- Fix bytes.split edge cases.
- For chr, ord: propagate constants when compiled.
- Also, fix and test for compiling min/max with spurious keyword parameter.
- Incidentally, support compiling chained comparisons.
- NOTE: partition and rpartition return Tuples that are not masqueraded.
- NOTE: where parameters could be 'bytes' or 'bytes-like' objects, only 'bytes' is supported.
- Compile str encode from bytes, and decode to bytes.
    * This uses PyUnicodeFromEncodedObject and PyUnicode_AsEncodedString, so it covers all supported codecs and error handlers
    * If needed for performance, we could special-case some encodings/decodings.
    * Implemented utf8 encode in c++, but it is slower than PyUnicode_AsEncodedString(), despite the conversions.
- Compile 'str' functions: capitalize, casefold, center, count, expandtabs, ljust, maketrans, partition,
  rfind, rindex, rjust, rpartition, rsplit, splitlines, swapcase, title, translate, zfill.
- Add range parameters for str.startswith, str.endswith.
- Fix str compilation of upper, lower.
- Tested compiling str.find as a py function instead of a c++ function.  Performance was 4 times worse.
- Clean up and fix bugs in str.find, str.split, bytes.split, bytes.rsplit, bytes.splitlines compilation.
- Fix str.getsubstr corruption (not enough bytes copied).
- Adjust `str.__repr__`
- Allow compilation of bytes.startswith and bytes.endswith with 2 or 3 arguments.
- Only remaining str methods are str.format and str.format_map

## How Has This Been Tested?
- Added tests for each operation, including testing error cases that raise exceptions.
- Improved some existing tests that were missing edge cases (e.g. empty bytes)

## Screenshots or console output (if appropriate)
<!-- if not appropriate, remove this section -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.


