### PR TITLE
Compile math functions on object arguments.  Refs #364.

### DIFF
--- a/docs/typed_python.md
+++ b/docs/typed_python.md
@@ -382,11 +382,12 @@ its tag name as `Name`, and the `NamedTuple` that makes up its body as `ElementT
 * Each `Class` has a list of `MemberNames` and `MemberTypes`, along with `BaseClasses`, `MRO`, and `IsFinal`.
 * Each `Tuple` has its items in `ElementTypes`
 * Each `NamedTuple` has its names in `ElementNames` and its types in `ElementTypes`
-* Each `ConstDict` and `Dict` has its key type as `KeyType` and its value type as `ValueType`.
+* Each `ConstDict` and `Dict` has its key type as `KeyType` and its value type as `ValueType`.  The key type is also in `ElementType`.
 * Each `Function` has a list of the individual function overloads as `overloads`. See `typed_python.internals.FunctionOverload`.
 * Each `PointerTo` has the pointed-to type as `ElementType`.
-* Each `Set` has the item type as `KeyType`
+* Each `Set` has the item type as `KeyType` and also as `ElementType`
 * Each `ListOf` and `TupleOf` has its element type as `ElementType`.
+* (For any container, `ElementType` is intended to give the type of an element that you get as you iterate.)
 
 ## The Compiler
 

--- a/typed_python/AlternativeType.hpp
+++ b/typed_python/AlternativeType.hpp
@@ -1,5 +1,5 @@
 /******************************************************************************
-   Copyright 2017-2019 typed_python Authors
+   Copyright 2017-2020 typed_python Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -18,6 +18,16 @@
 
 #include "Type.hpp"
 #include "CompositeType.hpp"
+
+PyDoc_STRVAR(Alternative_doc,
+    "Alternative(n, subs...[, methods...])() -> new tagged union with specified subtypes and shared methods\n"
+    "\n"
+    "n is the name of the Alternative type, as a str.\n"
+    "subs are given as kwargs and specify the subtypes of the type.\n"
+    "    Each subtype in subs is a dict giving the fields in the subtype.\n"
+    "methods are also given as kwargs and specify methods that are shared among all subtypes.\n"
+    "    Each method in methods is a function with at least one argument 'self'.\n"
+    );
 
 class Alternative : public Type {
 public:
@@ -49,6 +59,8 @@ public:
         if (m_subtypes.size() > 255) {
             throw std::runtime_error("Can't have an alternative with more than 255 subelements");
         }
+
+        m_doc = Alternative_doc;
 
         // call this _first_, so that our core properties, (which we know) are created
         // before we walk down to the ConcreteAlternatives

--- a/typed_python/ClassType.hpp
+++ b/typed_python/ClassType.hpp
@@ -1,5 +1,5 @@
 /******************************************************************************
-   Copyright 2017-2019 typed_python Authors
+   Copyright 2017-2020 typed_python Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -27,6 +27,13 @@ typedef VTable* vtable_ptr;
 
 #define BOTTOM_48_BITS 0xFFFFFFFFFFFF
 
+PyDoc_STRVAR(Class_doc,
+    "Class: subclass Class to produce typed python classes.\n"
+    "\n"
+    "Methods become TypedFunction instances, and support overloading.\n"
+    "Define data members with Member.\n"
+    );
+
 class Class : public Type {
 public:
     class layout {
@@ -43,13 +50,13 @@ public:
         m_size = sizeof(layout*);
         m_is_default_constructible = inClass->is_default_constructible();
         m_name = name;
+        m_doc = Class_doc;
         m_is_simple = false;
 
         endOfConstructorInitialization(); // finish initializing the type object.
 
         inClass->setClassType(this);
     }
-
 
     // convert an instance of the class to an actual layout pointer. Because
     // we encode the offset of the dispatch table we're supposed to use for

--- a/typed_python/CompositeType.hpp
+++ b/typed_python/CompositeType.hpp
@@ -1,5 +1,5 @@
 /******************************************************************************
-   Copyright 2017-2019 typed_python Authors
+   Copyright 2017-2020 typed_python Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -226,12 +226,21 @@ protected:
     std::unordered_map<size_t, size_t> m_serialize_typecodes_to_position; //codes to use when serializing/deserializing
 };
 
+PyDoc_STRVAR(NamedTuple_doc,
+    "NamedTuple(kw)() -> new default-initialized typed named tuple with names and types from kwargs kw\n"
+    "NamedTuple(kw)(t) -> new typed named tuple with names and types from kw, initialized from tuple t\n"
+    "\n"
+    "Raises TypeError if types don't match.\n"
+    );
+
 class NamedTuple : public CompositeType {
 public:
     NamedTuple(const std::vector<Type*>& types, const std::vector<std::string>& names) :
             CompositeType(TypeCategory::catNamedTuple, types, names)
     {
         assert(types.size() == names.size());
+
+        m_doc = NamedTuple_doc;
 
         endOfConstructorInitialization(); // finish initializing the type object.
     }
@@ -250,11 +259,19 @@ public:
     }
 };
 
+PyDoc_STRVAR(Tuple_doc,
+    "Tuple(T1, T2, ...)() -> new default-initialized typed tuple with element types T1, T2, ...\n"
+    "Tuple(T1, T2, ...)(t) -> new typed tuple with types T1, T2, ..., initialized from tuple t\n"
+    "\n"
+    "Raises TypeError if types don't match.\n"
+    );
+
 class Tuple : public CompositeType {
 public:
     Tuple(const std::vector<Type*>& types, const std::vector<std::string>& names) :
             CompositeType(TypeCategory::catTuple, types, names)
     {
+        m_doc = Tuple_doc;
         endOfConstructorInitialization(); // finish initializing the type object.
     }
 

--- a/typed_python/ConstDictType.hpp
+++ b/typed_python/ConstDictType.hpp
@@ -1,5 +1,5 @@
 /******************************************************************************
-   Copyright 2017-2019 typed_python Authors
+   Copyright 2017-2020 typed_python Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -19,6 +19,13 @@
 #include "Type.hpp"
 #include "ReprAccumulator.hpp"
 
+PyDoc_STRVAR(ConstDictType_doc,
+    "ConstDict(K, V)() -> new empty typed immutable dictionary with keytype K and valuetype V\n"
+    "ConstDict(K, V)(d) -> new typed immutable dictionary initialized from dict d\n"
+    "\n"
+    "Raises TypeError if types don't match.\n"
+    );
+
 class ConstDictType : public Type {
     class layout {
     public:
@@ -36,6 +43,7 @@ public:
             m_key(key),
             m_value(value)
     {
+        m_doc = ConstDictType_doc;
         endOfConstructorInitialization(); // finish initializing the type object.
     }
 

--- a/typed_python/DictType.hpp
+++ b/typed_python/DictType.hpp
@@ -22,6 +22,12 @@
 
 #include <unordered_map>
 
+PyDoc_STRVAR(DictType_doc,
+    "Dict(K, V)() -> new empty typed dictionary with keytype K and valuetype V\n"
+    "Dict(K, V)(d) -> new typed dictionary initialized from dict d\n"
+    "    Raises TypeError if types don't match.\n"
+    );
+
 class DictType : public Type {
 public:
     DictType(Type* key, Type* value) :
@@ -29,8 +35,10 @@ public:
             m_key(key),
             m_value(value)
     {
+        m_doc = DictType_doc;
         endOfConstructorInitialization(); // finish initializing the type object.
     }
+
 
     void _updateTypeMemosAfterForwardResolution() {
         DictType::Make(m_key, m_value, this);

--- a/typed_python/DictType.hpp
+++ b/typed_python/DictType.hpp
@@ -1,5 +1,5 @@
 /******************************************************************************
-   Copyright 2017-2019 typed_python Authors
+   Copyright 2017-2020 typed_python Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -25,7 +25,8 @@
 PyDoc_STRVAR(DictType_doc,
     "Dict(K, V)() -> new empty typed dictionary with keytype K and valuetype V\n"
     "Dict(K, V)(d) -> new typed dictionary initialized from dict d\n"
-    "    Raises TypeError if types don't match.\n"
+    "\n"
+    "Raises TypeError if types don't match.\n"
     );
 
 class DictType : public Type {

--- a/typed_python/ForwardType.hpp
+++ b/typed_python/ForwardType.hpp
@@ -19,6 +19,12 @@
 #include "Type.hpp"
 #include "ReprAccumulator.hpp"
 
+PyDoc_STRVAR(Forward_doc,
+    "Forward(n) -> new forward type named n\n"
+    "\n"
+    "Forward types must be resolved before any types that contain them can be used.\n"
+    );
+
 // forward types must be resolved (removed from the graph) before
 // any types that contain them can be used.
 class Forward : public Type {
@@ -27,9 +33,9 @@ public:
         Type(TypeCategory::catForward),
         mTarget(nullptr),
         mIndex(index)
-
     {
         m_name = name;
+        m_doc = Forward_doc;
 
         // deliberately don't invoke 'endOfConstructorInitialization'
     }

--- a/typed_python/FunctionType.hpp
+++ b/typed_python/FunctionType.hpp
@@ -1,5 +1,5 @@
 /******************************************************************************
-   Copyright 2017-2019 typed_python Authors
+   Copyright 2017-2020 typed_python Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -363,6 +363,11 @@ inline ClosureVariableBinding operator+(const ClosureVariableBindingStep& step, 
     return ClosureVariableBinding(steps);
 }
 
+PyDoc_STRVAR(Function_doc,
+    "Function(f) -> typed function\n"
+    "\n"
+    "Converts function f to a typed function.\n"
+    );
 
 class Function : public Type {
 public:
@@ -1346,6 +1351,7 @@ public:
         mModulename(moduleName)
     {
         m_is_simple = false;
+        m_doc = Function_doc;
 
         mClosureType = closureType;
 

--- a/typed_python/OneOfType.hpp
+++ b/typed_python/OneOfType.hpp
@@ -1,5 +1,5 @@
 /******************************************************************************
-   Copyright 2017-2019 typed_python Authors
+   Copyright 2017-2020 typed_python Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -18,6 +18,12 @@
 
 #include "Type.hpp"
 
+PyDoc_STRVAR(OneOf_doc,
+    "OneOfType(T1, T2, ...)() -> default-initialized variable type\n"
+    "\n"
+    "Each of T1, T2, ... may be a typed_python type, or any python primitive value.\n"
+    );
+
 class OneOfType : public Type {
 public:
     OneOfType(const std::vector<Type*>& types) noexcept :
@@ -27,6 +33,8 @@ public:
         if (m_types.size() > 255) {
             throw std::runtime_error("OneOf types are limited to 255 alternatives in this implementation");
         }
+
+        m_doc = OneOf_doc;
 
         endOfConstructorInitialization(); // finish initializing the type object.
     }

--- a/typed_python/PointerToType.hpp
+++ b/typed_python/PointerToType.hpp
@@ -1,5 +1,5 @@
 /******************************************************************************
-   Copyright 2017-2019 typed_python Authors
+   Copyright 2017-2020 typed_python Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -18,6 +18,25 @@
 
 #include "Type.hpp"
 
+PyDoc_STRVAR(PointerTo_doc,
+    "PointerTo(T) is a type that holds unsafe pointers to instances of type T.\n"
+    "\n"
+    "If t is of type T, PointerTo(T) is used to hold the value p=t.pointerUnsafe().\n"
+    "The pointed to object is accessed with p.get().\n"
+    "In compiled code, this access is faster than bounds-checked index access.\n"
+    "Instances of this type are valid only as long as the pointed-to object is not modified in a\n"
+    "way that affects the in-memory representation of the object (e.g. resizing or reallocation).\n\n"
+    "An instance p of PointerTo(T) can be used as follows:\n"
+    "p.get() is like C++ '*p'\n"
+    "p.set(v) is like C++ '*p = v;'\n"
+    "p.initialize(v) is like C++ 'p = new T(v);'\n"
+    "p.cast(T) is like C++ '(T*)p'\n"
+    "The expression p[3] is of type T, like the C++ expression 'p[3]'\n"
+    "The statement p[3]=v is like the C++ statement 'p[3]=v;'\n"
+    "The expression p+3 is of type PointerTo(T), like the C++ expression 'p+3'\n"
+    "The expression p1-p2 is of type int, like the C++ expression 'p1-p2'\n"
+    );
+
 class PointerTo : public Type {
 protected:
     typedef void* instance;
@@ -29,6 +48,7 @@ public:
     {
         m_size = sizeof(instance);
         m_is_default_constructible = true;
+        m_doc = PointerTo_doc;
 
         endOfConstructorInitialization(); // finish initializing the type object.
     }

--- a/typed_python/PyCompositeTypeInstance.cpp
+++ b/typed_python/PyCompositeTypeInstance.cpp
@@ -1,5 +1,5 @@
 /******************************************************************************
-   Copyright 2017-2019 typed_python Authors
+   Copyright 2017-2020 typed_python Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -400,6 +400,11 @@ int PyNamedTupleInstance::findElementIndex(const std::vector<std::string>& conta
 }
 
 // static
+PyDoc_STRVAR(replacing_doc,
+    "t.replacing(**kwargs) -> copy of t with updated fields and values\n"
+    "\n"
+    "Each keyword argument specifies a field and value to update.\n"
+    );
 PyObject* PyNamedTupleInstance::replacing(PyObject* o, PyObject* args, PyObject* kwargs) {
     PyNamedTupleInstance* self = (PyNamedTupleInstance*)o;
 
@@ -469,7 +474,7 @@ PyObject* PyNamedTupleInstance::replacing(PyObject* o, PyObject* args, PyObject*
 
 PyMethodDef* PyNamedTupleInstance::typeMethodsConcrete(Type* t) {
     return new PyMethodDef[2] {
-        {"replacing", (PyCFunction)PyNamedTupleInstance::replacing, METH_VARARGS | METH_KEYWORDS, NULL},
+        {"replacing", (PyCFunction)PyNamedTupleInstance::replacing, METH_VARARGS | METH_KEYWORDS, replacing_doc},
         {NULL, NULL}
     };
 

--- a/typed_python/PyConstDictInstance.cpp
+++ b/typed_python/PyConstDictInstance.cpp
@@ -21,6 +21,9 @@ ConstDictType* PyConstDictInstance::type() {
 }
 
 // static
+PyDoc_STRVAR(constDictItems_doc,
+    "D.items() -> an iterable containing D's items."
+    );
 PyObject* PyConstDictInstance::constDictItems(PyObject *o) {
     if (((PyInstance*)o)->mIteratorOffset != -1) {
         PyErr_SetString(PyExc_TypeError, "ConstDict iterators don't support 'items'");
@@ -51,6 +54,9 @@ PyObject* PyConstDictInstance::constDictItems(PyObject *o) {
 }
 
 // static
+PyDoc_STRVAR(constDictKeys_doc,
+    "D.keys() -> an iterable containing D's keys."
+    );
 PyObject* PyConstDictInstance::constDictKeys(PyObject *o) {
     if (((PyInstance*)o)->mIteratorOffset != -1) {
         PyErr_SetString(PyExc_TypeError, "ConstDict iterators don't support 'keys'");
@@ -79,6 +85,9 @@ PyObject* PyConstDictInstance::constDictKeys(PyObject *o) {
 }
 
 // static
+PyDoc_STRVAR(constDictValues_doc,
+    "D.values() -> an iterable containing D's values."
+    );
 PyObject* PyConstDictInstance::constDictValues(PyObject *o) {
     if (((PyInstance*)o)->mIteratorOffset != -1) {
         PyErr_SetString(PyExc_TypeError, "ConstDict iterators don't support 'values'");
@@ -108,6 +117,9 @@ PyObject* PyConstDictInstance::constDictValues(PyObject *o) {
 }
 
 // static
+PyDoc_STRVAR(constDictGet_doc,
+    "D.get(k[,d]) -> D[k] if k in D, else d.  d defaults to None."
+    );
 PyObject* PyConstDictInstance::constDictGet(PyObject* o, PyObject* args) {
     if (((PyInstance*)o)->mIteratorOffset != -1) {
         PyErr_SetString(PyExc_TypeError, "ConstDict iterators don't support 'get'");
@@ -413,10 +425,10 @@ PyObject* PyConstDictInstance::mp_subscript_concrete(PyObject* item) {
 
 PyMethodDef* PyConstDictInstance::typeMethodsConcrete(Type* t) {
     return new PyMethodDef [5] {
-        {"get", (PyCFunction)PyConstDictInstance::constDictGet, METH_VARARGS, NULL},
-        {"items", (PyCFunction)PyConstDictInstance::constDictItems, METH_NOARGS, NULL},
-        {"keys", (PyCFunction)PyConstDictInstance::constDictKeys, METH_NOARGS, NULL},
-        {"values", (PyCFunction)PyConstDictInstance::constDictValues, METH_NOARGS, NULL},
+        {"get", (PyCFunction)PyConstDictInstance::constDictGet, METH_VARARGS, constDictGet_doc},
+        {"items", (PyCFunction)PyConstDictInstance::constDictItems, METH_NOARGS, constDictItems_doc},
+        {"keys", (PyCFunction)PyConstDictInstance::constDictKeys, METH_NOARGS, constDictKeys_doc},
+        {"values", (PyCFunction)PyConstDictInstance::constDictValues, METH_NOARGS, constDictValues_doc},
         {NULL, NULL}
     };
 }

--- a/typed_python/PyDictInstance.cpp
+++ b/typed_python/PyDictInstance.cpp
@@ -79,7 +79,8 @@ PyObject* PyDictInstance::dictValues(PyObject *o) {
 
 PyDoc_STRVAR(dictUpdate_doc,
     "D.update(F) -> None.  Update D from dict F.\n"
-    "    for k in F:  D[k]=F[k]\n"
+    "\n"
+    "for k in F:  D[k]=F[k]\n"
     );
 // static
 PyObject* PyDictInstance::dictUpdate(PyObject* o, PyObject* args) {
@@ -743,6 +744,7 @@ PyObject* PyDictInstance::setDefault(PyObject* o, PyObject* args) {
 //static
 PyDoc_STRVAR(pop_doc,
     "D.pop(k[,d]) -> v, remove key k and return corresponding value v.\n"
+    "\n"
     "If k is not found, d is returned if given, otherwise KeyError is raised.\n"
     );
 PyObject* PyDictInstance::pop(PyObject* o, PyObject* args) {

--- a/typed_python/PyDictInstance.cpp
+++ b/typed_python/PyDictInstance.cpp
@@ -21,6 +21,9 @@ DictType* PyDictInstance::type() {
 }
 
 // static
+PyDoc_STRVAR(dictItems_doc,
+    "D.items() -> an iterable containing D's items."
+    );
 PyObject* PyDictInstance::dictItems(PyObject *o) {
     if (((PyInstance*)o)->mIteratorOffset != -1) {
         PyErr_SetString(PyExc_TypeError, "dict iterators don't support 'items'");
@@ -37,6 +40,9 @@ PyObject* PyDictInstance::dictItems(PyObject *o) {
 }
 
 // static
+PyDoc_STRVAR(dictKeys_doc,
+    "D.keys() -> an iterable containing D's keys."
+    );
 PyObject* PyDictInstance::dictKeys(PyObject *o) {
     if (((PyInstance*)o)->mIteratorOffset != -1) {
         PyErr_SetString(PyExc_TypeError, "dict iterators don't support 'keys'");
@@ -53,6 +59,9 @@ PyObject* PyDictInstance::dictKeys(PyObject *o) {
 }
 
 // static
+PyDoc_STRVAR(dictValues_doc,
+    "D.values() -> an iterable containing D's values."
+    );
 PyObject* PyDictInstance::dictValues(PyObject *o) {
     if (((PyInstance*)o)->mIteratorOffset != -1) {
         PyErr_SetString(PyExc_TypeError, "dict iterators don't support 'values'");
@@ -68,6 +77,10 @@ PyObject* PyDictInstance::dictValues(PyObject *o) {
     return (PyObject*)result;
 }
 
+PyDoc_STRVAR(dictUpdate_doc,
+    "D.update(F) -> None.  Update D from dict F.\n"
+    "    for k in F:  D[k]=F[k]\n"
+    );
 // static
 PyObject* PyDictInstance::dictUpdate(PyObject* o, PyObject* args) {
     PyDictInstance* self_w = (PyDictInstance*)o;
@@ -125,6 +138,9 @@ PyObject* PyDictInstance::dictUpdate(PyObject* o, PyObject* args) {
 }
 
 // static
+PyDoc_STRVAR(dictGet_doc,
+    "D.get(k[,d]) -> D[k] if k in D, else d.  d defaults to None."
+    );
 PyObject* PyDictInstance::dictGet(PyObject* o, PyObject* args) {
     PyDictInstance* self_w = (PyDictInstance*)o;
 
@@ -185,6 +201,9 @@ PyObject* PyDictInstance::dictGet(PyObject* o, PyObject* args) {
 }
 
 // static
+PyDoc_STRVAR(dictClear_doc,
+    "D.clear() -> None.  Removes all items from D."
+    );
 PyObject* PyDictInstance::dictClear(PyObject* o) {
     PyDictInstance* self_w = (PyDictInstance*)o;
 
@@ -442,20 +461,6 @@ int PyDictInstance::mp_ass_subscript_concrete(PyObject* item, PyObject* value) {
     }
 }
 
-PyMethodDef* PyDictInstance::typeMethodsConcrete(Type* t) {
-    return new PyMethodDef [9] {
-        {"get", (PyCFunction)PyDictInstance::dictGet, METH_VARARGS, NULL},
-        {"clear", (PyCFunction)PyDictInstance::dictClear, METH_NOARGS, NULL},
-        {"update", (PyCFunction)PyDictInstance::dictUpdate, METH_VARARGS, NULL},
-        {"items", (PyCFunction)PyDictInstance::dictItems, METH_NOARGS, NULL},
-        {"keys", (PyCFunction)PyDictInstance::dictKeys, METH_NOARGS, NULL},
-        {"values", (PyCFunction)PyDictInstance::dictValues, METH_NOARGS, NULL},
-        {"setdefault", (PyCFunction)PyDictInstance::setDefault, METH_VARARGS, NULL},
-        {"pop", (PyCFunction)PyDictInstance::pop, METH_VARARGS, NULL},
-        {NULL, NULL}
-    };
-}
-
 void PyDictInstance::mirrorTypeInformationIntoPyTypeConcrete(DictType* dictT, PyTypeObject* pyType) {
     PyDict_SetItemString(pyType->tp_dict, "KeyType",
         typePtrToPyTypeRepresentation(dictT->keyType())
@@ -644,6 +649,9 @@ bool PyDictInstance::compare_to_python_concrete(DictType* dictType, instance_ptr
 }
 
 //static
+PyDoc_STRVAR(setDefault_doc,
+    "D.setdefault(k[,d]) -> D.get(k,d), also set D[k]=d if k not in D."
+    );
 PyObject* PyDictInstance::setDefault(PyObject* o, PyObject* args) {
     return translateExceptionToPyObject([&]() {
         const int argsNumber = PyTuple_Size(args);
@@ -733,6 +741,10 @@ PyObject* PyDictInstance::setDefault(PyObject* o, PyObject* args) {
 }
 
 //static
+PyDoc_STRVAR(pop_doc,
+    "D.pop(k[,d]) -> v, remove key k and return corresponding value v.\n"
+    "If k is not found, d is returned if given, otherwise KeyError is raised.\n"
+    );
 PyObject* PyDictInstance::pop(PyObject* o, PyObject* args) {
     return translateExceptionToPyObject([&]() {
         const int argsNumber = PyTuple_Size(args);
@@ -824,4 +836,18 @@ PyObject* PyDictInstance::tp_repr_concrete() {
     }
 
     return PyUnicode_FromString(str.str().c_str());
+}
+
+PyMethodDef* PyDictInstance::typeMethodsConcrete(Type* t) {
+    return new PyMethodDef [9] {
+        {"get", (PyCFunction)PyDictInstance::dictGet, METH_VARARGS, dictGet_doc},
+        {"clear", (PyCFunction)PyDictInstance::dictClear, METH_NOARGS, dictClear_doc},
+        {"update", (PyCFunction)PyDictInstance::dictUpdate, METH_VARARGS, dictUpdate_doc},
+        {"items", (PyCFunction)PyDictInstance::dictItems, METH_NOARGS, dictItems_doc},
+        {"keys", (PyCFunction)PyDictInstance::dictKeys, METH_NOARGS, dictKeys_doc},
+        {"values", (PyCFunction)PyDictInstance::dictValues, METH_NOARGS, dictValues_doc},
+        {"setdefault", (PyCFunction)PyDictInstance::setDefault, METH_VARARGS, setDefault_doc},
+        {"pop", (PyCFunction)PyDictInstance::pop, METH_VARARGS, pop_doc},
+        {NULL, NULL}
+    };
 }

--- a/typed_python/PyInstance.cpp
+++ b/typed_python/PyInstance.cpp
@@ -1142,7 +1142,7 @@ PyTypeObject* PyInstance::typeObjInternal(Type* inType) {
             .tp_flags = typeCanBeSubclassed(inType) ?
                 Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE
             :   Py_TPFLAGS_DEFAULT,                     // unsigned long
-            .tp_doc = 0,                                // const char*
+            .tp_doc = inType->doc(),                    // const char*
             .tp_traverse = 0,                           // traverseproc
             .tp_clear = 0,                              // inquiry
             .tp_richcompare = tp_richcompare,           // richcmpfunc

--- a/typed_python/PyPointerToInstance.cpp
+++ b/typed_python/PyPointerToInstance.cpp
@@ -21,6 +21,14 @@ PointerTo* PyPointerToInstance::type() {
 }
 
 //static
+PyDoc_STRVAR(pointerInitialize_doc,
+    "p.initialize() -> None, and sets p to point to default-initialized value\n"
+    "p.initialize(v) -> None, and sets p to point to a copy of v\n"
+    "\n"
+    "In C++ terms, if p is type PointerTo(T):\n"
+    "(no arguments) p = new T;\n"
+    "(one argument) p = new T(v);\n"
+    );
 PyObject* PyPointerToInstance::pointerInitialize(PyObject* o, PyObject* args) {
     PyInstance* self_w = (PyInstance*)o;
     PointerTo* pointerT = (PointerTo*)extractTypeFrom(o->ob_type);
@@ -56,6 +64,11 @@ PyObject* PyPointerToInstance::pointerInitialize(PyObject* o, PyObject* args) {
 }
 
 //static
+PyDoc_STRVAR(pointerSet_doc,
+    "p.set(v) -> None, and sets where p points to to v.\n"
+    "\n"
+    "In C++ terms: *p = v;\n"
+    );
 PyObject* PyPointerToInstance::pointerSet(PyObject* o, PyObject* args) {
     PyInstance* self_w = (PyInstance*)o;
     PointerTo* pointerT = (PointerTo*)extractTypeFrom(o->ob_type);
@@ -87,6 +100,13 @@ PyObject* PyPointerToInstance::pointerSet(PyObject* o, PyObject* args) {
 
     return incref(Py_None);
 }
+
+PyDoc_STRVAR(
+    pointerDestroy_doc,
+    "p.destroy() -> None, and destroys the value pointed to by 'p'.\n"
+    "\n"
+    "In C++ terms, if p is type PointerTo(T), then this would be `p->~T()`.\n"
+);
 
 //static
 PyObject* PyPointerToInstance::pointerDestroy(PyObject* o, PyObject* args) {
@@ -142,9 +162,13 @@ int PyPointerToInstance::mp_ass_subscript_concrete(PyObject* item, PyObject* val
     });
 }
 
-
-
 //static
+PyDoc_STRVAR(pointerGet_doc,
+    "p.get() -> element pointed to by p\n"
+    "\n"
+    "If p is type PointerTo(T), p.get() is type T.\n"
+    "In C++ terms: *p\n"
+    );
 PyObject* PyPointerToInstance::pointerGet(PyObject* o, PyObject* args) {
     PyInstance* self_w = (PyInstance*)o;
     PointerTo* pointerT = (PointerTo*)extractTypeFrom(o->ob_type);
@@ -160,6 +184,11 @@ PyObject* PyPointerToInstance::pointerGet(PyObject* o, PyObject* args) {
 }
 
 //static
+PyDoc_STRVAR(pointerCast_doc,
+    "p.cast(T) -> pointer p cast to PointerTo(T)\n"
+    "\n"
+    "In C++ terms: (T*)p\n"
+    );
 PyObject* PyPointerToInstance::pointerCast(PyObject* o, PyObject* args) {
     PyInstance* self_w = (PyInstance*)o;
 
@@ -222,11 +251,11 @@ PyObject* PyPointerToInstance::pyOperatorConcrete(PyObject* rhs, const char* op,
 
 PyMethodDef* PyPointerToInstance::typeMethodsConcrete(Type* t) {
     return new PyMethodDef [6] {
-        {"initialize", (PyCFunction)PyPointerToInstance::pointerInitialize, METH_VARARGS, NULL},
-        {"set", (PyCFunction)PyPointerToInstance::pointerSet, METH_VARARGS, NULL},
-        {"get", (PyCFunction)PyPointerToInstance::pointerGet, METH_VARARGS, NULL},
-        {"cast", (PyCFunction)PyPointerToInstance::pointerCast, METH_VARARGS, NULL},
-        {"destroy", (PyCFunction)PyPointerToInstance::pointerDestroy, METH_VARARGS, NULL},
+        {"initialize", (PyCFunction)PyPointerToInstance::pointerInitialize, METH_VARARGS, pointerInitialize_doc},
+        {"set", (PyCFunction)PyPointerToInstance::pointerSet, METH_VARARGS, pointerSet_doc},
+        {"get", (PyCFunction)PyPointerToInstance::pointerGet, METH_VARARGS, pointerGet_doc},
+        {"cast", (PyCFunction)PyPointerToInstance::pointerCast, METH_VARARGS, pointerCast_doc},
+        {"destroy", (PyCFunction)PyPointerToInstance::pointerDestroy, METH_VARARGS, pointerDestroy_doc},
         {NULL, NULL}
     };
 }

--- a/typed_python/PyPythonObjectOfTypeInstance.hpp
+++ b/typed_python/PyPythonObjectOfTypeInstance.hpp
@@ -63,4 +63,8 @@ public:
             (PyObject*)inType->pyType()
         );
     }
+
+    static bool compare_to_python_concrete(PythonObjectOfType* oType, instance_ptr self, PyObject* other, bool exact, int pyComparisonOp) {
+        return PyObject_RichCompareBool(oType->getPyObj(self), other, pyComparisonOp);
+    }
 };

--- a/typed_python/PyRegisterTypeInstance.hpp
+++ b/typed_python/PyRegisterTypeInstance.hpp
@@ -21,6 +21,38 @@
 #include "PromotesTo.hpp"
 #include <cmath>
 
+PyDoc_STRVAR(_complex_doc,
+    "complex(n) -> complex\n"
+    "\n"
+    "Creates a complex number with real part n and zero imaginary part.\n"
+    );
+PyDoc_STRVAR(_round_doc,
+    "round(n[, d=0]) -> number\n"
+    "\n"
+    "Without d, returns the integer closest to x, rounding 0.5 towards even.\n"
+    "With d, rounds to precision of d decimal digits.\n"
+    "d may be negative.\n"
+    "Returned value has same type as n.\n"
+    );
+PyDoc_STRVAR(_trunc_doc,
+    "trunc(n) -> number\n"
+    "\n"
+    "Returns n with decimal part truncated to the nearest integer toward 0.\n"
+    "Returned value has same type as n.\n"
+    );
+PyDoc_STRVAR(_floor_doc,
+    "floor(n) -> number\n"
+    "\n"
+    "Returns the largest integer <= n.\n"
+    "Returned value has same type as n.\n"
+    );
+PyDoc_STRVAR(_ceil_doc,
+    "ceil(n) -> number\n"
+    "\n"
+    "Returns the smallest integer >= n.\n"
+    "Returned value has same type as n.\n"
+    );
+
 template<class T>
 static PyObject* registerValueToPyValue(T val) {
     static Type* typeObj = GetRegisterType<T>()();
@@ -1031,11 +1063,11 @@ private:
 public:
     static PyMethodDef* typeMethodsConcrete(Type* t) {
         return new PyMethodDef [6] {
-            {"__complex__", (PyCFunction)_complex, METH_VARARGS | METH_KEYWORDS, NULL},
-            {"__round__", (PyCFunction)_round, METH_VARARGS | METH_KEYWORDS, NULL},
-            {"__trunc__", (PyCFunction)_trunc, METH_VARARGS | METH_KEYWORDS, NULL},
-            {"__floor__", (PyCFunction)_floor, METH_VARARGS | METH_KEYWORDS, NULL},
-            {"__ceil__", (PyCFunction)_ceil, METH_VARARGS | METH_KEYWORDS, NULL},
+            {"__complex__", (PyCFunction)_complex, METH_VARARGS | METH_KEYWORDS, _complex_doc},
+            {"__round__", (PyCFunction)_round, METH_VARARGS | METH_KEYWORDS, _round_doc},
+            {"__trunc__", (PyCFunction)_trunc, METH_VARARGS | METH_KEYWORDS, _trunc_doc},
+            {"__floor__", (PyCFunction)_floor, METH_VARARGS | METH_KEYWORDS, _floor_doc},
+            {"__ceil__", (PyCFunction)_ceil, METH_VARARGS | METH_KEYWORDS, _ceil_doc},
             {NULL, NULL}
             };
         }

--- a/typed_python/PySetInstance.cpp
+++ b/typed_python/PySetInstance.cpp
@@ -32,28 +32,6 @@ void PySetInstance::getDataFromNative(PyTupleOrListOfInstance* src,
     }
 }
 
-
-PyMethodDef* PySetInstance::typeMethodsConcrete(Type* t) {
-    return new PyMethodDef[18]{{"add", (PyCFunction)PySetInstance::setAdd, METH_VARARGS, NULL},
-                              {"pop", (PyCFunction)PySetInstance::setPop, METH_VARARGS, NULL},
-                              {"discard", (PyCFunction)PySetInstance::setDiscard, METH_VARARGS, NULL},
-                              {"remove", (PyCFunction)PySetInstance::setRemove, METH_VARARGS, NULL},
-                              {"clear", (PyCFunction)PySetInstance::setClear, METH_VARARGS, NULL},
-                              {"copy", (PyCFunction)PySetInstance::setCopy, METH_VARARGS, NULL},
-                              {"union", (PyCFunction)PySetInstance::setUnion, METH_VARARGS, NULL},
-                              {"update", (PyCFunction)PySetInstance::setUpdate, METH_VARARGS, NULL},
-                              {"intersection", (PyCFunction)PySetInstance::setIntersection, METH_VARARGS, NULL},
-                              {"intersection_update", (PyCFunction)PySetInstance::setIntersectionUpdate, METH_VARARGS, NULL},
-                              {"difference", (PyCFunction)PySetInstance::setDifference, METH_VARARGS, NULL},
-                              {"difference_update", (PyCFunction)PySetInstance::setDifferenceUpdate, METH_VARARGS, NULL},
-                              {"symmetric_difference", (PyCFunction)PySetInstance::setSymmetricDifference, METH_VARARGS, NULL},
-                              {"symmetric_difference_update", (PyCFunction)PySetInstance::setSymmetricDifferenceUpdate, METH_VARARGS, NULL},
-                              {"issubset", (PyCFunction)PySetInstance::setIsSubset, METH_VARARGS, NULL},
-                              {"issuperset", (PyCFunction)PySetInstance::setIsSuperset, METH_VARARGS, NULL},
-                              {"isdisjoint", (PyCFunction)PySetInstance::setIsDisjoint, METH_VARARGS, NULL},
-                              {NULL, NULL}};
-}
-
 PyObject* PySetInstance::try_remove(PyObject* o, PyObject* item, bool assertKeyError) {
     PySetInstance* self_w = (PySetInstance*)o;
     Type* item_type = extractTypeFrom(item->ob_type);
@@ -132,6 +110,11 @@ PyObject* PySetInstance::try_add_if_not_found(PyObject* o, PySetInstance* to_be_
     Py_RETURN_NONE;
 }
 
+PyDoc_STRVAR(setRemove_doc,
+    "s.remove(item) -> None, and item is removed from s\n"
+    "\n"
+    "Raises KeyError if item is not in set.\n"
+    );
 PyObject* PySetInstance::setRemove(PyObject* o, PyObject* args) {
     if (PyTuple_Size(args) != 1) {
         PyErr_SetString(PyExc_TypeError, "Set.remove takes one argument");
@@ -142,6 +125,11 @@ PyObject* PySetInstance::setRemove(PyObject* o, PyObject* args) {
     return try_remove(o, item, true);
 }
 
+PyDoc_STRVAR(setDiscard_doc,
+    "s.discard(item) -> None, and item is removed from s\n"
+    "\n"
+    "No action if item not found.  Compare s.remove().\n"
+    );
 PyObject* PySetInstance::setDiscard(PyObject* o, PyObject* args) {
     if (PyTuple_Size(args) != 1) {
         PyErr_SetString(PyExc_TypeError, "Set.discard takes one argument");
@@ -152,6 +140,9 @@ PyObject* PySetInstance::setDiscard(PyObject* o, PyObject* args) {
     return try_remove(o, item, false);
 }
 
+PyDoc_STRVAR(setClear_doc,
+    "s.clear() -> None, and s becomes the empty set"
+    );
 PyObject* PySetInstance::setClear(PyObject* o, PyObject* args) {
     if (args && PyTuple_Size(args) != 0) {
         PyErr_SetString(PyExc_TypeError, "Set.clear takes no arguments");
@@ -190,6 +181,9 @@ void PySetInstance::copy_elements(PyObject* dst, PyObject* src) {
     }
 }
 
+PyDoc_STRVAR(setCopy_doc,
+    "s.copy() -> shallow copy of s"
+    );
 PyObject* PySetInstance::setCopy(PyObject* o, PyObject* args) {
     if (args && PyTuple_Size(args) != 0) {
         PyErr_SetString(PyExc_TypeError, "Set.copy takes no arguments");
@@ -610,6 +604,12 @@ PyObject* PySetInstance::set_union(PyObject* o, PyObject* other) {
     return (PyObject*)new_inst;
 }
 
+PyDoc_STRVAR(setDifference_doc,
+    "s.difference(s1) -> set that contain elements that are in s but not s1\n"
+    "s.difference(s1, s2, ...) -> set of elements that are in s but not s1, s2, ...\n"
+    "\n"
+    "s1, s2, ... can be sets or any iterable yielding the same element type as s.\n"
+    );
 PyObject* PySetInstance::setDifference(PyObject* o, PyObject* args) {
     if (PyTuple_Size(args) == 0) {
         return setCopy(o, NULL);
@@ -633,6 +633,11 @@ PyObject* PySetInstance::setDifference(PyObject* o, PyObject* args) {
     return result;
 }
 
+PyDoc_STRVAR(setSymmetricDifference_doc,
+    "s.symmetric_difference(s1) -> set of elements in one of s or s1, but not both\n"
+    "\n"
+    "s1 can be a set or any iterable yielding the same element type as s.\n"
+    );
 PyObject* PySetInstance::setSymmetricDifference(PyObject* o, PyObject* args) {
     if (Py_ssize_t n = PyTuple_Size(args) != 1) {
         PyErr_Format(PyExc_TypeError, "symmetric_difference() takes exactly one argument (%d given)", n);
@@ -645,6 +650,9 @@ PyObject* PySetInstance::setSymmetricDifference(PyObject* o, PyObject* args) {
     return result;
 }
 
+PyDoc_STRVAR(setIsSubset_doc,
+    "s.issubset(s1) -> Is s a subset of s1?"
+    );
 PyObject* PySetInstance::setIsSubset(PyObject* o, PyObject* args) {
     if (Py_ssize_t n = PyTuple_Size(args) != 1) {
         PyErr_Format(PyExc_TypeError, "issubset() takes exactly one argument (%d given)", n);
@@ -664,6 +672,9 @@ PyObject* PySetInstance::setIsSubset(PyObject* o, PyObject* args) {
     return incref(ret ? Py_True : Py_False);
 }
 
+PyDoc_STRVAR(setIsSuperset_doc,
+    "s.issuperset(s1) -> Is s a superset of s1?"
+    );
 PyObject* PySetInstance::setIsSuperset(PyObject* o, PyObject* args) {
     if (Py_ssize_t n = PyTuple_Size(args) != 1) {
         PyErr_Format(PyExc_TypeError, "issuperset() takes exactly one argument (%d given)", n);
@@ -682,6 +693,9 @@ PyObject* PySetInstance::setIsSuperset(PyObject* o, PyObject* args) {
     return incref(ret ? Py_True : Py_False);
 }
 
+PyDoc_STRVAR(setIsDisjoint_doc,
+    "s.isdisjoint(s1) -> Are s and s1 disjoint?"
+    );
 PyObject* PySetInstance::setIsDisjoint(PyObject* o, PyObject* args) {
     if (Py_ssize_t n = PyTuple_Size(args) != 1) {
         PyErr_Format(PyExc_TypeError, "isdisjoint() takes exactly one argument (%d given)", n);
@@ -700,6 +714,12 @@ PyObject* PySetInstance::setIsDisjoint(PyObject* o, PyObject* args) {
     return incref(ret ? Py_True : Py_False);
 }
 
+PyDoc_STRVAR(setIntersection_doc,
+    "s.intersection(s1) -> set of elements that are in both s and s1\n"
+    "s.intersection(s1, s2, ...) -> set of elements that are in s, s1, s2, ...\n"
+    "\n"
+    "s1, s2, ... can be sets or any iterable yielding the same element type as s.\n"
+    );
 PyObject* PySetInstance::setIntersection(PyObject* o, PyObject* args) {
     if (PyTuple_Size(args) == 0) {
         return setCopy(o, NULL);
@@ -738,6 +758,12 @@ PyObject* PySetInstance::setIntersection(PyObject* o, PyObject* args) {
     return self_w;
 }
 
+PyDoc_STRVAR(setUnion_doc,
+    "s.union(s1) -> set of elements that are in s or s1\n"
+    "s.union(s1, s2, ...) -> set of elements that are in one of s, s1, s2, ...\n"
+    "\n"
+    "s1, s2, ... can be sets or any iterable yielding the same element type as s.\n"
+    );
 PyObject* PySetInstance::setUnion(PyObject* o, PyObject* args) {
     if (PyTuple_Size(args) == 0) {
         return setCopy(o, NULL);
@@ -808,6 +834,12 @@ void PySetInstance::constructFromPythonArgumentsConcrete(SetType* t, uint8_t* da
     PyInstance::constructFromPythonArgumentsConcrete(t, data, args, kwargs);
 }
 
+PyDoc_STRVAR(setIntersectionUpdate_doc,
+    "s.intersection_update(s1) -> None, and s=s.intersection(s1)\n"
+    "s.intersection_update(s1, s2, ...) -> None, and s=s.intersection(s1, s2, ...)\n"
+    "\n"
+    "s1, s2, ... can be sets or any iterable yielding the same element type as s.\n"
+    );
 PyObject* PySetInstance::setIntersectionUpdate(PyObject* o, PyObject* args) {
     if (PyTuple_Size(args) == 0) {
         Py_RETURN_NONE;
@@ -839,6 +871,12 @@ PyObject* PySetInstance::setIntersectionUpdate(PyObject* o, PyObject* args) {
     Py_RETURN_NONE;
 }
 
+PyDoc_STRVAR(setDifferenceUpdate_doc,
+    "s.difference_update(s1) -> None, and s=s.difference(s1)\n"
+    "s.difference_update(s1, s2, ...) -> None, and s=s.difference(s1, s2, ...)\n"
+    "\n"
+    "s1, s2, ... can be sets or any iterable yielding the same element type as s.\n"
+    );
 PyObject* PySetInstance::setDifferenceUpdate(PyObject* o, PyObject* args) {
     if (PyTuple_Size(args) == 0) {
         Py_RETURN_NONE;
@@ -870,6 +908,11 @@ PyObject* PySetInstance::setDifferenceUpdate(PyObject* o, PyObject* args) {
     Py_RETURN_NONE;
 }
 
+PyDoc_STRVAR(setSymmetricDifferenceUpdate_doc,
+    "s.symmetric_difference_update(s1) -> None, and s=s.symmetric_difference(s1)\n"
+    "\n"
+    "s1 can be a set or any iterable yielding the same element type as s.\n"
+    );
 PyObject* PySetInstance::setSymmetricDifferenceUpdate(PyObject* o, PyObject* args) {
     if (PyTuple_Size(args) != 1) {
         PyErr_SetString(PyExc_TypeError, "symmetric_difference_update takes exactly one argument");
@@ -898,6 +941,12 @@ PyObject* PySetInstance::setSymmetricDifferenceUpdate(PyObject* o, PyObject* arg
     Py_RETURN_NONE;
 }
 
+PyDoc_STRVAR(setUpdate_doc,
+    "s.update(s1) -> None, and s=s.union(s1)\n"
+    "s.update(s1, s2, ...) -> None, and s=s.union(s1, s2, ...)\n"
+    "\n"
+    "s1, s2, ... can be sets or any iterable yielding the same element type as s.\n"
+    );
 PyObject* PySetInstance::setUpdate(PyObject* o, PyObject* args) {
     if (PyTuple_Size(args) == 0) {
         Py_RETURN_NONE;
@@ -949,6 +998,9 @@ int PySetInstance::sq_contains_concrete(PyObject* item) {
     }
 }
 
+PyDoc_STRVAR(setPop_doc,
+    "s.pop() -> an arbitrary element of the set, which is removed"
+    );
 PyObject* PySetInstance::setPop(PyObject* o, PyObject* args) {
     PySetInstance* self_w = (PySetInstance*)o;
     if (PyTuple_Size(args) != 0) {
@@ -980,6 +1032,9 @@ PyObject* PySetInstance::setPop(PyObject* o, PyObject* args) {
     return result;
 }
 
+PyDoc_STRVAR(setAdd_doc,
+    "s.add(item) -> None, and item is added to the set s"
+    );
 PyObject* PySetInstance::setAdd(PyObject* o, PyObject* args) {
     PySetInstance* self_w = (PySetInstance*)o;
     if (PyTuple_Size(args) != 1) {
@@ -1341,4 +1396,25 @@ bool PySetInstance::pyValCouldBeOfTypeConcrete(modeled_type* type, PyObject* pyR
     }
 
     return false;
+}
+
+PyMethodDef* PySetInstance::typeMethodsConcrete(Type* t) {
+    return new PyMethodDef[18]{{"add", (PyCFunction)PySetInstance::setAdd, METH_VARARGS, setAdd_doc},
+                              {"pop", (PyCFunction)PySetInstance::setPop, METH_VARARGS, setPop_doc},
+                              {"discard", (PyCFunction)PySetInstance::setDiscard, METH_VARARGS, setDiscard_doc},
+                              {"remove", (PyCFunction)PySetInstance::setRemove, METH_VARARGS, setRemove_doc},
+                              {"clear", (PyCFunction)PySetInstance::setClear, METH_VARARGS, setClear_doc},
+                              {"copy", (PyCFunction)PySetInstance::setCopy, METH_VARARGS, setCopy_doc},
+                              {"union", (PyCFunction)PySetInstance::setUnion, METH_VARARGS, setUnion_doc},
+                              {"update", (PyCFunction)PySetInstance::setUpdate, METH_VARARGS, setUpdate_doc},
+                              {"intersection", (PyCFunction)PySetInstance::setIntersection, METH_VARARGS, setIntersection_doc},
+                              {"intersection_update", (PyCFunction)PySetInstance::setIntersectionUpdate, METH_VARARGS, setIntersectionUpdate_doc},
+                              {"difference", (PyCFunction)PySetInstance::setDifference, METH_VARARGS, setDifference_doc},
+                              {"difference_update", (PyCFunction)PySetInstance::setDifferenceUpdate, METH_VARARGS, setDifferenceUpdate_doc},
+                              {"symmetric_difference", (PyCFunction)PySetInstance::setSymmetricDifference, METH_VARARGS, setSymmetricDifference_doc},
+                              {"symmetric_difference_update", (PyCFunction)PySetInstance::setSymmetricDifferenceUpdate, METH_VARARGS, setSymmetricDifferenceUpdate_doc},
+                              {"issubset", (PyCFunction)PySetInstance::setIsSubset, METH_VARARGS, setIsSubset_doc},
+                              {"issuperset", (PyCFunction)PySetInstance::setIsSuperset, METH_VARARGS, setIsSuperset_doc},
+                              {"isdisjoint", (PyCFunction)PySetInstance::setIsDisjoint, METH_VARARGS, setIsDisjoint_doc},
+                              {NULL, NULL}};
 }

--- a/typed_python/RegisterTypes.hpp
+++ b/typed_python/RegisterTypes.hpp
@@ -1,5 +1,5 @@
 /******************************************************************************
-   Copyright 2017-2019 typed_python Authors
+   Copyright 2017-2020 typed_python Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -259,11 +259,16 @@ public:
     }
 };
 
+
+PyDoc_STRVAR(Bool_doc,
+    "Bool(x=False) -> register type for bool"
+    );
 class Bool : public RegisterType<bool> {
 public:
     Bool() : RegisterType(TypeCategory::catBool)
     {
         m_name = "bool";
+        m_doc = Bool_doc;
     }
 
     void repr(instance_ptr self, ReprAccumulator& stream, bool isStr) {
@@ -276,11 +281,15 @@ public:
     }
 };
 
+PyDoc_STRVAR(UInt8_doc,
+    "UInt8(x=0) -> register type for uint8_t"
+    );
 class UInt8 : public RegisterType<uint8_t> {
 public:
     UInt8() : RegisterType(TypeCategory::catUInt8)
     {
         m_name = "UInt8";
+        m_doc = UInt8_doc;
     }
 
     void repr(instance_ptr self, ReprAccumulator& stream, bool isStr) {
@@ -293,11 +302,15 @@ public:
     }
 };
 
+PyDoc_STRVAR(UInt16_doc,
+    "UInt16(x=0) -> register type for uint16_t"
+    );
 class UInt16 : public RegisterType<uint16_t> {
 public:
     UInt16() : RegisterType(TypeCategory::catUInt16)
     {
         m_name = "UInt16";
+        m_doc = UInt16_doc;
     }
 
     void repr(instance_ptr self, ReprAccumulator& stream, bool isStr) {
@@ -307,11 +320,15 @@ public:
     static UInt16* Make() { static UInt16* res = new UInt16(); return res; }
 };
 
+PyDoc_STRVAR(UInt32_doc,
+    "UInt32(x=0) -> register type for uint32_t"
+    );
 class UInt32 : public RegisterType<uint32_t> {
 public:
     UInt32() : RegisterType(TypeCategory::catUInt32)
     {
         m_name = "UInt32";
+        m_doc = UInt32_doc;
     }
 
     void repr(instance_ptr self, ReprAccumulator& stream, bool isStr) {
@@ -321,11 +338,15 @@ public:
     static UInt32* Make() { static UInt32* res = new UInt32(); return res; }
 };
 
+PyDoc_STRVAR(UInt64_doc,
+    "UInt64(x=0) -> register type for uint64_t"
+    );
 class UInt64 : public RegisterType<uint64_t> {
 public:
     UInt64() : RegisterType(TypeCategory::catUInt64)
     {
         m_name = "UInt64";
+        m_doc = UInt64_doc;
     }
 
     void repr(instance_ptr self, ReprAccumulator& stream, bool isStr) {
@@ -335,12 +356,16 @@ public:
     static UInt64* Make() { static UInt64* res = new UInt64(); return res; }
 };
 
+PyDoc_STRVAR(Int8_doc,
+    "Int8(x=0) -> register type for int8_t"
+    );
 class Int8 : public RegisterType<int8_t> {
 public:
     Int8() : RegisterType(TypeCategory::catInt8)
     {
         m_name = "Int8";
-        m_size = 1;
+        m_doc = Int8_doc;
+        m_size = 1; // Why only specify this here and not in other specializations?
     }
 
     void repr(instance_ptr self, ReprAccumulator& stream, bool isStr) {
@@ -350,11 +375,15 @@ public:
     static Int8* Make() { static Int8* res = new Int8(); return res; }
 };
 
+PyDoc_STRVAR(Int16_doc,
+    "Int16(x=0) -> register type for int16_t"
+    );
 class Int16 : public RegisterType<int16_t> {
 public:
     Int16() : RegisterType(TypeCategory::catInt16)
     {
         m_name = "Int16";
+        m_doc = Int16_doc;
     }
 
     void repr(instance_ptr self, ReprAccumulator& stream, bool isStr) {
@@ -364,11 +393,15 @@ public:
     static Int16* Make() { static Int16* res = new Int16(); return res; }
 };
 
+PyDoc_STRVAR(Int32_doc,
+    "Int32(x=0) -> register type for int32_t"
+    );
 class Int32 : public RegisterType<int32_t> {
 public:
     Int32() : RegisterType(TypeCategory::catInt32)
     {
         m_name = "Int32";
+        m_doc = Int32_doc;
     }
 
     void repr(instance_ptr self, ReprAccumulator& stream, bool isStr) {
@@ -378,11 +411,15 @@ public:
     static Int32* Make() { static Int32* res = new Int32(); return res; }
 };
 
+PyDoc_STRVAR(Int64_doc,
+    "Int64(x=0) -> register type for int64_t"
+    );
 class Int64 : public RegisterType<int64_t> {
 public:
     Int64() : RegisterType(TypeCategory::catInt64)
     {
         m_name = "int";
+        m_doc = Int64_doc;
     }
 
     void repr(instance_ptr self, ReprAccumulator& stream, bool isStr) {
@@ -392,11 +429,15 @@ public:
     static Int64* Make() { static Int64* res = new Int64(); return res; }
 };
 
+PyDoc_STRVAR(Float32_doc,
+    "Float32(x=0) -> register type for (C++) float"
+    );
 class Float32 : public RegisterType<float> {
 public:
     Float32() : RegisterType(TypeCategory::catFloat32)
     {
         m_name = "Float32";
+        m_doc = Float32_doc;
     }
 
     void repr(instance_ptr self, ReprAccumulator& stream, bool isStr) {
@@ -406,11 +447,15 @@ public:
     static Float32* Make() { static Float32* res = new Float32(); return res; }
 };
 
+PyDoc_STRVAR(Float64_doc,
+    "Float64(x=0) -> register type for (C++) double"
+    );
 class Float64 : public RegisterType<double> {
 public:
     Float64() : RegisterType(TypeCategory::catFloat64)
     {
         m_name = "float";
+        m_doc = Float64_doc;
     }
 
     void repr(instance_ptr self, ReprAccumulator& stream, bool isStr) {

--- a/typed_python/SetType.hpp
+++ b/typed_python/SetType.hpp
@@ -1,12 +1,38 @@
+/******************************************************************************
+   Copyright 2017-2020 typed_python Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+******************************************************************************/
+
 #pragma once
 
 #include "Type.hpp"
+
+PyDoc_STRVAR(Set_doc,
+    "Set(T)() -> empty typed set, ready to contain type T\n"
+    "Set(T)(s) -> typed set with elements of type T, initialized from set s\n"
+    "Set(T)(x) -> typed set with elements of type T, initialized from iterable x\n"
+    "\n"
+    "Raises TypeError if types don't match.\n"
+    );
 
 class SetType : public Type {
   public:
     SetType(Type* eltype)
         : Type(TypeCategory::catSet)
-        , m_key_type(eltype) {
+        , m_key_type(eltype)
+    {
+        m_doc = Set_doc;
         endOfConstructorInitialization();
     }
 

--- a/typed_python/TupleOrListOfType.hpp
+++ b/typed_python/TupleOrListOfType.hpp
@@ -192,10 +192,17 @@ protected:
     bool m_is_tuple;
 };
 
+PyDoc_STRVAR(ListOf_doc,
+    "ListOf(T)() -> empty typed list\n"
+    "ListOf(T)(lst) -> typed list containing elements of type T, initialized from list lst\n"
+    "ListOf(T)(x) -> typed list containing elements of type T, initialized from iterable x\n"
+    );
+
 class ListOfType : public TupleOrListOfType {
 public:
     ListOfType(Type* type) : TupleOrListOfType(type, false)
     {
+        m_doc = ListOf_doc;
     }
 
     static ListOfType* Make(Type* elt, ListOfType* knownType=nullptr);
@@ -314,10 +321,17 @@ public:
     }
 };
 
+PyDoc_STRVAR(TupleOf_doc,
+    "TupleOf(T)() -> empty typed tuple\n"
+    "TupleOf(T)(t) -> typed tuple containing elements of type T, initialized from tuple t\n"
+    "TupleOf(T)(x) -> typed tuple containing elements of type T, initialized from iterable x\n"
+    );
+
 class TupleOfType : public TupleOrListOfType {
 public:
     TupleOfType(Type* type) : TupleOrListOfType(type, true)
     {
+        m_doc = TupleOf_doc;
     }
 
     void _updateTypeMemosAfterForwardResolution() {

--- a/typed_python/Type.hpp
+++ b/typed_python/Type.hpp
@@ -247,6 +247,10 @@ public:
         return m_name;
     }
 
+    const char* doc() const {
+        return m_doc;
+    }
+
     size_t bytecount() const {
         return m_size;
     }
@@ -785,6 +789,7 @@ protected:
             m_size(0),
             m_is_default_constructible(false),
             m_name("Undefined"),
+            m_doc(nullptr),
             mTypeRep(nullptr),
             m_base(nullptr),
             m_is_simple(true),
@@ -807,6 +812,8 @@ protected:
     std::string m_name;
 
     mutable std::string m_stripped_name;
+
+    const char* m_doc;
 
     PyTypeObject* mTypeRep;
 

--- a/typed_python/ValueType.hpp
+++ b/typed_python/ValueType.hpp
@@ -1,5 +1,5 @@
 /******************************************************************************
-   Copyright 2017-2019 typed_python Authors
+   Copyright 2017-2020 typed_python Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -17,6 +17,10 @@
 #pragma once
 
 #include "Type.hpp"
+
+PyDoc_STRVAR(Value_doc,
+    "Value(x) -> type representing the single immutable value x"
+    );
 
 class Value : public Type {
 public:
@@ -119,6 +123,7 @@ private:
         m_size = 0;
         m_is_default_constructible = true;
         m_name = mInstance.repr();
+        m_doc = Value_doc;
 
         endOfConstructorInitialization(); // finish initializing the type object.
     }

--- a/typed_python/_runtime.cpp
+++ b/typed_python/_runtime.cpp
@@ -226,11 +226,23 @@ extern "C" {
     }
 
     double np_cosh_float64(double d) {
-        return std::cosh(d);
+        double ret = std::cosh(d);
+        if (std::isinf(ret)) {
+            PyEnsureGilAcquired getTheGil;
+            PyErr_Format(PyExc_OverflowError, "math range error");
+            throw PythonExceptionSet();
+        }
+        return ret;
     }
 
     float np_cosh_float32(float f) {
-        return std::cosh(f);
+        float ret = std::cosh(f);
+        if (std::isinf(ret)) {
+            PyEnsureGilAcquired getTheGil;
+            PyErr_Format(PyExc_OverflowError, "math range error");
+            throw PythonExceptionSet();
+        }
+        return ret;
     }
 
     double np_erf_float64(double d) {
@@ -250,11 +262,23 @@ extern "C" {
     }
 
     double np_expm1_float64(double d) {
-        return std::expm1(d);
+        double ret = std::expm1(d);
+        if (std::isinf(ret)) {
+            PyEnsureGilAcquired getTheGil;
+            PyErr_Format(PyExc_OverflowError, "math range error");
+            throw PythonExceptionSet();
+        }
+        return ret;
     }
 
     float np_expm1_float32(float f) {
-        return std::expm1(f);
+        float ret = std::expm1(f);
+        if (std::isinf(ret)) {
+            PyEnsureGilAcquired getTheGil;
+            PyErr_Format(PyExc_OverflowError, "math range error");
+            throw PythonExceptionSet();
+        }
+        return ret;
     }
 
     // d = 171.0 will overflow 64-bit float, so could replace this calculation with a table lookup
@@ -334,11 +358,23 @@ extern "C" {
     }
 
     double np_gamma_float64(double d) {
-        return std::tgamma(d);
+        double ret = std::tgamma(d);
+        if (std::isinf(ret)) {
+            PyEnsureGilAcquired getTheGil;
+            PyErr_Format(PyExc_OverflowError, "math range error");
+            throw PythonExceptionSet();
+        }
+        return ret;
     }
 
     float np_gamma_float32(float f) {
-        return std::tgamma(f);
+        float ret = std::tgamma(f);
+        if (std::isinf(ret)) {
+            PyEnsureGilAcquired getTheGil;
+            PyErr_Format(PyExc_OverflowError, "math range error");
+            throw PythonExceptionSet();
+        }
+        return ret;
     }
 
     uint64_t np_gcd(uint64_t i1, uint64_t i2) {
@@ -2288,6 +2324,155 @@ extern "C" {
         return res;
     }
 
+    double np_pyobj_ceil(PythonObjectOfType::layout_type* obj) {
+        PyEnsureGilAcquired acquireTheGil;
+        if (PyFloat_Check(obj->pyObj)) {
+            double val = PyFloat_AsDouble(obj->pyObj);
+            if (val == -1.0 && PyErr_Occurred()) {
+                throw PythonExceptionSet();
+            }
+            return ceil(val);
+        }
+
+        if (!PyObject_HasAttrString(obj->pyObj, "__ceil__")) {
+            PyObjectHolder floatObj(PyObject_CallMethod(obj->pyObj, "__float__", NULL));
+            if ((PyObject*)floatObj) {
+                double val = PyFloat_AsDouble(floatObj);
+                if (val == -1.0 && PyErr_Occurred()) {
+                    throw PythonExceptionSet();
+                }
+                return ceil(val);
+             }
+             PyErr_Format(PyExc_TypeError, "'%s' object has no attribute __ceil__", Py_TYPE(obj->pyObj)->tp_name);
+             throw PythonExceptionSet();
+        }
+
+        PyObjectHolder retObj(PyObject_CallMethod(obj->pyObj, "__ceil__", NULL));
+        double ret;
+
+        // This is an additional condition.  Python does not have this condition (__ceil__ does not have to return a number).
+        if (PyFloat_Check(retObj)) {
+            ret = PyFloat_AsDouble(retObj);
+        }
+        else if (PyLong_Check(retObj)) {
+             ret = (double)PyLong_AsLong(retObj);
+        }
+        else {
+            PyObjectHolder floatObj(PyObject_CallMethod(retObj, "__float__", NULL));
+            if (floatObj) {
+                ret = PyFloat_AsDouble(floatObj);
+            }
+            else {
+                PyErr_SetString(PyExc_TypeError, "__ceil__ returned non-number");
+                throw PythonExceptionSet();
+            }
+        }
+        if (ret == -1.0 && PyErr_Occurred()) {
+            throw PythonExceptionSet();
+        }
+        return ret;
+    }
+
+    double np_pyobj_floor(PythonObjectOfType::layout_type* obj) {
+        PyEnsureGilAcquired acquireTheGil;
+        if (PyFloat_Check(obj->pyObj)) {
+            double val = PyFloat_AsDouble(obj->pyObj);
+            if (val == -1.0 && PyErr_Occurred()) {
+                throw PythonExceptionSet();
+            }
+            return floor(val);
+        }
+
+        if (!PyObject_HasAttrString(obj->pyObj, "__floor__")) {
+            PyObjectHolder floatObj(PyObject_CallMethod(obj->pyObj, "__float__", NULL));
+            if ((PyObject*)floatObj) {
+                double val = PyFloat_AsDouble(floatObj);
+                if (val == -1.0 && PyErr_Occurred()) {
+                    throw PythonExceptionSet();
+                }
+                return floor(val);
+             }
+             PyErr_Format(PyExc_TypeError, "'%s' object has no attribute __floor__", Py_TYPE(obj->pyObj)->tp_name);
+             throw PythonExceptionSet();
+        }
+
+        PyObjectHolder retObj(PyObject_CallMethod(obj->pyObj, "__floor__", NULL));
+        double ret;
+
+        // This is an additional condition.  Python does not have this condition (__floor__ does not have to return a number).
+        if (PyFloat_Check(retObj)) {
+            ret = PyFloat_AsDouble(retObj);
+        }
+        else if (PyLong_Check(retObj)) {
+             ret = (double)PyLong_AsLong(retObj);
+        }
+        else {
+            PyObjectHolder floatObj(PyObject_CallMethod(retObj, "__float__", NULL));
+            if (floatObj) {
+                ret = PyFloat_AsDouble(floatObj);
+            }
+            else {
+                PyErr_SetString(PyExc_TypeError, "__floor__ returned non-number");
+                throw PythonExceptionSet();
+            }
+        }
+        if (ret == -1.0 && PyErr_Occurred()) {
+            throw PythonExceptionSet();
+        }
+        return ret;
+    }
+
+    double np_pyobj_trunc(PythonObjectOfType::layout_type* obj) {
+        PyEnsureGilAcquired acquireTheGil;
+        if (PyFloat_Check(obj->pyObj)) {
+            double val = PyFloat_AsDouble(obj->pyObj);
+            if (val == -1.0 && PyErr_Occurred()) {
+                throw PythonExceptionSet();
+            }
+            return trunc(val);
+        }
+
+        if (PyLong_Check(obj->pyObj)) {
+            long val = PyLong_AsLong(obj->pyObj);
+            if (val == -1 && PyErr_Occurred()) {
+                throw PythonExceptionSet();
+            }
+            return double(val);
+        }
+
+        if (!PyObject_HasAttrString(obj->pyObj, "__trunc__")) {
+            // unlike the others, __trunc__ doesn't devolve to __float__
+            PyErr_Format(PyExc_TypeError, "type %s doesn't define __trunc__ method", Py_TYPE(obj->pyObj)->tp_name);
+            throw PythonExceptionSet();
+        }
+
+        PyObjectHolder retObj(PyObject_CallMethod(obj->pyObj, "__trunc__", NULL));
+        double ret;
+
+        // This is an additional condition.  Python does not have this condition (__trunc__ does not have to return a number).
+        if (PyFloat_Check(retObj)) {
+            ret = PyFloat_AsDouble(retObj);
+        }
+        else if (PyLong_Check(retObj)) {
+             ret = (double)PyLong_AsLong(retObj);
+        }
+        else {
+            PyObjectHolder floatObj(PyObject_CallMethod(retObj, "__float__", NULL));
+            if (floatObj) {
+                ret = PyFloat_AsDouble(floatObj);
+            }
+            else {
+                PyErr_SetString(PyExc_TypeError, "__trunc__ returned non-number");
+                throw PythonExceptionSet();
+            }
+        }
+        if (ret == -1.0 && PyErr_Occurred()) {
+            throw PythonExceptionSet();
+        }
+        return ret;
+    }
+
+
     // this struct is defined in threadmodule.c - so it's internal to python itself,
     // but because we want to bypass the GIL, we'll just read from the corresponding
     // PyObject* knowing its structure.
@@ -2447,7 +2632,7 @@ extern "C" {
         PyEnsureGilAcquired getTheGil;
 
         double res = PyFloat_AsDouble(obj->pyObj);
-        if (PyErr_Occurred()) {
+        if (res == -1.0 && PyErr_Occurred()) {
             throw PythonExceptionSet();
         }
         return res;
@@ -2457,7 +2642,7 @@ extern "C" {
         PyEnsureGilAcquired getTheGil;
 
         int64_t res = PyLong_AsLong(obj->pyObj);
-        if (PyErr_Occurred()) {
+        if (res == -1 && PyErr_Occurred()) {
             throw PythonExceptionSet();
         }
         return res;

--- a/typed_python/compiler/tests/dict_compilation_test.py
+++ b/typed_python/compiler/tests/dict_compilation_test.py
@@ -773,3 +773,21 @@ class TestDictCompilation(unittest.TestCase):
         setIt(aDict, set([1]))
 
         assert len(aDict[10]) == 1
+
+    def test_dict_compiled_equality_with_python_and_object(self):
+        def f_compare(x, y):
+            return x == y
+
+        c_compare = Entrypoint(f_compare)
+
+        cases = [
+            (Dict(int, object), {1: 2}),
+            (Dict(int, object), {1: (7, 8, 9)}),
+            (Dict(int, object), {1: 'one'})
+        ]
+
+        for T, v in cases:
+            r1 = f_compare(T(v), v)
+            r2 = c_compare(T(v), v)
+            self.assertEqual(r2, True)
+            self.assertEqual(r1, r2)

--- a/typed_python/compiler/tests/math_functions_compilation_test.py
+++ b/typed_python/compiler/tests/math_functions_compilation_test.py
@@ -33,6 +33,13 @@ def compiledHash(x):
     return hash(x)
 
 
+def callOrExceptType(f, *args):
+    try:
+        return ("Normal", f(*args))
+    except Exception as e:
+        return ("Exception", str(type(e)))
+
+
 class TestMathFunctionsCompilation(unittest.TestCase):
     def test_entrypoint_overrides(self):
         @Entrypoint
@@ -470,8 +477,9 @@ class TestMathFunctionsCompilation(unittest.TestCase):
             compiled = Entrypoint(mathFun)
             self.assertEqual(compiled.resultTypeFor(float, int).typeRepresentation, float)
             self.assertEqual(compiled.resultTypeFor(Float32, int).typeRepresentation, Float32)
-            self.assertEqual(compiled.resultTypeFor(float, Int32).typeRepresentation, float)
-            self.assertEqual(compiled.resultTypeFor(Float32, Int32).typeRepresentation, Float32)
+            # If 2nd parameter is not int, expect to raise TypeError, not return float or Float32
+            # self.assertEqual(compiled.resultTypeFor(float, Int32).typeRepresentation, float)
+            # self.assertEqual(compiled.resultTypeFor(Float32, Int32).typeRepresentation, Float32)
 
             for v1 in [-123.45, -2.0, -1.0, -0.999, -0.7, -0.5, 0.0, 0.5, 0.7, 0.999, 1.0, 2.0, 123.45]:
                 for v2 in range(-10, 10):
@@ -481,7 +489,7 @@ class TestMathFunctionsCompilation(unittest.TestCase):
                     self.assertEqual(r1, r2, (mathFun, v1, v2))
 
                     r3 = Float32(r1)
-                    r4 = compiled(Float32(v1), Float32(v2))
+                    r4 = compiled(Float32(v1), v2)
                     self.assertEqual(r3, r4, (mathFun, v1, v2))
 
     def test_math_fsum(self):
@@ -630,3 +638,193 @@ class TestMathFunctionsCompilation(unittest.TestCase):
 
                 del f
                 del g
+
+    def test_math_functions_on_object(self):
+        class ClassCeil:
+            def __ceil__(self):
+                return 123.45
+
+        class ClassFloor:
+            def __floor__(self):
+                return 123.45
+
+        class ClassTrunc:
+            def __trunc__(self):
+                return 123
+
+        class ClassFloat:
+            def __float__(self):
+                return 1.24
+
+        class ClassInt:
+            def __int__(self):
+                return 13
+
+        class ClassIndex:
+            def __index__(self):
+                return 17
+
+        class ClassCeilFloat:
+            def __ceil__(self):
+                return 1.23
+
+            def __float__(self):
+                return 1.24
+
+        def f_ceil(t: object):
+            return math.ceil(t)
+
+        def f_floor(t: object):
+            return math.floor(t)
+
+        def f_trunc(t: object):
+            return math.trunc(t)
+
+        def f_acos(t: object):
+            return math.acos(t)
+
+        def f_acosh(t: object):
+            return math.acosh(t)
+
+        def f_asin(t: object):
+            return math.asin(t)
+
+        def f_asinh(t: object):
+            return math.asinh(t)
+
+        def f_atan(t: object):
+            return math.atan(t)
+
+        def f_atan2(t: object):
+            return math.atan2(t, t)
+
+        def f_atanh(t: object):
+            return math.atanh(t)
+
+        def f_copysign(t: object):
+            return math.copysign(t, t)
+
+        def f_cos(t: object):
+            return math.cos(t)
+
+        def f_cosh(t: object):
+            return math.cosh(t)
+
+        def f_degrees(t: object):
+            return math.degrees(t)
+
+        def f_erf(t: object):
+            return math.erf(t)
+
+        def f_erfc(t: object):
+            return math.erfc(t)
+
+        def f_exp(t: object):
+            return math.exp(t)
+
+        def f_expm1(t: object):
+            return math.expm1(t)
+
+        def f_fabs(t: object):
+            return math.fabs(t)
+
+        def f_fmod(t: object):
+            return math.fmod(t, t)
+
+        def f_frexp(t: object):
+            x = math.frexp(t)
+            return x[0] + x[1]
+
+        def f_fsum(t: object):
+            return math.fsum([t, t, t])
+
+        def f_gamma(t: object):
+            return math.gamma(t)
+
+        def f_gcd(t: object):
+            return math.gcd(t, t)
+
+        def f_hypot(t: object):
+            return math.hypot(t, t)
+
+        def f_isclose(t: object):
+            return math.isclose(t, t)
+
+        def f_isfinite(t: object):
+            return math.isfinite(t)
+
+        def f_isinf(t: object):
+            return math.isinf(t)
+
+        def f_isnan(t: object):
+            return math.isnan(t)
+
+        def f_ldexp1(t: object):
+            return math.ldexp(t, 5)
+
+        def f_ldexp2(t: object):
+            return math.ldexp(2.0, t)
+
+        def f_lgamma(t: object):
+            return math.lgamma(t)
+
+        def f_log(t: object):
+            return math.log(t)
+
+        def f_log10(t: object):
+            return math.log10(t)
+
+        def f_log1p(t: object):
+            return math.log1p(t)
+
+        def f_log2(t: object):
+            return math.log2(t)
+
+        def f_modf(t: object):
+            return math.modf(t)
+
+        def f_pow(t: object):
+            return math.pow(t, t)
+
+        def f_radians(t: object):
+            return math.radians(t)
+
+        def f_sin(t: object):
+            return math.sin(t)
+
+        def f_sinh(t: object):
+            return math.sinh(t)
+
+        def f_sqrt(t: object):
+            return math.sqrt(t)
+
+        def f_tan(t: object):
+            return math.tan(t)
+
+        def f_tanh(t: object):
+            return math.tanh(t)
+
+        self.assertEqual(Entrypoint(f_ceil)(1.5), 2.0)
+        self.assertEqual(Entrypoint(f_sin)(0.0), 0.0)
+
+        fns = [f_trunc, f_ceil, f_floor, f_acos, f_acosh, f_asin, f_asinh, f_atan, f_atan2, f_atanh, f_copysign,
+               f_cos, f_cosh, f_degrees, f_erf, f_erfc, f_exp, f_expm1, f_fabs, f_fmod, f_frexp, f_fsum, f_gamma, f_gcd,
+               f_hypot, f_isclose, f_isfinite, f_isinf, f_isnan, f_ldexp1, f_ldexp2, f_lgamma, f_log, f_log10, f_log1p,
+               f_log2, f_modf, f_pow, f_radians, f_sin, f_sinh, f_sqrt, f_tan, f_tanh]
+        values = [
+            0, 0.5, -0.5, 1.0, -1.0, 7, -7, 1e100, -1e100,
+            ClassCeil(), ClassFloor(), ClassTrunc(), ClassFloat(), ClassInt(), ClassIndex(), ClassCeilFloat(),
+            Int32(0), Float32(0.5), None, set()
+        ]
+        for f in fns:
+            c_f = Entrypoint(f)
+            for v in values:
+                r1 = callOrExceptType(f, v)
+                r2 = callOrExceptType(c_f, v)
+                if r1[0] == 'Normal' and r2[0] == 'Normal' and isinstance(r1[1], (float, int)):
+                    if r1[1] == 0.0:
+                        self.assertLess(abs(r2[1] - r1[1]), 1e-10, (f, v))
+                    else:
+                        self.assertLess(abs((r2[1] - r1[1]) / r1[1]), 1e-10, (f, v))
+                else:
+                    self.assertEqual(r1, r2, (f, v))

--- a/typed_python/compiler/type_wrappers/math_wrappers.py
+++ b/typed_python/compiler/type_wrappers/math_wrappers.py
@@ -138,71 +138,60 @@ class MathFunctionWrapper(Wrapper):
         return native_ast.Type.Void()
 
     def convert_call(self, context, expr, args, kwargs):
-        if len(args) == 2 and not kwargs and self.typeRepresentation is ldexp:
+        # Set check_inf to generate a check for an infinite result that generates an Overflow exception.
+        # This is only needed for the few operations that are compiled directly to llvm intrinsic functions.
+        check_inf = False
+
+        if self.typeRepresentation is ldexp and len(args) == 2 and not kwargs:
             arg1 = args[0]
-            if not arg1.expr_type.is_arithmetic:
-                return context.pushException(TypeError, f"must be a real number, not {arg1.expr_type}")
             arg2 = args[1]
-            if not arg2.expr_type.is_arithmetic:
-                return context.pushException(TypeError, "Expected an int as second argument to ldexp.")
+
             argType1 = arg1.expr_type.typeRepresentation
             argType2 = arg2.expr_type.typeRepresentation
+
             if argType1 not in (Float32, float):
-                arg1 = arg1.toFloat64()
+                arg1 = arg1.convert_to_type(float, ConversionLevel.Implicit)
+                argType1 = float
+
                 if arg1 is None:
                     return None
-                argType1 = float
-            if argType2 not in (int,):
-                arg2 = arg2.toInt64()
-                if arg2 is None:
-                    return context.pushException(TypeError, "Expected an int as second argument to ldexp.")
-            # argType2 == int
+
+            arg2 = arg2.convert_to_type(int, ConversionLevel.Implicit)
+            if arg2 is None:
+                return None
+
             outT = argType1
             func = runtime_functions.ldexp32 if argType1 is Float32 else runtime_functions.ldexp64
             return context.pushPod(outT, func.call(arg1.nonref_expr, arg2.nonref_expr))
 
-        if len(args) == 2 and not kwargs and self.typeRepresentation is gcd:
+        if self.typeRepresentation is gcd and len(args) == 2 and not kwargs:
             arg1 = args[0]
             arg2 = args[1]
-            argType1 = arg1.expr_type.typeRepresentation
-            argType2 = arg2.expr_type.typeRepresentation
-            if argType1 in (Float32, float) or not arg1.expr_type.is_arithmetic:
-                return context.pushException(ValueError, f"'{argType1}' object cannot be interpreted as an integer")
-            if argType2 in (Float32, float) or not arg2.expr_type.is_arithmetic:
-                return context.pushException(ValueError, f"'{argType2}' object cannot be interpreted as an integer")
-            arg1 = arg1.convert_abs()
-            if arg1 is None:
+
+            # gcd uses __index__, not __int__, to process integer arguments
+            arg1 = arg1.toIndex()
+            arg2 = arg2.toIndex()
+
+            if arg1 is None or arg2 is None:
                 return None
-            arg1 = arg1.convert_to_type(UInt64, ConversionLevel.Implicit)
-            if arg1 is None:
-                return None
-            arg2 = arg2.convert_abs()
-            if arg2 is None:
-                return None
-            arg2 = arg2.convert_to_type(UInt64, ConversionLevel.Implicit)
-            if arg2 is None:
-                return None
+
+            arg1 = arg1.convert_abs().convert_to_type(UInt64)
+            arg2 = arg2.convert_abs().convert_to_type(UInt64)
             return context.pushPod(UInt64, runtime_functions.gcd.call(arg1.nonref_expr, arg2.nonref_expr))
 
-        if len(args) == 2 and (not kwargs or self.typeRepresentation is isclose):
+        # this block is for methods with 2 parameters
+        if (not kwargs or self.typeRepresentation is isclose) and len(args) == 2:
             arg1 = args[0]
-            if not arg1.expr_type.is_arithmetic:
-                return context.pushException(TypeError, f"must be a real number, not {arg1.expr_type}")
             arg2 = args[1]
-            if not arg2.expr_type.is_arithmetic:
-                return context.pushException(TypeError, f"must be a real number, not {arg2.expr_type}")
+
+            if not arg1.expr_type.is_arithmetic or arg1.expr_type.typeRepresentation not in (Float32, float):
+                arg1 = arg1.toFloat64()
+            if not arg2.expr_type.is_arithmetic or arg2.expr_type.typeRepresentation not in (Float32, float):
+                arg2 = arg2.toFloat64()
+
             argType1 = arg1.expr_type.typeRepresentation
             argType2 = arg2.expr_type.typeRepresentation
-            if argType1 not in (Float32, float):
-                arg1 = arg1.toFloat64()
-                if arg1 is None:
-                    return None
-                argType1 = float
-            if argType2 not in (Float32, float):
-                arg2 = arg2.toFloat64()
-                if arg2 is None:
-                    return None
-                argType2 = float
+
             if argType1 == Float32 and argType2 == float:
                 arg1 = arg1.toFloat64()
                 argType1 = float
@@ -219,7 +208,7 @@ class MathFunctionWrapper(Wrapper):
             elif self.typeRepresentation is fmod:
                 with context.ifelse(arg2.nonref_expr.eq(0.0)) as (ifTrue, ifFalse):
                     with ifTrue:
-                        context.pushException(ValueError, "math domain error")
+                        context.pushException(ValueError, 'math domain error')
                 func = runtime_functions.fmod32 if argType1 is Float32 else runtime_functions.fmod64
             elif self.typeRepresentation is hypot:
                 # calculate this one directly
@@ -228,17 +217,13 @@ class MathFunctionWrapper(Wrapper):
             elif self.typeRepresentation is isclose:
                 func = runtime_functions.isclose32 if argType1 is Float32 else runtime_functions.isclose64
 
-                if "rel_tol" in kwargs:
-                    rel_tol = kwargs["rel_tol"].convert_to_type(argType1, ConversionLevel.Implicit)
-                    if rel_tol is None:
-                        return None
+                if 'rel_tol' in kwargs:
+                    rel_tol = kwargs['rel_tol'].convert_to_type(argType1)
                 else:
                     rel_tol = native_ast.const_float32_expr(1e-5) if argType1 is Float32 else native_ast.const_float_expr(1e-9)
 
-                if "abs_tol" in kwargs:
-                    abs_tol = kwargs["abs_tol"].convert_to_type(argType1, ConversionLevel.Implicit)
-                    if abs_tol is None:
-                        return None
+                if 'abs_tol' in kwargs:
+                    abs_tol = kwargs['abs_tol'].convert_to_type(argType1)
                 else:
                     abs_tol = native_ast.const_float32_expr(0.0) if argType1 is Float32 else native_ast.const_float_expr(0.0)
 
@@ -251,32 +236,33 @@ class MathFunctionWrapper(Wrapper):
                             with ifTrue2:  # arg1 == 0
                                 with context.ifelse(arg2.nonref_expr.lt(0.0)) as (ifTrue3, ifFalse3):
                                     with ifTrue3:  # arg1 == 0, arg2 < 0
-                                        context.pushException(ValueError, "math domain error")
+                                        context.pushException(ValueError, 'math domain error')
                             with ifFalse2:  # arg1 < 0
                                 with context.ifelse(f_func.call(arg2.nonref_expr).sub(arg2.nonref_expr).eq(0.0)) as (ifTrue4, ifFalse4):
                                     with ifFalse4:  # arg1 < 0, arg2 not an integer
                                         context.pushException(ValueError, "math domain error")
                 func = runtime_functions.pow32 if argType1 is Float32 else runtime_functions.pow64
+                check_inf = True
             else:
                 assert False, "Unreachable"
 
-            return context.pushPod(outT, func.call(arg1.nonref_expr, arg2.nonref_expr))
+            ret = context.pushPod(outT, func.call(arg1.nonref_expr, arg2.nonref_expr))
+            if check_inf:
+                f_isfinite = runtime_functions.isfinite_float32 if outT is Float32 else runtime_functions.isfinite_float64
+                with context.ifelse(f_isfinite.call(ret.nonref_expr)) as (ifTrue, ifFalse):
+                    with ifFalse:
+                        context.pushException(OverflowError, 'math range error')
+            return ret
 
         # handle integer factorial here
         if len(args) == 1 and not kwargs and self.typeRepresentation is factorial:
             arg = args[0]
-            if not arg.expr_type.is_arithmetic:
-                return context.pushException(TypeError, f"must be a real number, not {arg.expr_type}")
-
             argType = arg.expr_type.typeRepresentation
             if argType not in (Float32, float):
-                if argType not in (int,):
-                    arg = arg.convert_to_type(int, ConversionLevel.New)
-                    if arg is None:
-                        return None
+                arg = arg.toInt64()
                 with context.ifelse(arg.nonref_expr.lt(0)) as (ifTrue, ifFalse):
                     with ifTrue:
-                        context.pushException(ValueError, "factorial() not defined for negative values")
+                        context.pushException(ValueError, 'factorial() not defined for negative values')
                 return context.pushPod(int, runtime_functions.factorial.call(arg.nonref_expr))
             # let Float32 and float args fall through to later section, which will handle float factorials
 
@@ -284,11 +270,11 @@ class MathFunctionWrapper(Wrapper):
             arg = args[0]
             return context.call_py_function(sumIterable, (arg,), {})
 
+        # this block is for all other methods with one parameter
         if len(args) == 1 and not kwargs:
             arg = args[0]
             if not arg.expr_type.is_arithmetic:
-                return context.pushException(TypeError, f"must be a real number, not {arg.expr_type}")
-
+                arg = arg.toFloat64()
             argType = arg.expr_type.typeRepresentation
 
             if argType not in (Float32, float):
@@ -306,23 +292,23 @@ class MathFunctionWrapper(Wrapper):
             if self.typeRepresentation is acos:
                 with context.ifelse(arg.nonref_expr.gt(1.0)) as (ifTrue, ifFalse):
                     with ifTrue:
-                        context.pushException(ValueError, "math domain error")
+                        context.pushException(ValueError, 'math domain error')
                 with context.ifelse(arg.nonref_expr.lt(-1.0)) as (ifTrue, ifFalse):
                     with ifTrue:
-                        context.pushException(ValueError, "math domain error")
+                        context.pushException(ValueError, 'math domain error')
                 func = runtime_functions.acos32 if argType is Float32 else runtime_functions.acos64
             elif self.typeRepresentation is acosh:
                 with context.ifelse(arg.nonref_expr.lt(1.0)) as (ifTrue, ifFalse):
                     with ifTrue:
-                        context.pushException(ValueError, "math domain error")
+                        context.pushException(ValueError, 'math domain error')
                 func = runtime_functions.acosh32 if argType is Float32 else runtime_functions.acosh64
             elif self.typeRepresentation is asin:
                 with context.ifelse(arg.nonref_expr.gt(1.0)) as (ifTrue, ifFalse):
                     with ifTrue:
-                        context.pushException(ValueError, "math domain error")
+                        context.pushException(ValueError, 'math domain error')
                 with context.ifelse(arg.nonref_expr.lt(-1.0)) as (ifTrue, ifFalse):
                     with ifTrue:
-                        context.pushException(ValueError, "math domain error")
+                        context.pushException(ValueError, 'math domain error')
                 func = runtime_functions.asin32 if argType is Float32 else runtime_functions.asin64
             elif self.typeRepresentation is asinh:
                 func = runtime_functions.asinh32 if argType is Float32 else runtime_functions.asinh64
@@ -331,10 +317,10 @@ class MathFunctionWrapper(Wrapper):
             elif self.typeRepresentation is atanh:
                 with context.ifelse(arg.nonref_expr.gte(1.0)) as (ifTrue, ifFalse):
                     with ifTrue:
-                        context.pushException(ValueError, "math domain error")
+                        context.pushException(ValueError, 'math domain error')
                 with context.ifelse(arg.nonref_expr.lte(-1.0)) as (ifTrue, ifFalse):
                     with ifTrue:
-                        context.pushException(ValueError, "math domain error")
+                        context.pushException(ValueError, 'math domain error')
                 func = runtime_functions.atanh32 if argType is Float32 else runtime_functions.atanh64
             elif self.typeRepresentation is ceil:
                 func = runtime_functions.ceil32 if argType is Float32 else runtime_functions.ceil64
@@ -353,6 +339,7 @@ class MathFunctionWrapper(Wrapper):
                 func = runtime_functions.erfc32 if argType is Float32 else runtime_functions.erfc64
             elif self.typeRepresentation is exp:
                 func = runtime_functions.exp32 if argType is Float32 else runtime_functions.exp64
+                check_inf = True
             elif self.typeRepresentation is expm1:
                 func = runtime_functions.expm1_32 if argType is Float32 else runtime_functions.expm1_64
             elif self.typeRepresentation is fabs:
@@ -363,25 +350,25 @@ class MathFunctionWrapper(Wrapper):
                     with ifTrue:  # arg >= 0
                         with context.ifelse(f_func.call(arg.nonref_expr).sub(arg.nonref_expr).neq(0.0)) as (ifTrue2, ifFalse2):
                             with ifTrue2:  # arg >= 0, arg not an integer
-                                context.pushException(ValueError, "factorial() only accepts integral values")
+                                context.pushException(ValueError, 'factorial() only accepts integral values')
                     with ifFalse:  # arg < 0
-                        context.pushException(ValueError, "factorial() not defined for negative values")
+                        context.pushException(ValueError, 'factorial() not defined for negative values')
                 func = runtime_functions.factorial32 if argType is Float32 else runtime_functions.factorial64
             elif self.typeRepresentation is floor:
                 func = runtime_functions.floor32 if argType is Float32 else runtime_functions.floor64
             elif self.typeRepresentation is frexp:
                 outT = MasqueradingTupleWrapper(Tuple(argType, int))
-                return_tuple = native_ast.Expression.StackSlot(name=".return_tuple", type=outT.layoutType)
+                return_tuple = native_ast.Expression.StackSlot(name='.return_tuple', type=outT.layoutType)
                 func = runtime_functions.frexp32 if argType is Float32 else runtime_functions.frexp64
                 context.pushEffect(func.call(arg.nonref_expr, return_tuple.elemPtr(0).cast(native_ast.VoidPtr)))
-                return typed_python.compiler.typed_expression.TypedExpression(self, return_tuple, outT, True)
+                return typed_python.compiler.typed_expression.TypedExpression(context, return_tuple, outT, True)
             elif self.typeRepresentation is gamma:
                 f_func = runtime_functions.floor32 if argType is Float32 else runtime_functions.floor64
                 with context.ifelse(arg.nonref_expr.lte(0.0)) as (ifTrue, ifFalse):
                     with ifTrue:  # arg <= 0
                         with context.ifelse(f_func.call(arg.nonref_expr).sub(arg.nonref_expr).eq(0.0)) as (ifTrue2, ifFalse2):
                             with ifTrue2:  # arg <= 0, arg an integer
-                                context.pushException(ValueError, "math domain error")
+                                context.pushException(ValueError, 'math domain error')
                 func = runtime_functions.gamma32 if argType is Float32 else runtime_functions.gamma64
             elif self.typeRepresentation is isnan:
                 func = runtime_functions.isnan_float32 if argType is Float32 else runtime_functions.isnan_float64
@@ -398,27 +385,27 @@ class MathFunctionWrapper(Wrapper):
                     with ifTrue:  # arg <= 0
                         with context.ifelse(f_func.call(arg.nonref_expr).sub(arg.nonref_expr).eq(0.0)) as (ifTrue2, ifFalse2):
                             with ifTrue2:  # arg <= 0, arg an integer
-                                context.pushException(ValueError, "math domain error")
+                                context.pushException(ValueError, 'math domain error')
                 func = runtime_functions.lgamma32 if argType is Float32 else runtime_functions.lgamma64
             elif self.typeRepresentation is log:
                 with context.ifelse(arg.nonref_expr.gt(0.0)) as (ifTrue, ifFalse):
                     with ifFalse:  # arg <= 0
-                        context.pushException(ValueError, "math domain error")
+                        context.pushException(ValueError, 'math domain error')
                 func = runtime_functions.log32 if argType is Float32 else runtime_functions.log64
             elif self.typeRepresentation is log1p:
                 with context.ifelse(arg.nonref_expr.gt(-1.0)) as (ifTrue, ifFalse):
                     with ifFalse:  # arg <= -1
-                        context.pushException(ValueError, "math domain error")
+                        context.pushException(ValueError, 'math domain error')
                 func = runtime_functions.log1p32 if argType is Float32 else runtime_functions.log1p64
             elif self.typeRepresentation is log2:
                 with context.ifelse(arg.nonref_expr.gt(0.0)) as (ifTrue, ifFalse):
                     with ifFalse:  # arg <= 0
-                        context.pushException(ValueError, "math domain error")
+                        context.pushException(ValueError, 'math domain error')
                 func = runtime_functions.log2_32 if argType is Float32 else runtime_functions.log2_64
             elif self.typeRepresentation is log10:
                 with context.ifelse(arg.nonref_expr.gt(0.0)) as (ifTrue, ifFalse):
                     with ifFalse:
-                        context.pushException(ValueError, "math domain error")
+                        context.pushException(ValueError, 'math domain error')
                 func = runtime_functions.log10_32 if argType is Float32 else runtime_functions.log10_64
             elif self.typeRepresentation is radians:
                 if argType is Float32:
@@ -427,18 +414,19 @@ class MathFunctionWrapper(Wrapper):
                     return context.pushPod(outT, arg.nonref_expr.mul(native_ast.const_float_expr(pi / 180)))
             elif self.typeRepresentation is modf:
                 outT = MasqueradingTupleWrapper(Tuple(argType, argType))
-                return_tuple = native_ast.Expression.StackSlot(name=".return_tuple", type=outT.layoutType)
+                return_tuple = native_ast.Expression.StackSlot(name='.return_tuple', type=outT.layoutType)
                 func = runtime_functions.modf32 if argType is Float32 else runtime_functions.modf64
                 context.pushEffect(func.call(arg.nonref_expr, return_tuple.elemPtr(0).cast(native_ast.VoidPtr)))
-                return typed_python.compiler.typed_expression.TypedExpression(self, return_tuple, outT, True)
+                return typed_python.compiler.typed_expression.TypedExpression(context, return_tuple, outT, True)
             elif self.typeRepresentation is sin:
                 func = runtime_functions.sin32 if argType is Float32 else runtime_functions.sin64
             elif self.typeRepresentation is sinh:
                 func = runtime_functions.sinh32 if argType is Float32 else runtime_functions.sinh64
+                check_inf = True
             elif self.typeRepresentation is sqrt:
                 with context.ifelse(arg.nonref_expr.gte(0.0)) as (ifTrue, ifFalse):
                     with ifFalse:  # arg < 0
-                        context.pushException(ValueError, "math domain error")
+                        context.pushException(ValueError, 'math domain error')
                 func = runtime_functions.sqrt32 if argType is Float32 else runtime_functions.sqrt64
             elif self.typeRepresentation is tan:
                 func = runtime_functions.tan32 if argType is Float32 else runtime_functions.tan64
@@ -447,8 +435,14 @@ class MathFunctionWrapper(Wrapper):
             elif self.typeRepresentation is trunc:
                 func = runtime_functions.trunc32 if argType is Float32 else runtime_functions.trunc64
             else:
-                assert False, "Unreachable"
+                assert False, 'Unreachable'
 
-            return context.pushPod(outT, func.call(arg.nonref_expr))
+            ret = context.pushPod(outT, func.call(arg.nonref_expr))
+            if check_inf:
+                f_isfinite = runtime_functions.isfinite_float32 if outT is Float32 else runtime_functions.isfinite_float64
+                with context.ifelse(f_isfinite.call(ret.nonref_expr)) as (ifTrue, ifFalse):
+                    with ifFalse:
+                        context.pushException(OverflowError, 'math range error')
+            return ret
 
         return super().convert_call(context, expr, args, kwargs)

--- a/typed_python/compiler/type_wrappers/python_object_of_type_wrapper.py
+++ b/typed_python/compiler/type_wrappers/python_object_of_type_wrapper.py
@@ -23,6 +23,7 @@ import typed_python.compiler.native_ast as native_ast
 from typed_python.compiler.native_ast import VoidPtr, UInt64
 import typed_python
 import typed_python.compiler.type_wrappers.runtime_functions as runtime_functions
+from math import trunc, floor, ceil
 
 
 typeWrapper = lambda t: typed_python.compiler.python_object_representation.typedPythonTypeToTypeWrapper(t)
@@ -232,6 +233,15 @@ class PythonObjectOfTypeWrapper(RefcountedWrapper):
         )
 
         return context.constant(None)
+
+    def convert_builtin(self, f, context, expr, a1=None):
+        if f == ceil:
+            return context.pushPod(float, runtime_functions.pyobj_ceil.call(expr.nonref_expr.cast(VoidPtr)))
+        elif f == floor:
+            return context.pushPod(float, runtime_functions.pyobj_floor.call(expr.nonref_expr.cast(VoidPtr)))
+        elif f == trunc:
+            return context.pushPod(float, runtime_functions.pyobj_trunc.call(expr.nonref_expr.cast(VoidPtr)))
+        return super().convert_builtin(f, context, expr, a1)
 
     def convert_call(self, context, instance, args, kwargs):
         argsAsObjects = []

--- a/typed_python/compiler/type_wrappers/runtime_functions.py
+++ b/typed_python/compiler/type_wrappers/runtime_functions.py
@@ -1164,3 +1164,21 @@ raiseAttributeError = externalCallTarget(
     Void,
     UInt8Ptr
 )
+
+pyobj_ceil = externalCallTarget(
+    "np_pyobj_ceil",
+    Float64,
+    Void.pointer()
+)
+
+pyobj_floor = externalCallTarget(
+    "np_pyobj_floor",
+    Float64,
+    Void.pointer()
+)
+
+pyobj_trunc = externalCallTarget(
+    "np_pyobj_trunc",
+    Float64,
+    Void.pointer()
+)

--- a/typed_python/compiler/typed_expression.py
+++ b/typed_python/compiler/typed_expression.py
@@ -196,6 +196,9 @@ class TypedExpression:
     def convert_bool_cast(self):
         return self.convert_to_type(bool, ConversionLevel.New)
 
+    def convert_index_cast(self):
+        return self.expr_type.convert_index_cast(self.context, self)
+
     def convert_int_cast(self):
         return self.convert_to_type(int, ConversionLevel.New)
 

--- a/typed_python/types_test.py
+++ b/typed_python/types_test.py
@@ -2460,6 +2460,11 @@ class NativeTypesTests(unittest.TestCase):
         T = Dict(OneOf(int, float), OneOf(int, float))
         self.assertEqual(T({1: 2.5}), {1: 2.5})
 
+    def test_dict_equality_with_python_and_object(self):
+        self.assertTrue(Dict(int, object)({1: 2}) == {1: 2})
+        self.assertTrue(Dict(int, object)({1: (7, 8, 9)}) == {1: (7, 8, 9)})
+        self.assertTrue(Dict(int, object)({1: 'two'}) == {1: 'two'})
+
     def test_const_dict_with_noncomparable_things(self):
         DictType = ConstDict(OneOf(int, str), int)
 

--- a/typed_python/types_test.py
+++ b/typed_python/types_test.py
@@ -3193,3 +3193,18 @@ class NativeTypesTests(unittest.TestCase):
                     self.assertEqual(t1 >= t2, t1Untyped >= t2Untyped)
                     self.assertEqual(t1 != t2, t1Untyped != t2Untyped)
                     self.assertEqual(t1 == t2, t1Untyped == t2Untyped)
+
+    def test_docstrings_all_types(self):
+        # TODO: actually test all types
+        types = [int, str, bytes, Dict(int, str)]
+        for T in types:
+            type_docstring = T.__doc__
+            self.assertTrue(type_docstring, f"Type {T} missing docstring")
+            for a in dir(T):
+                m = getattr(T, a)
+                if callable(m):
+                    docstring = m.__doc__
+                    # ignore certain magic methods that don't always have docstrings, even for builtin types
+                    if a in ['__format__', '__getnewargs__']:
+                        continue
+                    self.assertTrue(docstring, f"Type {T} missing docstring for '{a}'")


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Motivation and Context
Addresses issue# 364.

## Approach
- The functions math.ceil, math.floor, math.trunc have magic methods `__ceil__`, `__floor__`, and `__trunc__`.
   - For these functions, the magic method is attempted first.  
   - For ceil and floor, if there is no magic method, attempt to call `__float__` and call the regular ceil or floor on that value.
   - For trunc, if there is no magic method, it raises TypeError.
- For other math functions with float arguments, if `__float__` is available, evaluate the math function on that value.
- If a math function is passed an object instead of a float argument, we try a non-explicit conversion to float.
- Math functions with int arguments behave differently.  For gcd, the arguments are considered valid if `__index__` is available.  For ldexp, only type int is acceptable.
- Also, improved error checking for other math function compilation (e.g. raising OverflowError for inf when appropriate).
- Adjust and fix other argument conversions for compiled math functions.

<!-- Describe your changes in reasonable detail -->

## How Has This Been Tested?
Call all math functions with floats and integers as objects, also some classes with `__float__` and other magic methods to simulate other numeric types.
<!-- Describe in reasonable detail how you tested your changes. -->
<!-- If appropriate, include details of your testing environment, -->
<!-- tests ran to see how your change affects other areas of the code, etc. -->

## Screenshots or console output (if appropriate)
<!-- if not appropriate, remove this section -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.