### PR TITLE
Compile math functions on object arguments.  Refs #364.

### DIFF
--- a/typed_python/_runtime.cpp
+++ b/typed_python/_runtime.cpp
@@ -226,11 +226,23 @@ extern "C" {
     }
 
     double np_cosh_float64(double d) {
-        return std::cosh(d);
+        double ret = std::cosh(d);
+        if (std::isinf(ret)) {
+            PyEnsureGilAcquired getTheGil;
+            PyErr_Format(PyExc_OverflowError, "math range error");
+            throw PythonExceptionSet();
+        }
+        return ret;
     }
 
     float np_cosh_float32(float f) {
-        return std::cosh(f);
+        float ret = std::cosh(f);
+        if (std::isinf(ret)) {
+            PyEnsureGilAcquired getTheGil;
+            PyErr_Format(PyExc_OverflowError, "math range error");
+            throw PythonExceptionSet();
+        }
+        return ret;
     }
 
     double np_erf_float64(double d) {
@@ -250,11 +262,23 @@ extern "C" {
     }
 
     double np_expm1_float64(double d) {
-        return std::expm1(d);
+        double ret = std::expm1(d);
+        if (std::isinf(ret)) {
+            PyEnsureGilAcquired getTheGil;
+            PyErr_Format(PyExc_OverflowError, "math range error");
+            throw PythonExceptionSet();
+        }
+        return ret;
     }
 
     float np_expm1_float32(float f) {
-        return std::expm1(f);
+        float ret = std::expm1(f);
+        if (std::isinf(ret)) {
+            PyEnsureGilAcquired getTheGil;
+            PyErr_Format(PyExc_OverflowError, "math range error");
+            throw PythonExceptionSet();
+        }
+        return ret;
     }
 
     // d = 171.0 will overflow 64-bit float, so could replace this calculation with a table lookup
@@ -334,11 +358,23 @@ extern "C" {
     }
 
     double np_gamma_float64(double d) {
-        return std::tgamma(d);
+        double ret = std::tgamma(d);
+        if (std::isinf(ret)) {
+            PyEnsureGilAcquired getTheGil;
+            PyErr_Format(PyExc_OverflowError, "math range error");
+            throw PythonExceptionSet();
+        }
+        return ret;
     }
 
     float np_gamma_float32(float f) {
-        return std::tgamma(f);
+        float ret = std::tgamma(f);
+        if (std::isinf(ret)) {
+            PyEnsureGilAcquired getTheGil;
+            PyErr_Format(PyExc_OverflowError, "math range error");
+            throw PythonExceptionSet();
+        }
+        return ret;
     }
 
     uint64_t np_gcd(uint64_t i1, uint64_t i2) {
@@ -1873,6 +1909,129 @@ extern "C" {
         return res;
     }
 
+    double np_pyobj_ceil(PythonObjectOfType::layout_type* obj) {
+        PyEnsureGilAcquired acquireTheGil;
+        if (PyFloat_Check(obj->pyObj)) {
+            double val = PyFloat_AsDouble(obj->pyObj);
+            if (val == -1.0 && PyErr_Occurred()) {
+                throw PythonExceptionSet();
+            }
+            return ceil(val);
+        }
+
+        if (!PyObject_HasAttrString(obj->pyObj, "__ceil__")) {
+            PyObjectHolder floatObj(PyObject_CallMethod(obj->pyObj, "__float__", NULL));
+            if ((PyObject*)floatObj) {
+                double val = PyFloat_AsDouble(floatObj);
+                if (val == -1.0 && PyErr_Occurred()) {
+                    throw PythonExceptionSet();
+                }
+                return ceil(val);
+             }
+             PyErr_Format(PyExc_TypeError, "'%s' object has no attribute __ceil__", Py_TYPE(obj->pyObj)->tp_name);
+             throw PythonExceptionSet();
+        }
+
+        PyObjectHolder retObj(PyObject_CallMethod(obj->pyObj, "__ceil__", NULL));
+        double ret;
+
+        // This is an additional condition.  Python does not have this condition (__ceil__ does not have to return a number).
+        if (PyFloat_Check(retObj)) {
+            ret = PyFloat_AsDouble(retObj);
+        }
+        else if (PyLong_Check(retObj)) {
+             ret = (double)PyLong_AsLong(retObj);
+        }
+        else {
+            PyErr_SetString(PyExc_TypeError, "__ceil__ returned non-number");
+            throw PythonExceptionSet();
+        }
+        if (ret == -1.0 && PyErr_Occurred()) {
+            throw PythonExceptionSet();
+        }
+        return ret;
+    }
+
+    double np_pyobj_floor(PythonObjectOfType::layout_type* obj) {
+        PyEnsureGilAcquired acquireTheGil;
+        if (PyFloat_Check(obj->pyObj)) {
+            double val = PyFloat_AsDouble(obj->pyObj);
+            if (val == -1.0 && PyErr_Occurred()) {
+                throw PythonExceptionSet();
+            }
+            return floor(val);
+        }
+
+        if (!PyObject_HasAttrString(obj->pyObj, "__floor__")) {
+            PyObjectHolder floatObj(PyObject_CallMethod(obj->pyObj, "__float__", NULL));
+            if ((PyObject*)floatObj) {
+                double val = PyFloat_AsDouble(floatObj);
+                if (val == -1.0 && PyErr_Occurred()) {
+                    throw PythonExceptionSet();
+                }
+                return floor(val);
+             }
+             PyErr_Format(PyExc_TypeError, "'%s' object has no attribute __floor__", Py_TYPE(obj->pyObj)->tp_name);
+             throw PythonExceptionSet();
+        }
+
+        PyObjectHolder retObj(PyObject_CallMethod(obj->pyObj, "__floor__", NULL));
+        double ret;
+
+        // This is an additional condition.  Python does not have this condition (__floor__ does not have to return a number).
+        if (PyFloat_Check(retObj)) {
+            ret = PyFloat_AsDouble(retObj);
+        }
+        else if (PyLong_Check(retObj)) {
+             ret = (double)PyLong_AsLong(retObj);
+        }
+        else {
+            PyErr_SetString(PyExc_TypeError, "__floor__ returned non-number");
+            throw PythonExceptionSet();
+        }
+        if (ret == -1.0 && PyErr_Occurred()) {
+            throw PythonExceptionSet();
+        }
+        return ret;
+    }
+
+    double np_pyobj_trunc(PythonObjectOfType::layout_type* obj) {
+        PyEnsureGilAcquired acquireTheGil;
+        if (PyFloat_Check(obj->pyObj)) {
+            double val = PyFloat_AsDouble(obj->pyObj);
+            if (val == -1.0 && PyErr_Occurred()) {
+                throw PythonExceptionSet();
+            }
+            return trunc(val);
+        }
+
+        if (!PyObject_HasAttrString(obj->pyObj, "__trunc__")) {
+            // unlike the others, __trunc__ doesn't devolve to __float__
+            PyErr_Format(PyExc_TypeError, "type %s doesn't define __trunc__ method", Py_TYPE(obj->pyObj)->tp_name);
+            throw PythonExceptionSet();
+        }
+
+        PyObjectHolder retObj(PyObject_CallMethod(obj->pyObj, "__trunc__", NULL));
+        double ret;
+
+        // This is an additional condition.  Python does not have this condition (__trunc__ does not have to return a number).
+        if (PyFloat_Check(retObj)) {
+            ret = PyFloat_AsDouble(retObj);
+        }
+        else if (PyLong_Check(retObj)) {
+             ret = (double)PyLong_AsLong(retObj);
+        }
+        else {
+            PyErr_Format(PyExc_TypeError, "__trunc__ returned non-number");
+            throw PythonExceptionSet();
+        }
+        if (ret == -1.0 && PyErr_Occurred()) {
+            throw PythonExceptionSet();
+        }
+        return ret;
+    }
+
+
     // this struct is defined in threadmodule.c - so it's internal to python itself,
     // but because we want to bypass the GIL, we'll just read from the corresponding
     // PyObject* knowing its structure.
@@ -2030,7 +2189,7 @@ extern "C" {
         PyEnsureGilAcquired getTheGil;
 
         double res = PyFloat_AsDouble(obj->pyObj);
-        if (PyErr_Occurred()) {
+        if (res == -1.0 && PyErr_Occurred()) {
             throw PythonExceptionSet();
         }
         return res;
@@ -2040,7 +2199,7 @@ extern "C" {
         PyEnsureGilAcquired getTheGil;
 
         int64_t res = PyLong_AsLong(obj->pyObj);
-        if (PyErr_Occurred()) {
+        if (res == -1 && PyErr_Occurred()) {
             throw PythonExceptionSet();
         }
         return res;

--- a/typed_python/compiler/tests/math_functions_compilation_test.py
+++ b/typed_python/compiler/tests/math_functions_compilation_test.py
@@ -33,6 +33,13 @@ def compiledHash(x):
     return hash(x)
 
 
+def callOrExceptType(f, *args):
+    try:
+        return ("Normal", f(*args))
+    except Exception as e:
+        return ("Exception", str(type(e)))
+
+
 class TestMathFunctionsCompilation(unittest.TestCase):
     def test_entrypoint_overrides(self):
         @Entrypoint
@@ -481,7 +488,7 @@ class TestMathFunctionsCompilation(unittest.TestCase):
                     self.assertEqual(r1, r2, (mathFun, v1, v2))
 
                     r3 = Float32(r1)
-                    r4 = compiled(Float32(v1), Float32(v2))
+                    r4 = compiled(Float32(v1), v2)
                     self.assertEqual(r3, r4, (mathFun, v1, v2))
 
     def test_math_fsum(self):
@@ -630,3 +637,188 @@ class TestMathFunctionsCompilation(unittest.TestCase):
 
                 del f
                 del g
+
+    def test_math_functions_on_object(self):
+        class ClassCeil:
+            def __ceil__(self):
+                return 123.45
+
+        class ClassFloor:
+            def __floor__(self):
+                return 123.45
+
+        class ClassTrunc:
+            def __trunc__(self):
+                return 123
+
+        class ClassFloat:
+            def __float__(self):
+                return 1.24
+
+        class ClassInt:
+            def __int__(self):
+                return 13
+
+        class ClassCeilFloat:
+            def __ceil__(self):
+                return 1.23
+
+            def __float__(self):
+                return 1.24
+
+        def f_ceil(t: object):
+            return math.ceil(t)
+
+        def f_floor(t: object):
+            return math.floor(t)
+
+        def f_trunc(t: object):
+            return math.trunc(t)
+
+        def f_acos(t: object):
+            return math.acos(t)
+
+        def f_acosh(t: object):
+            return math.acosh(t)
+
+        def f_asin(t: object):
+            return math.asin(t)
+
+        def f_asinh(t: object):
+            return math.asinh(t)
+
+        def f_atan(t: object):
+            return math.atan(t)
+
+        def f_atan2(t: object):
+            return math.atan2(t, t / 2 + 0.1)
+
+        def f_atanh(t: object):
+            return math.atanh(t)
+
+        def f_copysign(t: object):
+            return math.copysign(t, t + 1)
+
+        def f_cos(t: object):
+            return math.cos(t)
+
+        def f_cosh(t: object):
+            return math.cosh(t)
+
+        def f_degrees(t: object):
+            return math.degrees(t)
+
+        def f_erf(t: object):
+            return math.erf(t)
+
+        def f_erfc(t: object):
+            return math.erfc(t)
+
+        def f_exp(t: object):
+            return math.exp(t)
+
+        def f_expm1(t: object):
+            return math.expm1(t)
+
+        def f_fabs(t: object):
+            return math.fabs(t)
+
+        def f_fmod(t: object):
+            return math.fmod(t + 3, t + 1)
+
+        def f_frexp(t: object):
+            x = math.frexp(t)
+            return x[0] + x[1]
+
+        def f_fsum(t: object):
+            return math.fsum([t, t+1, t+2])
+
+        def f_gamma(t: object):
+            return math.gamma(t)
+
+        def f_gcd(t: object):
+            return math.gcd(t, t + 3)
+
+        def f_hypot(t: object):
+            return math.hypot(t, t + 3)
+
+        def f_isclose(t: object):
+            return math.isclose(t, t * 2 - 1)
+
+        def f_isfinite(t: object):
+            return math.isfinite(t)
+
+        def f_isinf(t: object):
+            return math.isinf(t)
+
+        def f_isnan(t: object):
+            return math.isnan(t)
+
+        def f_ldexp1(t: object):
+            return math.ldexp(t, 5)
+
+        def f_ldexp2(t: object):
+            return math.ldexp(2.0, t)
+
+        def f_lgamma(t: object):
+            return math.lgamma(t)
+
+        def f_log(t: object):
+            return math.log(t)
+
+        def f_log10(t: object):
+            return math.log10(t)
+
+        def f_log1p(t: object):
+            return math.log1p(t)
+
+        def f_log2(t: object):
+            return math.log2(t)
+
+        def f_modf(t: object):
+            return math.modf(t)
+
+        def f_pow(t: object):
+            return math.pow(t, t)
+
+        def f_radians(t: object):
+            return math.radians(t)
+
+        def f_sin(t: object):
+            return math.sin(t)
+
+        def f_sinh(t: object):
+            return math.sinh(t)
+
+        def f_sqrt(t: object):
+            return math.sqrt(t)
+
+        def f_tan(t: object):
+            return math.tan(t)
+
+        def f_tanh(t: object):
+            return math.tanh(t)
+
+        self.assertEqual(Entrypoint(f_ceil)(1.5), 2.0)
+        self.assertEqual(Entrypoint(f_sin)(0.0), 0.0)
+
+        fns = [f_pow, f_trunc, f_ceil, f_floor, f_acos, f_acosh, f_asin, f_asinh, f_atan, f_atan2, f_atanh, f_copysign,
+               f_cos, f_cosh, f_degrees, f_erf, f_erfc, f_exp, f_expm1, f_fabs, f_fmod, f_frexp, f_fsum, f_gamma, f_gcd,
+               f_hypot, f_isclose, f_isfinite, f_isinf, f_isnan, f_ldexp1, f_ldexp2, f_lgamma, f_log, f_log10, f_log1p,
+               f_log2, f_modf, f_pow, f_radians, f_sin, f_sinh, f_sqrt, f_tan, f_tanh]
+        values = [
+            0, 0.5, -0.5, 1.0, -1.0, 7, -7, 1e100, -1e100,
+            ClassCeil(), ClassFloor(), ClassTrunc(), ClassFloat(), ClassInt(), ClassCeilFloat()
+        ]
+        for f in fns:
+            c_f = Entrypoint(f)
+            for v in values:
+                r1 = callOrExceptType(f, v)
+                r2 = callOrExceptType(c_f, v)
+                if r1[0] == 'Normal' and r2[0] == 'Normal' and isinstance(r1[1], (float, int)):
+                    if r1[1] == 0.0:
+                        self.assertLess(abs(r2[1] - r1[1]), 1e-10, (f, v))
+                    else:
+                        self.assertLess(abs((r2[1] - r1[1]) / r1[1]), 1e-10, (f, v))
+                else:
+                    self.assertEqual(r1, r2, (f, v))

--- a/typed_python/compiler/type_wrappers/math_wrappers.py
+++ b/typed_python/compiler/type_wrappers/math_wrappers.py
@@ -137,38 +137,66 @@ class MathFunctionWrapper(Wrapper):
         return native_ast.Type.Void()
 
     def convert_call(self, context, expr, args, kwargs):
-        if len(args) == 2 and not kwargs and self.typeRepresentation is ldexp:
+        # Set check_inf to generate a check for an infinite result that generates an Overflow exception.
+        # This is only needed for the few operations that are compiled directly to llvm intrinsic functions.
+        check_inf = False
+
+        if self.typeRepresentation is ldexp and len(args) == 2 and not kwargs:
             arg1 = args[0]
-            if not arg1.expr_type.is_arithmetic:
-                return context.pushException(TypeError, f"must be a real number, not {arg1.expr_type}")
             arg2 = args[1]
-            if not arg2.expr_type.is_arithmetic:
-                return context.pushException(TypeError, f"Expected an int as second argument to ldexp.")
             argType1 = arg1.expr_type.typeRepresentation
             argType2 = arg2.expr_type.typeRepresentation
             if argType1 not in (Float32, float):
-                arg1 = arg1.convert_to_type(float)
+                arg1 = arg1.toFloat64()
                 if arg1 is None:
-                    return None
+                    return context.pushException(TypeError, f'must be a real number, not {argType1}')
                 argType1 = float
-            if argType2 not in (int,):
-                arg2 = arg2.convert_to_type(int)
+            if argType2 is object:
+                arg2 = arg2.convert_to_type(int, explicit=False)
                 if arg2 is None:
-                    return context.pushException(TypeError, f"Expected an int as second argument to ldexp.")
-            # argType2 == int
+                    return None
+            elif hasattr(argType2, 'IsInteger') and argType2.IsInteger:
+                arg2 = arg2.toInt64()
+                if arg2 is None:
+                    return None
+            argType2 = arg2.expr_type.typeRepresentation
+            if argType2 is not int:
+                return context.pushException(TypeError, f'Expected an int as second argument to ldexp, not {argType2}')
+            # now argType2 == int
             outT = argType1
             func = runtime_functions.ldexp32 if argType1 is Float32 else runtime_functions.ldexp64
             return context.pushPod(outT, func.call(arg1.nonref_expr, arg2.nonref_expr))
 
-        if len(args) == 2 and not kwargs and self.typeRepresentation is gcd:
+        if self.typeRepresentation is gcd and len(args) == 2 and not kwargs:
             arg1 = args[0]
             arg2 = args[1]
             argType1 = arg1.expr_type.typeRepresentation
             argType2 = arg2.expr_type.typeRepresentation
-            if argType1 in (Float32, float) or not arg1.expr_type.is_arithmetic:
+
+            if argType1 is object:
+                arg1 = arg1.convert_to_type(int, explicit=False)
+                if arg1 is None:
+                    return None
+            elif hasattr(argType1, 'IsInteger') and argType1.IsInteger:
+                arg1 = arg1.toInt64()
+                if arg1 is None:
+                    return None
+            argType1 = arg1.expr_type.typeRepresentation
+            if argType1 is not int:
                 return context.pushException(ValueError, f"'{argType1}' object cannot be interpreted as an integer")
-            if argType2 in (Float32, float) or not arg2.expr_type.is_arithmetic:
+
+            if argType2 is object:
+                arg2 = arg2.convert_to_type(int, explicit=False)
+                if arg2 is None:
+                    return None
+            elif hasattr(argType2, 'IsInteger') and argType2.IsInteger:
+                arg2 = arg2.toInt64()
+                if arg2 is None:
+                    return None
+            argType2 = arg2.expr_type.typeRepresentation
+            if argType2 is not int:
                 return context.pushException(ValueError, f"'{argType2}' object cannot be interpreted as an integer")
+
             arg1 = arg1.convert_abs()
             if arg1 is None:
                 return None
@@ -183,30 +211,35 @@ class MathFunctionWrapper(Wrapper):
                 return None
             return context.pushPod(UInt64, runtime_functions.gcd.call(arg1.nonref_expr, arg2.nonref_expr))
 
-        if len(args) == 2 and (not kwargs or self.typeRepresentation is isclose):
+        # this block is for methods with 2 parameters
+        if (not kwargs or self.typeRepresentation is isclose) and len(args) == 2:
             arg1 = args[0]
             if not arg1.expr_type.is_arithmetic:
-                return context.pushException(TypeError, f"must be a real number, not {arg1.expr_type}")
+                arg1 = arg1.toFloat64()
+                if arg1 is None:
+                    return context.pushException(TypeError, f'must be a real number, not {arg1.expr_type}')
             arg2 = args[1]
             if not arg2.expr_type.is_arithmetic:
-                return context.pushException(TypeError, f"must be a real number, not {arg2.expr_type}")
+                arg2 = arg2.toFloat64()
+                if arg2 is None:
+                    return context.pushException(TypeError, f'must be a real number, not {arg2.expr_type}')
             argType1 = arg1.expr_type.typeRepresentation
             argType2 = arg2.expr_type.typeRepresentation
             if argType1 not in (Float32, float):
-                arg1 = arg1.convert_to_type(float)
+                arg1 = arg1.toFloat64()
                 if arg1 is None:
                     return None
                 argType1 = float
             if argType2 not in (Float32, float):
-                arg2 = arg2.convert_to_type(float)
+                arg2 = arg2.toFloat64()
                 if arg2 is None:
                     return None
                 argType2 = float
             if argType1 == Float32 and argType2 == float:
-                arg1 = arg1.convert_to_type(float)
+                arg1 = arg1.toFloat64()
                 argType1 = float
             if argType1 == float and argType2 == Float32:
-                arg2 = arg2.convert_to_type(float)
+                arg2 = arg2.toFloat64()
                 argType2 = float
             assert argType1 == argType2
 
@@ -218,7 +251,7 @@ class MathFunctionWrapper(Wrapper):
             elif self.typeRepresentation is fmod:
                 with context.ifelse(arg2.nonref_expr.eq(0.0)) as (ifTrue, ifFalse):
                     with ifTrue:
-                        context.pushException(ValueError, "math domain error")
+                        context.pushException(ValueError, 'math domain error')
                 func = runtime_functions.fmod32 if argType1 is Float32 else runtime_functions.fmod64
             elif self.typeRepresentation is hypot:
                 # calculate this one directly
@@ -227,20 +260,28 @@ class MathFunctionWrapper(Wrapper):
             elif self.typeRepresentation is isclose:
                 func = runtime_functions.isclose32 if argType1 is Float32 else runtime_functions.isclose64
 
-                if "rel_tol" in kwargs:
-                    rel_tol = kwargs["rel_tol"].convert_to_type(argType1)
+                if 'rel_tol' in kwargs:
+                    rel_tol = kwargs['rel_tol'].convert_to_type(argType1)
                     if rel_tol is None:
                         return None
                 else:
                     rel_tol = native_ast.const_float32_expr(1e-5) if argType1 is Float32 else native_ast.const_float_expr(1e-9)
 
-                if "abs_tol" in kwargs:
-                    abs_tol = kwargs["abs_tol"].convert_to_type(argType1)
+                if 'abs_tol' in kwargs:
+                    abs_tol = kwargs['abs_tol'].convert_to_type(argType1)
                     if abs_tol is None:
                         return None
                 else:
                     abs_tol = native_ast.const_float32_expr(0.0) if argType1 is Float32 else native_ast.const_float_expr(0.0)
 
+                if not arg1.expr_type.is_arithmetic:
+                    arg1 = arg1.toFloat64()
+                    if arg1 is None:
+                        return context.pushException(TypeError, f'must be a real number, not {arg1.expr_type}')
+                if not arg2.expr_type.is_arithmetic:
+                    arg2 = arg2.toFloat64()
+                    if arg2 is None:
+                        return context.pushException(TypeError, f'must be a real number, not {arg2.expr_type}')
                 return context.pushPod(bool, func.call(arg1.nonref_expr, arg2.nonref_expr, rel_tol, abs_tol))
             elif self.typeRepresentation is pow:
                 f_func = runtime_functions.floor32 if argType1 is Float32 else runtime_functions.floor64
@@ -250,32 +291,52 @@ class MathFunctionWrapper(Wrapper):
                             with ifTrue2:  # arg1 == 0
                                 with context.ifelse(arg2.nonref_expr.lt(0.0)) as (ifTrue3, ifFalse3):
                                     with ifTrue3:  # arg1 == 0, arg2 < 0
-                                        context.pushException(ValueError, "math domain error")
+                                        context.pushException(ValueError, 'math domain error')
                             with ifFalse2:  # arg1 < 0
                                 with context.ifelse(f_func.call(arg2.nonref_expr).sub(arg2.nonref_expr).eq(0.0)) as (ifTrue4, ifFalse4):
                                     with ifFalse4:  # arg1 < 0, arg2 not an integer
                                         context.pushException(ValueError, "math domain error")
                 func = runtime_functions.pow32 if argType1 is Float32 else runtime_functions.pow64
+                check_inf = True
             else:
                 assert False, "Unreachable"
 
-            return context.pushPod(outT, func.call(arg1.nonref_expr, arg2.nonref_expr))
+            if not arg1.expr_type.is_arithmetic:
+                arg1 = arg1.toFloat64()
+                if arg1 is None:
+                    return context.pushException(TypeError, f'must be a real number, not {arg1.expr_type}')
+            if not arg2.expr_type.is_arithmetic:
+                arg2 = arg2.toFloat64()
+                if arg2 is None:
+                    return context.pushException(TypeError, f'must be a real number, not {arg2.expr_type}')
+            ret = context.pushPod(outT, func.call(arg1.nonref_expr, arg2.nonref_expr))
+            if check_inf:
+                f_isfinite = runtime_functions.isfinite_float32 if outT is Float32 else runtime_functions.isfinite_float64
+                with context.ifelse(f_isfinite.call(ret.nonref_expr)) as (ifTrue, ifFalse):
+                    with ifFalse:
+                        context.pushException(OverflowError, 'math range error')
+            return ret
 
         # handle integer factorial here
         if len(args) == 1 and not kwargs and self.typeRepresentation is factorial:
             arg = args[0]
             if not arg.expr_type.is_arithmetic:
-                return context.pushException(TypeError, f"must be a real number, not {arg.expr_type}")
+                return context.pushException(TypeError, f'must be a real number, not {arg.expr_type}')
 
             argType = arg.expr_type.typeRepresentation
             if argType not in (Float32, float):
-                if argType not in (int,):
-                    arg = arg.convert_to_type(int, explicit=True)
+                if hasattr(argType, 'IsInteger') and argType.IsInteger:
+                    arg = arg.toInt64()
+                    if arg is None:
+                        return None
+                    argType = arg.expr_type.typeRepresentation
+                elif argType not in (int,):
+                    arg = arg.convert_to_type(int, explicit=False)
                     if arg is None:
                         return None
                 with context.ifelse(arg.nonref_expr.lt(0)) as (ifTrue, ifFalse):
                     with ifTrue:
-                        context.pushException(ValueError, "factorial() not defined for negative values")
+                        context.pushException(ValueError, 'factorial() not defined for negative values')
                 return context.pushPod(int, runtime_functions.factorial.call(arg.nonref_expr))
             # let Float32 and float args fall through to later section, which will handle float factorials
 
@@ -283,10 +344,13 @@ class MathFunctionWrapper(Wrapper):
             arg = args[0]
             return context.call_py_function(sumIterable, (arg,), {})
 
+        # this block is for all other methods with one parameter
         if len(args) == 1 and not kwargs:
             arg = args[0]
             if not arg.expr_type.is_arithmetic:
-                return context.pushException(TypeError, f"must be a real number, not {arg.expr_type}")
+                arg = arg.toFloat64()
+                if not arg:
+                    return context.pushException(TypeError, f'must be a real number, not {arg.expr_type}')
 
             argType = arg.expr_type.typeRepresentation
 
@@ -296,7 +360,7 @@ class MathFunctionWrapper(Wrapper):
                 elif self.typeRepresentation in (isfinite,):
                     return context.constant(True)
                 else:
-                    arg = arg.convert_to_type(float)
+                    arg = arg.toFloat64()
                     if arg is None:
                         return None
                     argType = float
@@ -305,23 +369,23 @@ class MathFunctionWrapper(Wrapper):
             if self.typeRepresentation is acos:
                 with context.ifelse(arg.nonref_expr.gt(1.0)) as (ifTrue, ifFalse):
                     with ifTrue:
-                        context.pushException(ValueError, "math domain error")
+                        context.pushException(ValueError, 'math domain error')
                 with context.ifelse(arg.nonref_expr.lt(-1.0)) as (ifTrue, ifFalse):
                     with ifTrue:
-                        context.pushException(ValueError, "math domain error")
+                        context.pushException(ValueError, 'math domain error')
                 func = runtime_functions.acos32 if argType is Float32 else runtime_functions.acos64
             elif self.typeRepresentation is acosh:
                 with context.ifelse(arg.nonref_expr.lt(1.0)) as (ifTrue, ifFalse):
                     with ifTrue:
-                        context.pushException(ValueError, "math domain error")
+                        context.pushException(ValueError, 'math domain error')
                 func = runtime_functions.acosh32 if argType is Float32 else runtime_functions.acosh64
             elif self.typeRepresentation is asin:
                 with context.ifelse(arg.nonref_expr.gt(1.0)) as (ifTrue, ifFalse):
                     with ifTrue:
-                        context.pushException(ValueError, "math domain error")
+                        context.pushException(ValueError, 'math domain error')
                 with context.ifelse(arg.nonref_expr.lt(-1.0)) as (ifTrue, ifFalse):
                     with ifTrue:
-                        context.pushException(ValueError, "math domain error")
+                        context.pushException(ValueError, 'math domain error')
                 func = runtime_functions.asin32 if argType is Float32 else runtime_functions.asin64
             elif self.typeRepresentation is asinh:
                 func = runtime_functions.asinh32 if argType is Float32 else runtime_functions.asinh64
@@ -330,10 +394,10 @@ class MathFunctionWrapper(Wrapper):
             elif self.typeRepresentation is atanh:
                 with context.ifelse(arg.nonref_expr.gte(1.0)) as (ifTrue, ifFalse):
                     with ifTrue:
-                        context.pushException(ValueError, "math domain error")
+                        context.pushException(ValueError, 'math domain error')
                 with context.ifelse(arg.nonref_expr.lte(-1.0)) as (ifTrue, ifFalse):
                     with ifTrue:
-                        context.pushException(ValueError, "math domain error")
+                        context.pushException(ValueError, 'math domain error')
                 func = runtime_functions.atanh32 if argType is Float32 else runtime_functions.atanh64
             elif self.typeRepresentation is ceil:
                 func = runtime_functions.ceil32 if argType is Float32 else runtime_functions.ceil64
@@ -352,6 +416,7 @@ class MathFunctionWrapper(Wrapper):
                 func = runtime_functions.erfc32 if argType is Float32 else runtime_functions.erfc64
             elif self.typeRepresentation is exp:
                 func = runtime_functions.exp32 if argType is Float32 else runtime_functions.exp64
+                check_inf = True
             elif self.typeRepresentation is expm1:
                 func = runtime_functions.expm1_32 if argType is Float32 else runtime_functions.expm1_64
             elif self.typeRepresentation is fabs:
@@ -362,25 +427,25 @@ class MathFunctionWrapper(Wrapper):
                     with ifTrue:  # arg >= 0
                         with context.ifelse(f_func.call(arg.nonref_expr).sub(arg.nonref_expr).neq(0.0)) as (ifTrue2, ifFalse2):
                             with ifTrue2:  # arg >= 0, arg not an integer
-                                context.pushException(ValueError, "factorial() only accepts integral values")
+                                context.pushException(ValueError, 'factorial() only accepts integral values')
                     with ifFalse:  # arg < 0
-                        context.pushException(ValueError, "factorial() not defined for negative values")
+                        context.pushException(ValueError, 'factorial() not defined for negative values')
                 func = runtime_functions.factorial32 if argType is Float32 else runtime_functions.factorial64
             elif self.typeRepresentation is floor:
                 func = runtime_functions.floor32 if argType is Float32 else runtime_functions.floor64
             elif self.typeRepresentation is frexp:
                 outT = MasqueradingTupleWrapper(Tuple(argType, int))
-                return_tuple = native_ast.Expression.StackSlot(name=".return_tuple", type=outT.layoutType)
+                return_tuple = native_ast.Expression.StackSlot(name='.return_tuple', type=outT.layoutType)
                 func = runtime_functions.frexp32 if argType is Float32 else runtime_functions.frexp64
                 context.pushEffect(func.call(arg.nonref_expr, return_tuple.elemPtr(0).cast(native_ast.VoidPtr)))
-                return typed_python.compiler.typed_expression.TypedExpression(self, return_tuple, outT, True)
+                return typed_python.compiler.typed_expression.TypedExpression(context, return_tuple, outT, True)
             elif self.typeRepresentation is gamma:
                 f_func = runtime_functions.floor32 if argType is Float32 else runtime_functions.floor64
                 with context.ifelse(arg.nonref_expr.lte(0.0)) as (ifTrue, ifFalse):
                     with ifTrue:  # arg <= 0
                         with context.ifelse(f_func.call(arg.nonref_expr).sub(arg.nonref_expr).eq(0.0)) as (ifTrue2, ifFalse2):
                             with ifTrue2:  # arg <= 0, arg an integer
-                                context.pushException(ValueError, "math domain error")
+                                context.pushException(ValueError, 'math domain error')
                 func = runtime_functions.gamma32 if argType is Float32 else runtime_functions.gamma64
             elif self.typeRepresentation is isnan:
                 func = runtime_functions.isnan_float32 if argType is Float32 else runtime_functions.isnan_float64
@@ -397,27 +462,27 @@ class MathFunctionWrapper(Wrapper):
                     with ifTrue:  # arg <= 0
                         with context.ifelse(f_func.call(arg.nonref_expr).sub(arg.nonref_expr).eq(0.0)) as (ifTrue2, ifFalse2):
                             with ifTrue2:  # arg <= 0, arg an integer
-                                context.pushException(ValueError, "math domain error")
+                                context.pushException(ValueError, 'math domain error')
                 func = runtime_functions.lgamma32 if argType is Float32 else runtime_functions.lgamma64
             elif self.typeRepresentation is log:
                 with context.ifelse(arg.nonref_expr.gt(0.0)) as (ifTrue, ifFalse):
                     with ifFalse:  # arg <= 0
-                        context.pushException(ValueError, "math domain error")
+                        context.pushException(ValueError, 'math domain error')
                 func = runtime_functions.log32 if argType is Float32 else runtime_functions.log64
             elif self.typeRepresentation is log1p:
                 with context.ifelse(arg.nonref_expr.gt(-1.0)) as (ifTrue, ifFalse):
                     with ifFalse:  # arg <= -1
-                        context.pushException(ValueError, "math domain error")
+                        context.pushException(ValueError, 'math domain error')
                 func = runtime_functions.log1p32 if argType is Float32 else runtime_functions.log1p64
             elif self.typeRepresentation is log2:
                 with context.ifelse(arg.nonref_expr.gt(0.0)) as (ifTrue, ifFalse):
                     with ifFalse:  # arg <= 0
-                        context.pushException(ValueError, "math domain error")
+                        context.pushException(ValueError, 'math domain error')
                 func = runtime_functions.log2_32 if argType is Float32 else runtime_functions.log2_64
             elif self.typeRepresentation is log10:
                 with context.ifelse(arg.nonref_expr.gt(0.0)) as (ifTrue, ifFalse):
                     with ifFalse:
-                        context.pushException(ValueError, "math domain error")
+                        context.pushException(ValueError, 'math domain error')
                 func = runtime_functions.log10_32 if argType is Float32 else runtime_functions.log10_64
             elif self.typeRepresentation is radians:
                 if argType is Float32:
@@ -426,18 +491,19 @@ class MathFunctionWrapper(Wrapper):
                     return context.pushPod(outT, arg.nonref_expr.mul(native_ast.const_float_expr(pi / 180)))
             elif self.typeRepresentation is modf:
                 outT = MasqueradingTupleWrapper(Tuple(argType, argType))
-                return_tuple = native_ast.Expression.StackSlot(name=".return_tuple", type=outT.layoutType)
+                return_tuple = native_ast.Expression.StackSlot(name='.return_tuple', type=outT.layoutType)
                 func = runtime_functions.modf32 if argType is Float32 else runtime_functions.modf64
                 context.pushEffect(func.call(arg.nonref_expr, return_tuple.elemPtr(0).cast(native_ast.VoidPtr)))
-                return typed_python.compiler.typed_expression.TypedExpression(self, return_tuple, outT, True)
+                return typed_python.compiler.typed_expression.TypedExpression(context, return_tuple, outT, True)
             elif self.typeRepresentation is sin:
                 func = runtime_functions.sin32 if argType is Float32 else runtime_functions.sin64
             elif self.typeRepresentation is sinh:
                 func = runtime_functions.sinh32 if argType is Float32 else runtime_functions.sinh64
+                check_inf = True
             elif self.typeRepresentation is sqrt:
                 with context.ifelse(arg.nonref_expr.gte(0.0)) as (ifTrue, ifFalse):
                     with ifFalse:  # arg < 0
-                        context.pushException(ValueError, "math domain error")
+                        context.pushException(ValueError, 'math domain error')
                 func = runtime_functions.sqrt32 if argType is Float32 else runtime_functions.sqrt64
             elif self.typeRepresentation is tan:
                 func = runtime_functions.tan32 if argType is Float32 else runtime_functions.tan64
@@ -446,8 +512,14 @@ class MathFunctionWrapper(Wrapper):
             elif self.typeRepresentation is trunc:
                 func = runtime_functions.trunc32 if argType is Float32 else runtime_functions.trunc64
             else:
-                assert False, "Unreachable"
+                assert False, 'Unreachable'
 
-            return context.pushPod(outT, func.call(arg.nonref_expr))
+            ret = context.pushPod(outT, func.call(arg.nonref_expr))
+            if check_inf:
+                f_isfinite = runtime_functions.isfinite_float32 if outT is Float32 else runtime_functions.isfinite_float64
+                with context.ifelse(f_isfinite.call(ret.nonref_expr)) as (ifTrue, ifFalse):
+                    with ifFalse:
+                        context.pushException(OverflowError, 'math range error')
+            return ret
 
         return super().convert_call(context, expr, args, kwargs)

--- a/typed_python/compiler/type_wrappers/python_object_of_type_wrapper.py
+++ b/typed_python/compiler/type_wrappers/python_object_of_type_wrapper.py
@@ -22,6 +22,7 @@ import typed_python.compiler.native_ast as native_ast
 from typed_python.compiler.native_ast import VoidPtr, UInt64
 import typed_python
 import typed_python.compiler.type_wrappers.runtime_functions as runtime_functions
+from math import trunc, floor, ceil
 
 
 typeWrapper = lambda t: typed_python.compiler.python_object_representation.typedPythonTypeToTypeWrapper(t)
@@ -231,6 +232,15 @@ class PythonObjectOfTypeWrapper(RefcountedWrapper):
         )
 
         return context.constant(None)
+
+    def convert_builtin(self, f, context, expr, a1=None):
+        if f == ceil:
+            return context.pushPod(float, runtime_functions.pyobj_ceil.call(expr.nonref_expr.cast(VoidPtr)))
+        elif f == floor:
+            return context.pushPod(float, runtime_functions.pyobj_floor.call(expr.nonref_expr.cast(VoidPtr)))
+        elif f == trunc:
+            return context.pushPod(float, runtime_functions.pyobj_trunc.call(expr.nonref_expr.cast(VoidPtr)))
+        return super().convert_builtin(f, context, expr, a1)
 
     def convert_call(self, context, instance, args, kwargs):
         argsAsObjects = []

--- a/typed_python/compiler/type_wrappers/runtime_functions.py
+++ b/typed_python/compiler/type_wrappers/runtime_functions.py
@@ -990,3 +990,21 @@ raiseAttributeError = externalCallTarget(
     Void,
     UInt8Ptr
 )
+
+pyobj_ceil = externalCallTarget(
+    "np_pyobj_ceil",
+    Float64,
+    Void.pointer()
+)
+
+pyobj_floor = externalCallTarget(
+    "np_pyobj_floor",
+    Float64,
+    Void.pointer()
+)
+
+pyobj_trunc = externalCallTarget(
+    "np_pyobj_trunc",
+    Float64,
+    Void.pointer()
+)


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->

## Motivation and Context
Addresses issue# 364.

## Approach
- The functions math.ceil, math.floor, math.trunc have magic methods `__ceil__`, `__floor__`, and `__trunc__`.
   - For these functions, the magic method is attempted first.  
   - For ceil and floor, if there is no magic method, attempt to call `__float__` and call the regular ceil or floor on that value.
   - For trunc, if there is no magic method, it raises TypeError.
- For other math functions with float arguments, if `__float__` is available, evaluate the math function on that value.
- If a math function is passed an object instead of a float argument, we try a non-explicit conversion to float.
- Similar handling for math functions with int arguments.
- Also, improved error checking for other math function compilation (e.g. raising OverflowError for inf when appropriate).
<!-- Describe your changes in reasonable detail -->

## How Has This Been Tested?
Call all math functions with floats and integers as objects, also some classes with `__float__` and other magic methods to simulate other numeric types.
<!-- Describe in reasonable detail how you tested your changes. -->
<!-- If appropriate, include details of your testing environment, -->
<!-- tests ran to see how your change affects other areas of the code, etc. -->

## Screenshots or console output (if appropriate)
<!-- if not appropriate, remove this section -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.