### PR TITLE
Fixes for 'try' and 'with' compilation. Refs #359

### DIFF
--- a/typed_python/compiler/expression_conversion_context.py
+++ b/typed_python/compiler/expression_conversion_context.py
@@ -1313,7 +1313,10 @@ class ExpressionConversionContext:
         )
 
         if clear_exc:
-            nativeExpr = nativeExpr >> runtime_functions.clear_exc_info.call()
+            nativeExpr = nativeExpr >> native_ast.Expression.Branch(
+                cond=self.functionContext.exception_occurred_slot.load(),
+                true=runtime_functions.clear_exc_info.call()
+            )
 
         nativeExpr = nativeExpr >> native_ast.Expression.Throw(
             expr=native_ast.Expression.Constant(
@@ -1337,7 +1340,10 @@ class ExpressionConversionContext:
             )
         )
         if deferred:
-            nativeExpr = nativeExpr >> runtime_functions.clear_exc_info.call()
+            nativeExpr = nativeExpr >> native_ast.Expression.Branch(
+                cond=self.functionContext.exception_occurred_slot.load(),
+                true=runtime_functions.clear_exc_info.call()
+            )
 
         nativeExpr = nativeExpr >> native_ast.Expression.Throw(
             expr=native_ast.Expression.Constant(

--- a/typed_python/compiler/function_conversion_context.py
+++ b/typed_python/compiler/function_conversion_context.py
@@ -1061,6 +1061,11 @@ class FunctionConversionContext(ConversionContextBase):
 
             return True
 
+    @property
+    def exception_occurred_slot(self):
+        exception_occurred_name = ".exc_occurred"
+        return native_ast.Expression.StackSlot(name=exception_occurred_name, type=native_ast.Bool)
+
     def convert_statement_ast(self, ast, variableStates: FunctionStackState, return_to=None, in_loop=False, try_flow=None):
         """Convert a single statement to native_ast.
 
@@ -1174,7 +1179,12 @@ class FunctionConversionContext(ConversionContextBase):
                         try_flow.store(native_ast.const_int_expr(CONTROL_FLOW_RETURN))
                     )
                 self.assignToLocalVariable(".return_value", e, variableStates)
-                subcontext.pushEffect(runtime_functions.clear_exc_info.call())
+                subcontext.pushEffect(
+                    native_ast.Expression.Branch(
+                        cond=self.exception_occurred_slot.load(),
+                        true=runtime_functions.clear_exc_info.call()
+                    )
+                )
 
                 subcontext.pushTerminal(
                     native_ast.Expression.Return(
@@ -1305,11 +1315,10 @@ class FunctionConversionContext(ConversionContextBase):
             # .exception_occurred turns on once any exception occurs
             # .control_flow indicates the control flow instruction that is deferred until after the 'finally' block
             #   0=default, 1=unhandled exception, 2=break, 3=continue, 4=return
-            exception_occurred_name = f".exc_occurred{ast.line_number}.{ast.col_offset}"
             control_flow_name = f".control_flow{ast.line_number}.{ast.col_offset}"
             end_of_try_marker = f"end_of_try{ast.line_number}.{ast.col_offset}"
             end_of_finally_marker = f"end_of_finally{ast.line_number}.{ast.col_offset}"
-            exception_occurred = native_ast.Expression.StackSlot(name=exception_occurred_name, type=native_ast.Bool)
+            exception_occurred = self.exception_occurred_slot
             control_flow = native_ast.Expression.StackSlot(name=control_flow_name, type=native_ast.Int64)
 
             body_context = ExpressionConversionContext(self, variableStates)
@@ -1372,9 +1381,13 @@ class FunctionConversionContext(ConversionContextBase):
                     variableStates.clone(),
                     variableStatesHandler
                 )
+                handler = handler >> native_ast.Expression.Branch(
+                    cond=exception_occurred.load(),
+                    true=runtime_functions.clear_exc_info.call()
+                )
                 working = native_ast.Expression.Branch(
                     cond=cond_context.finalize(cond.nonref_expr),
-                    true=handler_context.finalize(handler >> runtime_functions.clear_exc_info.call()),
+                    true=handler_context.finalize(handler),
                     false=working_context.finalize(working)
                 )
                 working_returns = handler_returns or working_returns
@@ -1465,7 +1478,10 @@ class FunctionConversionContext(ConversionContextBase):
                 )
                 complete = complete >> native_ast.Expression.Branch(
                     cond=control_flow.load().eq(CONTROL_FLOW_BREAK),
-                    true=runtime_functions.clear_exc_info.call() >> break_context.finalize(brk)
+                    true=native_ast.Expression.Branch(
+                        cond=exception_occurred.load(),
+                        true=runtime_functions.clear_exc_info.call()
+                    ) >> break_context.finalize(brk)
                 )
 
                 cont_context = ExpressionConversionContext(self, variableStates)
@@ -1478,7 +1494,10 @@ class FunctionConversionContext(ConversionContextBase):
                 )
                 complete = complete >> native_ast.Expression.Branch(
                     cond=control_flow.load().eq(CONTROL_FLOW_CONTINUE),
-                    true=runtime_functions.clear_exc_info.call() >> cont_context.finalize(cont)
+                    true=native_ast.Expression.Branch(
+                        cond=exception_occurred.load(),
+                        true=runtime_functions.clear_exc_info.call()
+                    ) >> cont_context.finalize(cont)
                 )
 
             raise_context = ExpressionConversionContext(self, variableStates)
@@ -1884,9 +1903,15 @@ class FunctionConversionContext(ConversionContextBase):
             # return, when in fact it does.
             if return_to is not None:
                 if try_flow:
-                    return try_flow.store(native_ast.const_int_expr(CONTROL_FLOW_BREAK)) \
-                        >> runtime_functions.clear_exc_info.call() \
-                        >> native_ast.Expression.Return(blockName=return_to), True
+                    return (
+                        try_flow.store(native_ast.const_int_expr(CONTROL_FLOW_BREAK)) >>
+                        native_ast.Expression.Branch(
+                            cond=self.exception_occurred_slot.load(),
+                            true=runtime_functions.clear_exc_info.call()
+                        ) >>
+                        native_ast.Expression.Return(blockName=return_to),
+                        True
+                    )
                 else:
                     return native_ast.Expression.Return(blockName=return_to), True
             else:
@@ -1898,9 +1923,15 @@ class FunctionConversionContext(ConversionContextBase):
             # return, when in fact it does.
             if return_to is not None:
                 if try_flow:
-                    return try_flow.store(native_ast.const_int_expr(CONTROL_FLOW_CONTINUE)) \
-                        >> runtime_functions.clear_exc_info.call() \
-                        >> native_ast.Expression.Return(blockName=return_to), True
+                    return (
+                        try_flow.store(native_ast.const_int_expr(CONTROL_FLOW_CONTINUE)) >>
+                        native_ast.Expression.Branch(
+                            cond=self.exception_occurred_slot.load(),
+                            true=runtime_functions.clear_exc_info.call()
+                        ) >>
+                        native_ast.Expression.Return(blockName=return_to),
+                        True
+                    )
                 else:
                     return native_ast.Expression.Return(blockName=return_to), True
             else:


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->

## Motivation and Context
After a fix to how `__exit__` was handled in interpreted Class types, expected that this could fix some problems observed with compiled `with`.
Also, when compiling 'try' statements, many extra calls to clear_exc_info() were generated.

## Approach
Compile 'with' statement with multiple context managers on one line.  Needed to make certain temporary slots more specific.

When compiling 'try', check if an exception has occurred before calling clear_exc_info().  Needed to make the 'exception occurred' indicator non-specific - we can use a slot with the same name everywhere.

Retested cases that used to fail:
- Repeating exceptions in compiled `with` sometimes were chained inappropriately.
- Can now use an uncompiled context manager in a compiled `with` statement.
- While adding these tests, also re-added tests for compiling multiple context manangers in a single `with` statement.  These previously failed, and continued to fail, but were corrected.

## How Has This Been Tested?
Activated tests that used to fail.
<!-- Describe in reasonable detail how you tested your changes. -->
<!-- If appropriate, include details of your testing environment, -->
<!-- tests ran to see how your change affects other areas of the code, etc. -->

## Screenshots or console output (if appropriate)
<!-- if not appropriate, remove this section -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.