### PR TITLE
Improvements for compiled math functions to work on object arguments.  Refs #364

### DIFF
--- a/typed_python/ConversionLevel.hpp
+++ b/typed_python/ConversionLevel.hpp
@@ -12,6 +12,7 @@ enum class ConversionLevel {
     UpcastContainers,
     Implicit,
     ImplicitContainers,
+    Math,
     New,
 };
 
@@ -31,8 +32,11 @@ inline int conversionLevelToInt(ConversionLevel level) {
     if (level == ConversionLevel::ImplicitContainers) {
         return 4;
     }
-    if (level == ConversionLevel::New) {
+    if (level == ConversionLevel::Math) {
         return 5;
+    }
+    if (level == ConversionLevel::New) {
+        return 6;
     }
 
     throw std::runtime_error("Invalid ConversionLevel");
@@ -53,6 +57,9 @@ inline std::string conversionLevelToString(ConversionLevel level) {
     }
     if (level == ConversionLevel::ImplicitContainers) {
         return "ImplicitContainers";
+    }
+    if (level == ConversionLevel::Math) {
+        return "Math";
     }
     if (level == ConversionLevel::New) {
         return "New";
@@ -78,6 +85,9 @@ inline ConversionLevel intToConversionLevel(int level) {
         return ConversionLevel::ImplicitContainers;
     }
     if (level == 5) {
+        return ConversionLevel::Math;
+    }
+    if (level == 6) {
         return ConversionLevel::New;
     }
 

--- a/typed_python/compiler/conversion_level.py
+++ b/typed_python/compiler/conversion_level.py
@@ -39,6 +39,7 @@ class ConversionLevel:
             ConversionLevel.UpcastContainers,
             ConversionLevel.Implicit,
             ConversionLevel.ImplicitContainers,
+            ConversionLevel.Math,
             ConversionLevel.New
         ]:
             if level.LEVEL == intLevel:
@@ -128,11 +129,25 @@ class ImplicitContainers(ConversionLevel):
     LEVEL = 4
 
 
+class Math(ConversionLevel):
+    """Just like Implicit, but also allow objects with __float__ or __int__ methods.
+    This should convert float and int the same way the Python math module does,
+    in other words, with the same logic as PyFloat_AsDouble or PyLong_AsLong, which
+    use __float__, or  __int__. [3.8+: also, __float__ falls back to __index__]
+    So this conversion level will not convert str to float, but will convert classes
+    with __float__ to float.
+    Note: some parameters in the Python math module are strictly int, and others are 'index',
+    * This conversion is not appropriate for the strictly int arguments.
+    * For 'index', use .toIndex() instead of this conversion.
+    """
+    LEVEL = 5
+
+
 class New(ConversionLevel):
     """Invoked by an explicit call to a type constructor. Allows the construction of a
     new instance of the type itself. Internal conversions are done as 'ImplicitContainers' calls.
     """
-    LEVEL = 5
+    LEVEL = 6
 
 
 ConversionLevel.Signature = Signature()
@@ -140,4 +155,5 @@ ConversionLevel.Upcast = Upcast()
 ConversionLevel.UpcastContainers = UpcastContainers()
 ConversionLevel.Implicit = Implicit()
 ConversionLevel.ImplicitContainers = ImplicitContainers()
+ConversionLevel.Math = Math()
 ConversionLevel.New = New()

--- a/typed_python/compiler/tests/math_functions_compilation_test.py
+++ b/typed_python/compiler/tests/math_functions_compilation_test.py
@@ -22,9 +22,10 @@ from typed_python import (
 )
 
 from typed_python import Entrypoint
-
-
 import typed_python.compiler
+from typed_python.compiler.type_wrappers.math_wrappers import sumIterable, sumIterable38
+
+
 typeWrapper = lambda t: typed_python.compiler.python_object_representation.typedPythonTypeToTypeWrapper(t)
 
 
@@ -899,3 +900,16 @@ class TestMathFunctionsCompilation(unittest.TestCase):
                 self.assertEqual(r1[1], r2[1], v)
             else:
                 self.assertEqual(r1[1], r2[1], v)
+
+    def test_math_internal_fns(self):
+        self.assertEqual(sumIterable([1, 2, 3]), 6)
+        self.assertEqual(sumIterable([1e100, 1e-100, -1e100]), 1e-100)
+        self.assertLess(sumIterable(x/1e6 for x in range(-1000000, 1000000, 999)), 0)
+        with self.assertRaises(TypeError):
+            sumIterable([1, 2, "3"])
+
+        self.assertEqual(sumIterable38([1, 2, 3]), 6)
+        self.assertEqual(sumIterable38([1e100, 1e-100, -1e100]), 1e-100)
+        self.assertLess(sumIterable38(x/1e6 for x in range(-1000000, 1000000, 999)), 0)
+        with self.assertRaises(TypeError):
+            sumIterable38([1, 2, "3"])

--- a/typed_python/compiler/tests/math_functions_compilation_test.py
+++ b/typed_python/compiler/tests/math_functions_compilation_test.py
@@ -18,7 +18,7 @@ import time
 import numpy
 
 from typed_python import (
-    Float32, UInt64, UInt32, UInt16, UInt8, Int32, Int16, Int8, ListOf, TupleOf
+    Float32, UInt64, UInt32, UInt16, UInt8, Int32, Int16, Int8, ListOf, Tuple, TupleOf, OneOf
 )
 
 from typed_python import Entrypoint
@@ -26,6 +26,20 @@ from typed_python import Entrypoint
 
 import typed_python.compiler
 typeWrapper = lambda t: typed_python.compiler.python_object_representation.typedPythonTypeToTypeWrapper(t)
+
+
+def callOrExcept(f, *args):
+    try:
+        return ("Normal", f(*args))
+    except Exception as e:
+        return ("Exception", str(e))
+
+
+def callOrExceptType(f, *args):
+    try:
+        return ("Normal", f(*args))
+    except Exception as e:
+        return ("Exception", str(type(e)))
 
 
 @Entrypoint
@@ -156,13 +170,13 @@ class TestMathFunctionsCompilation(unittest.TestCase):
             return math.log10(x)
 
         def f_pow1(x):
-            return math.pow(x, type(x)(2.0))
+            return math.pow(x, 2.0)
 
         def f_pow2(x):
-            return math.pow(x, type(x)(0.8))
+            return math.pow(x, 0.8)
 
         def f_pow3(x):
-            return math.pow(x, type(x)(-2.5))
+            return math.pow(x, -2.5)
 
         def f_sin(x):
             return math.sin(x)
@@ -185,6 +199,11 @@ class TestMathFunctionsCompilation(unittest.TestCase):
         def f_atan2(x, y):
             return math.atan2(x, y)
 
+        cases = [-2.34, -1.0, -0.6, -0.5, 0.0, 0.5, 0.6, 1.0, 2.34, 1e30, -1e30, 1e100, -1e100, math.inf, -math.inf, math.nan]
+        cases += [Float32(v) for v in cases]
+        cases += [Int8(-127), UInt8(255), Int16(-32767), UInt16(65535), Int32(-1), UInt32(1), UInt64(123)]
+        cases += ['1234', set(), {1.1, }, list(), [1.1], tuple()]
+
         for mathFun in [f_acos, f_acosh, f_asin, f_asinh,
                         f_cos, f_cosh, f_sin, f_sinh,
                         f_atan, f_atanh, f_tan, f_tanh,
@@ -195,64 +214,50 @@ class TestMathFunctionsCompilation(unittest.TestCase):
                         f_sqrt]:
             compiled = Entrypoint(mathFun)
 
-            self.assertEqual(compiled.resultTypeFor(float).typeRepresentation, float)
-            self.assertEqual(compiled.resultTypeFor(Float32).typeRepresentation, Float32)
+            self.assertEqual(compiled.resultTypeFor(float).typeRepresentation, float, mathFun)
+            self.assertEqual(compiled.resultTypeFor(Float32).typeRepresentation, float, mathFun)
 
-            for v in [-2.34, -1.0, -0.6, -0.5, 0.0, 0.5, 0.6, 1.0, 2.34]:
-                raisesValueError = False
-                try:
-                    r1 = mathFun(v)
-                except ValueError:
-                    raisesValueError = True
+            for v in cases:
+                r1 = callOrExceptType(mathFun, v)
+                r2 = callOrExceptType(compiled, v)
+                self.assertEqual(r1[0], r2[0], (mathFun, v, r1, r2))
+                if r2[0] == "Normal":
+                    self.assertIsInstance(r2[1], float)
 
-                if raisesValueError:
-                    with self.assertRaises(ValueError):
-                        compiled(v)
-                    with self.assertRaises(ValueError):
-                        compiled(Float32(v))
+                if r1[0] == "Normal" and math.isnan(r1[1]):
+                    self.assertTrue(math.isnan(r2[1]))
+                elif r1[0] == "Normal" and mathFun in (f_erf, f_erfc, f_gamma, f_lgamma) \
+                        and r1[1] != 0.0 and math.isfinite(r1[1]):
+                    # I'm seeing a small difference between python math.erf and C++ std:erf.
+                    # I'm seeing a small difference between python math.erfcand C++ std:erfc
+                    # I'm seeing a small difference between python math.gamma and C++ std:gamma.
+                    # I'm seeing a small difference between python math.lgamma and C++ std:lgamma.
+                    self.assertLess(abs((r2[1] - r1[1]) / r1[1]), 1e-10, (mathFun, v, r1[1], r2[1]))
                 else:
-                    r2 = compiled(v)
-                    self.assertIsInstance(r2, float)
-                    if r1 == 0.0:
-                        self.assertLess(abs(r2 - r1), 1e-10, (mathFun, v, r1, r2))
-                    else:
-                        self.assertLess(abs((r2 - r1) / r1), 1e-10, (mathFun, v, r1, r2))
-
-                    r3 = compiled(Float32(v))
-                    self.assertIsInstance(r3, Float32, (mathFun, v))
-                    if r1 == 0.0:
-                        self.assertLess(abs(r3 - r1), 1e-6, (mathFun, v, r1, r3))
-                    else:
-                        self.assertLess(abs((r3 - r1) / r1), 1e-6, (mathFun, v, r1, r3))
+                    self.assertEqual(r1, r2, (mathFun, v))
 
         for mathFun in [f_pow, f_atan2]:
             compiled = Entrypoint(mathFun)
             self.assertEqual(compiled.resultTypeFor(float, float).typeRepresentation, float)
             self.assertEqual(compiled.resultTypeFor(Float32, float).typeRepresentation, float)
             self.assertEqual(compiled.resultTypeFor(float, Float32).typeRepresentation, float)
-            self.assertEqual(compiled.resultTypeFor(Float32, Float32).typeRepresentation, Float32)
+            self.assertEqual(compiled.resultTypeFor(Float32, Float32).typeRepresentation, float)
 
-            for v1 in [-5.4, -3.0, -1.0, -0.6, -0.5, 0.0, 0.5, 0.6, 1.0, 3.0, 5.4]:
-                for v2 in [-5.4, -3.0, -1.0, -0.6, -0.5, 0.0, 0.5, 0.6, 1.0, 3.0, 5.4]:
-                    raisesValueError = False
-                    try:
-                        r1 = mathFun(v1, v2)
-                    except ValueError:
-                        raisesValueError = True
+            for v1 in [-5.4, -3.0, -1.0, -0.6, -0.5, 0.0, 0.5, 0.6, 1.0, 3.0, 5.4, math.inf, -math.inf, math.nan]:
+                for v2 in [-5.4, -3.0, -1.0, -0.6, -0.5, 0.0, 0.5, 0.6, 1.0, 3.0, 5.4, math.inf, -math.inf, math.nan]:
+                    r1 = callOrExceptType(mathFun, v1, v2)
+                    r2 = callOrExceptType(compiled, v1, v2)
+                    self.assertEqual(r1[0], r2[0], (mathFun, v1, v2, r1, r2))
+                    if r2[0] == "Normal":
+                        self.assertIsInstance(r2[1], float)
 
-                    if raisesValueError:
-                        with self.assertRaises(ValueError):
-                            compiled(v1, v2)
-                        with self.assertRaises(ValueError):
-                            compiled(Float32(v1), Float32(v2))
+                    if r1[0] == "Normal" and math.isnan(r1[1]):
+                        self.assertTrue(math.isnan(r2[1]))
+                    elif r1[0] == "Normal" and mathFun in (f_erf, f_erfc, f_gamma, f_lgamma) \
+                            and r1[1] != 0.0 and math.isfinite(r1[1]):
+                        self.assertLess(abs((r2[1] - r1[1]) / r1[1]), 1e-10, (mathFun, v1, v2, r1[1], r2[1]))
                     else:
-                        r2 = compiled(v1, v2)
-                        self.assertEqual(r1, r2)
-                        r3 = compiled(Float32(v1), Float32(v2))
-                        if r1 == 0.0:
-                            self.assertLess(abs(r3 - r1), 1e-6, (mathFun, v1, v2, r1, r3))
-                        else:
-                            self.assertLess(abs((r3 - r1)/r1), 1e-6, (mathFun, v1, v2, r1, r3))
+                        self.assertEqual(r1, r2, (mathFun, v1, v2))
 
     def test_math_other_one(self):
         def f_fabs(x):
@@ -286,7 +291,7 @@ class TestMathFunctionsCompilation(unittest.TestCase):
             compiled = Entrypoint(mathFun)
 
             self.assertEqual(compiled.resultTypeFor(float).typeRepresentation, float)
-            self.assertEqual(compiled.resultTypeFor(Float32).typeRepresentation, Float32)
+            self.assertEqual(compiled.resultTypeFor(Float32).typeRepresentation, float)
 
             for v in [-1234.5, -12.34, -1.0, -0.5, 0.0, 0.5, 1.0, 12.34, 1234.5]:
                 r1 = mathFun(v)
@@ -295,7 +300,7 @@ class TestMathFunctionsCompilation(unittest.TestCase):
                 self.assertEqual(r1, r2, (mathFun, v))
 
                 r3 = compiled(Float32(v))
-                self.assertIsInstance(r3, Float32)
+                self.assertIsInstance(r3, float)
                 if r1 == 0.0:
                     self.assertLess(abs(r3 - r1), 1e-6, (mathFun, v, r1, r3))
                 else:
@@ -304,14 +309,14 @@ class TestMathFunctionsCompilation(unittest.TestCase):
         for mathFun in [f_factorial]:
             compiled = Entrypoint(mathFun)
 
-            self.assertEqual(compiled.resultTypeFor(int).typeRepresentation, int)
-            self.assertEqual(compiled.resultTypeFor(Int32).typeRepresentation, int)
-            self.assertEqual(compiled.resultTypeFor(UInt8).typeRepresentation, int)
+            self.assertEqual(compiled.resultTypeFor(int).typeRepresentation, float)
+            self.assertEqual(compiled.resultTypeFor(Int32).typeRepresentation, float)
+            self.assertEqual(compiled.resultTypeFor(UInt8).typeRepresentation, float)
 
             for v in range(21):
                 r1 = mathFun(v)
                 r2 = compiled(v)
-                self.assertIsInstance(r2, int)
+                self.assertIsInstance(r2, float)
                 self.assertEqual(r1, r2, (mathFun, v))
 
             with self.assertRaises(ValueError):
@@ -324,8 +329,8 @@ class TestMathFunctionsCompilation(unittest.TestCase):
             for v in range(34):
                 r1 = mathFun(v)
                 r2 = compiled(Float32(v))
-                self.assertIsInstance(r2, Float32)
-                self.assertTrue(abs(Float32(r1) - r2) / Float32(r1) < 1e-6, (mathFun, v))
+                self.assertIsInstance(r2, float)
+                self.assertTrue(abs(r1 - r2) / r1 < 1e-6, (mathFun, v))
 
             for v in range(170):
                 r1 = mathFun(v)
@@ -353,9 +358,9 @@ class TestMathFunctionsCompilation(unittest.TestCase):
                 self.assertEqual(r1, r2, (mathFun, v))
 
                 r3 = compiled(Float32(v))
-                self.assertTrue(type(r3[0]) is Float32)
+                self.assertTrue(type(r3[0]) is float)
                 # self.assertIsInstance(r2[0], Float32) fails for some reason
-                self.assertTrue(type(r3[1]) is (Float32 if mathFun is f_modf else int))
+                self.assertTrue(type(r3[1]) is (float if mathFun is f_modf else int))
                 for i in range(2):
                     self.assertLess(abs((r1[i] - r3[i])/r1[i]) if r1[i] else abs(r1[i] - r3[i]), 1e-6)
 
@@ -366,14 +371,14 @@ class TestMathFunctionsCompilation(unittest.TestCase):
         def f_fmod(x, y):
             return math.fmod(x, y)
 
-        test_values = [-1234.5, -12.34, -1.0, -0.5, 0.0, 0.5, 1.0, 12.34, 1234.5]
+        test_values = [12.34, -1234.5, -12.34, -1.0, -0.5, 0.0, 0.5, 1.0, 12.34, 1234.5]
         for mathFun in [f_hypot, f_fmod]:
             compiled = Entrypoint(mathFun)
 
             self.assertEqual(compiled.resultTypeFor(float, float).typeRepresentation, float)
             self.assertEqual(compiled.resultTypeFor(Float32, float).typeRepresentation, float)
             self.assertEqual(compiled.resultTypeFor(float, Float32).typeRepresentation, float)
-            self.assertEqual(compiled.resultTypeFor(Float32, Float32).typeRepresentation, Float32)
+            self.assertEqual(compiled.resultTypeFor(Float32, Float32).typeRepresentation, float)
 
             for v1 in test_values:
                 for v2 in test_values:
@@ -396,7 +401,7 @@ class TestMathFunctionsCompilation(unittest.TestCase):
                             compiled(Float32(v1), Float32(v2))
                     else:
                         r3 = compiled(Float32(v1), Float32(v2))
-                        self.assertIsInstance(r3, Float32)
+                        self.assertIsInstance(r3, float)
                         if r1 == 0.0:
                             self.assertLess(abs(r3 - r1), 1e-6, (mathFun, v1, v2, r1, r3))
                         else:
@@ -427,12 +432,7 @@ class TestMathFunctionsCompilation(unittest.TestCase):
                             self.assertIsInstance(r2, bool)
                             self.assertEqual(r1, r2, (mathFun, v1, v2, rel_tol, abs_tol))
 
-                            # don't bother testing Float32 if rel_tol is too small
-                            if rel_tol is not None and rel_tol < 1e-5:
-                                continue
-
-                            # default rel_tol is different for Float32
-                            r3 = mathFun(v1, v2, 1e-5 if rel_tol is None else rel_tol, abs_tol)
+                            r3 = mathFun(Float32(v1), Float32(v2), rel_tol, abs_tol)
                             r4 = compiled(Float32(v1), Float32(v2), rel_tol, abs_tol)
                             self.assertIsInstance(r4, bool)
                             self.assertEqual(r3, r4, (mathFun, v1, v2, rel_tol, abs_tol))
@@ -442,11 +442,11 @@ class TestMathFunctionsCompilation(unittest.TestCase):
 
         for mathFun in [f_gcd]:
             compiled = Entrypoint(mathFun)
-            self.assertEqual(compiled.resultTypeFor(int, int).typeRepresentation, UInt64)
-            self.assertEqual(compiled.resultTypeFor(Int32, Int32).typeRepresentation, UInt64)
-            self.assertEqual(compiled.resultTypeFor(UInt32, Int16).typeRepresentation, UInt64)
-            self.assertEqual(compiled.resultTypeFor(Int8, UInt64).typeRepresentation, UInt64)
-            self.assertEqual(compiled.resultTypeFor(UInt64, UInt64).typeRepresentation, UInt64)
+            self.assertEqual(compiled.resultTypeFor(int, int).typeRepresentation, int)
+            self.assertEqual(compiled.resultTypeFor(Int32, Int32).typeRepresentation, int)
+            self.assertEqual(compiled.resultTypeFor(UInt32, Int16).typeRepresentation, int)
+            self.assertEqual(compiled.resultTypeFor(Int8, UInt64).typeRepresentation, int)
+            self.assertEqual(compiled.resultTypeFor(UInt64, UInt64).typeRepresentation, int)
 
             test_values = [-2**63+1, -35, 0, 1, 2, 3, 12, 15, 81, 90, 360, 1000, 1080, 2**16 * 3 * 5 * 7, 2**63-1]
             for v1 in test_values:
@@ -469,9 +469,9 @@ class TestMathFunctionsCompilation(unittest.TestCase):
         for mathFun in [f_ldexp]:
             compiled = Entrypoint(mathFun)
             self.assertEqual(compiled.resultTypeFor(float, int).typeRepresentation, float)
-            self.assertEqual(compiled.resultTypeFor(Float32, int).typeRepresentation, Float32)
-            self.assertEqual(compiled.resultTypeFor(float, Int32).typeRepresentation, float)
-            self.assertEqual(compiled.resultTypeFor(Float32, Int32).typeRepresentation, Float32)
+            self.assertEqual(compiled.resultTypeFor(Float32, int).typeRepresentation, float)
+            self.assertEqual(compiled.resultTypeFor(float, Int32), None)
+            self.assertEqual(compiled.resultTypeFor(Float32, Int32), None)
 
             for v1 in [-123.45, -2.0, -1.0, -0.999, -0.7, -0.5, 0.0, 0.5, 0.7, 0.999, 1.0, 2.0, 123.45]:
                 for v2 in range(-10, 10):
@@ -481,7 +481,7 @@ class TestMathFunctionsCompilation(unittest.TestCase):
                     self.assertEqual(r1, r2, (mathFun, v1, v2))
 
                     r3 = Float32(r1)
-                    r4 = compiled(Float32(v1), Float32(v2))
+                    r4 = compiled(Float32(v1), v2)
                     self.assertEqual(r3, r4, (mathFun, v1, v2))
 
     def test_math_fsum(self):
@@ -503,7 +503,7 @@ class TestMathFunctionsCompilation(unittest.TestCase):
             r2 = compiled(v)
             self.assertEqual(r1, r2)
 
-        with self.assertRaises(ValueError):
+        with self.assertRaises(TypeError):
             compiled([0.1, 0.2, 0.3, "abc"])
 
         with self.assertRaises(TypeError):
@@ -520,6 +520,25 @@ class TestMathFunctionsCompilation(unittest.TestCase):
         self.assertTrue(math.isnan(r2[5]))
         # Note r1 != r2 because nan != nan
         self.assertEqual(r1[0:-1], r2[0:-1])
+
+        def f_calculated_const():
+            return math.log(math.atan(math.exp(math.sin(math.pi))))
+
+        r1 = f_calculated_const()
+        r2 = Entrypoint(f_calculated_const)()
+        # Ensure that any constant propagation optimization does not affect the value.
+        self.assertEqual(r1, r2)
+
+        def f_runtime_error():
+            return math.log(math.log(math.atan(math.exp(math.sin(math.pi)))))
+
+        # Ensure that any constant propagation optimization does not affect runtime errors
+        with self.assertRaises(ValueError):
+            f_runtime_error()
+
+        c_runtime_error = Entrypoint(f_runtime_error)
+        with self.assertRaises(ValueError):
+            c_runtime_error()
 
     def test_math_functions_perf_other(self):
         count = 1000000
@@ -630,3 +649,253 @@ class TestMathFunctionsCompilation(unittest.TestCase):
 
                 del f
                 del g
+
+    def test_math_functions_on_object(self):
+        class ClassCeil:
+            def __ceil__(self):
+                return 123.45
+
+        class ClassFloor:
+            def __floor__(self):
+                return 123.45
+
+        class ClassTrunc:
+            def __trunc__(self):
+                return 123
+
+        class ClassFloat:
+            def __float__(self):
+                return 1.24
+
+        class ClassInt:
+            def __int__(self):
+                return 13
+
+        class ClassIndex:
+            def __index__(self):
+                return 17
+
+        class ClassCeilFloat:
+            def __ceil__(self):
+                return 1.23
+
+            def __float__(self):
+                return 2.34
+
+        def f_ceil(t: object):
+            return math.ceil(t)
+
+        def f_floor(t: object):
+            return math.floor(t)
+
+        def f_trunc(t: object):
+            return math.trunc(t)
+
+        def f_acos(t: object):
+            return math.acos(t)
+
+        def f_acosh(t: object):
+            return math.acosh(t)
+
+        def f_asin(t: object):
+            return math.asin(t)
+
+        def f_asinh(t: object):
+            return math.asinh(t)
+
+        def f_atan(t: object):
+            return math.atan(t)
+
+        def f_atan2(t: object):
+            return math.atan2(t, t)
+
+        def f_atanh(t: object):
+            return math.atanh(t)
+
+        def f_copysign(t: object):
+            return math.copysign(t, t)
+
+        def f_cos(t: object):
+            return math.cos(t)
+
+        def f_cosh(t: object):
+            return math.cosh(t)
+
+        def f_degrees(t: object):
+            return math.degrees(t)
+
+        def f_erf(t: object):
+            return math.erf(t)
+
+        def f_erfc(t: object):
+            return math.erfc(t)
+
+        def f_exp(t: object):
+            return math.exp(t)
+
+        def f_expm1(t: object):
+            return math.expm1(t)
+
+        def f_fabs(t: object):
+            return math.fabs(t)
+
+        def f_fmod(t: object):
+            return math.fmod(t, t)
+
+        def f_frexp(t: object):
+            x = math.frexp(t)
+            return x[0] + x[1]
+
+        def f_fsum(t: object):
+            return math.fsum([t, t, t])
+
+        def f_gamma(t: object):
+            return math.gamma(t)
+
+        def f_gcd(t: object):
+            return math.gcd(t, t)
+
+        def f_hypot(t: object):
+            return math.hypot(t, t)
+
+        def f_isclose(t: object):
+            return math.isclose(t, t)
+
+        def f_isclose2(t: object):
+            return math.isclose(t, t, rel_tol=t)
+
+        def f_isclose3(t: object):
+            return math.isclose(t, t, abs_tol=t)
+
+        def f_isclose4(t: object):
+            return math.isclose(t, t, rel_tol=t, abs_tol=t)
+
+        def f_isfinite(t: object):
+            return math.isfinite(t)
+
+        def f_isinf(t: object):
+            return math.isinf(t)
+
+        def f_isnan(t: object):
+            return math.isnan(t)
+
+        def f_ldexp1(t: object):
+            return math.ldexp(t, 5)
+
+        def f_ldexp2(t: object):
+            return math.ldexp(2.0, t)
+
+        def f_lgamma(t: object):
+            return math.lgamma(t)
+
+        def f_log(t: object):
+            return math.log(t)
+
+        def f_log10(t: object):
+            return math.log10(t)
+
+        def f_log1p(t: object):
+            return math.log1p(t)
+
+        def f_log2(t: object):
+            return math.log2(t)
+
+        def f_modf(t: object):
+            return math.modf(t)
+
+        def f_pow(t: object):
+            return math.pow(t, t)
+
+        def f_radians(t: object):
+            return math.radians(t)
+
+        def f_sin(t: object):
+            return math.sin(t)
+
+        def f_sinh(t: object):
+            return math.sinh(t)
+
+        def f_sqrt(t: object):
+            return math.sqrt(t)
+
+        def f_tan(t: object):
+            return math.tan(t)
+
+        def f_tanh(t: object):
+            return math.tanh(t)
+
+        self.assertEqual(Entrypoint(f_ceil)(1.5), 2.0)
+        self.assertEqual(Entrypoint(f_sin)(0.0), 0.0)
+
+        fns = [f_trunc, f_ceil, f_floor, f_acos, f_acosh, f_asin, f_asinh, f_atan, f_atan2, f_atanh, f_copysign,
+               f_cos, f_cosh, f_degrees, f_erf, f_erfc, f_exp, f_expm1, f_fabs, f_fmod, f_frexp, f_fsum, f_gamma, f_gcd,
+               f_hypot, f_isclose, f_isclose2, f_isclose3, f_isclose4, f_isfinite, f_isinf, f_isnan, f_ldexp1, f_ldexp2, f_lgamma,
+               f_log, f_log10, f_log1p, f_log2, f_modf, f_pow, f_radians, f_sin, f_sinh, f_sqrt, f_tan, f_tanh]
+        values = [
+            0, 0.5, -0.5, 1.0, -1.0, 7, -7, 1e100, -1e100,
+            ClassCeil(), ClassFloor(), ClassTrunc(), ClassFloat(), ClassInt(), ClassIndex(), ClassCeilFloat(),
+            Int32(0), Float32(0.5), None, set(), "1234", "0.0",
+        ]
+        for f in fns:
+            c_f = Entrypoint(f)
+            for v in values:
+                r1 = callOrExceptType(f, v)
+                r2 = callOrExceptType(c_f, v)
+                if r1[0] == 'Normal' and r2[0] == 'Normal' and isinstance(r1[1], (float, int)):
+                    if r1[1] == 0.0:
+                        self.assertLess(abs(r2[1] - r1[1]), 1e-10, (f, v))
+                    else:
+                        self.assertLess(abs((r2[1] - r1[1]) / r1[1]), 1e-10, (f, v))
+                else:
+                    self.assertEqual(r1, r2, (f, v))
+
+    def test_math_functions_on_oneof(self):
+        class ClassIndex:
+            def __index__(self):
+                return 6
+
+        T = OneOf(int, str, 1.99)
+
+        def f_sin(x: T) -> float:
+            return math.sin(x)
+
+        compiled = Entrypoint(f_sin)
+        cases = ListOf(T)([12, "987", 1.99])
+        for v in cases:
+            r1 = callOrExceptType(f_sin, v)
+            r2 = callOrExceptType(compiled, v)
+            self.assertEqual(r1, r2, v)
+
+        T2 = OneOf(int, float, str)
+
+        def f_factorial(x: T2) -> float:
+            return math.factorial(x)
+
+        compiled = Entrypoint(f_factorial)
+        cases = ListOf(T2)([12, 50, 50.0, "string"])
+        for v in cases:
+            r1 = callOrExceptType(f_factorial, v)
+            r2 = callOrExceptType(compiled, v)
+            self.assertEqual(r1[0], r2[0], (v, r1, r2))
+            if r1[0] == 'Exception':
+                self.assertEqual(r1[1], r2[1], v)
+            else:
+                # Python factorial is an exact integer, but our factorial is a float,
+                # so convert python result to float before comparing.
+                self.assertEqual(float(r1[1]), r2[1], v)
+
+        T3 = OneOf(int, float, str, ClassIndex)
+
+        def f_gcd(x: T3, y: T3) -> int:
+            return math.gcd(x, y)
+
+        compiled = Entrypoint(f_gcd)
+        cases = ListOf(Tuple(T3, T3))([(6, 8), (6.0, 8.0), ("6", "8"), (ClassIndex(), ClassIndex())])
+        for v in cases:
+            r1 = callOrExceptType(f_gcd, *v)
+            r2 = callOrExceptType(compiled, *v)
+            self.assertEqual(r1[0], r2[0], (v, r1, r2))
+            if r1[0] == 'Exception':
+                self.assertEqual(r1[1], r2[1], v)
+            else:
+                self.assertEqual(r1[1], r2[1], v)

--- a/typed_python/compiler/tests/type_conversion_test.py
+++ b/typed_python/compiler/tests/type_conversion_test.py
@@ -94,8 +94,8 @@ def makeConverterDict():
         return TriggerConvert(T, 4)(arg)
 
     @Entrypoint
-    def convert5(arg, T):
-        return TriggerConvert(T, 5)(arg)
+    def convert6(arg, T):
+        return TriggerConvert(T, 6)(arg)
 
     return {
         ConversionLevel.Signature: convert0,
@@ -103,7 +103,7 @@ def makeConverterDict():
         ConversionLevel.UpcastContainers: convert2,
         ConversionLevel.Implicit: convert3,
         ConversionLevel.ImplicitContainers: convert4,
-        ConversionLevel.New: convert5,
+        ConversionLevel.New: convert6,
     }
 
 

--- a/typed_python/compiler/type_wrappers/class_or_alternative_wrapper_mixin.py
+++ b/typed_python/compiler/type_wrappers/class_or_alternative_wrapper_mixin.py
@@ -330,8 +330,6 @@ class ClassOrAlternativeWrapperMixin:
         return context.pushException(TypeError, f"__index__ not implemented for {self.typeRepresentation}")
 
     def convert_builtin(self, f, context, expr, a1=None):
-        # TODO: this should go in some common wrapper base class for alternatives and classes, along with
-        # generate method call
         if f is format:
             if self.has_method("__format__"):
                 return self.convert_method_call(

--- a/typed_python/compiler/type_wrappers/math_wrappers.py
+++ b/typed_python/compiler/type_wrappers/math_wrappers.py
@@ -15,10 +15,11 @@
 import typed_python.compiler
 from typed_python.compiler.type_wrappers.wrapper import Wrapper
 import typed_python.compiler.native_ast as native_ast
-from typed_python import UInt64, Float32, Tuple, ListOf
+from typed_python import ListOf, Tuple, TupleOf, NamedTuple, Dict
 from typed_python.compiler.conversion_level import ConversionLevel
 import typed_python.compiler.type_wrappers.runtime_functions as runtime_functions
 from typed_python.compiler.type_wrappers.tuple_wrapper import MasqueradingTupleWrapper
+import sys
 
 from math import (
     acos,
@@ -28,7 +29,7 @@ from math import (
     atan,
     atan2,
     atanh,
-    ceil,
+    # ceil,
     copysign,
     cos,
     cosh,
@@ -40,7 +41,7 @@ from math import (
     expm1,
     fabs,
     factorial,
-    floor,
+    # floor,
     fmod,
     frexp,
     fsum,
@@ -69,7 +70,7 @@ from math import (
     tan,
     tanh,
     # tau,
-    trunc
+    # trunc
     # added in 3.7:
     # remainder
     # added in 3.8:
@@ -85,6 +86,7 @@ def sumIterable(iterable):
     """Full precision summation using multiple floats for intermediate values.
     Code modified from msum() at code.activestate.com/recipes/393090/, which
     is licensed under the PSF License.
+    Processes arguments as python3.6 or 3.7 math module.
     Original comment below.
     """
     # Rounded x+y stored in hi with the round-off stored in lo.  Together
@@ -95,7 +97,14 @@ def sumIterable(iterable):
 
     partials = ListOf(float)()
     for item in iterable:
-        x = float(item)
+        # float(item) would convert str to float, so __float__ is better
+        if not isinstance(item, float):
+            try:
+                item = item.__float__()  # does not convert str to float
+            except AttributeError:
+                raise TypeError('must be real number')
+        x = float(item)  # I know item is a float now, but force compiler to know this too
+
         i = 0
         for y in partials:
             if abs(x) < abs(y):
@@ -119,16 +128,130 @@ def sumIterable(iterable):
     return ret
 
 
+def sumIterable38(iterable):
+    """Full precision summation using multiple floats for intermediate values.
+    Code modified from msum() at code.activestate.com/recipes/393090/, which
+    is licensed under the PSF License.
+    Processes arguments as python3.8+ math module.
+    Original comment below.
+    """
+    # Rounded x+y stored in hi with the round-off stored in lo.  Together
+    # hi+lo are exactly equal to x+y.  The inner loop applies hi/lo summation
+    # to each partial so that the list of partial sums remains exact.
+    # Depends on IEEE-754 arithmetic guarantees.  See proof of correctness at:
+    # www-2.cs.cmu.edu/afs/cs/project/quake/public/papers/robust-arithmetic.ps
+
+    partials = ListOf(float)()
+    for item in iterable:
+        # float(item) would convert str to float, so __float__ is better
+        if not isinstance(item, float):
+            try:
+                item = item.__float__()  # does not convert str to float
+            except AttributeError:
+                try:
+                    item = item.__index__()
+                except AttributeError:
+                    raise TypeError('must be real number')
+        x = float(item)  # force to float
+
+        i = 0
+        for y in partials:
+            if abs(x) < abs(y):
+                t = x
+                x = y
+                y = t
+            hi = x + y
+            lo = y - (hi - x)
+            if lo:
+                partials[i] = lo
+                i += 1
+            x = hi
+        popindex = len(partials) - 1
+        while popindex >= i:
+            partials.pop()
+            popindex -= 1
+        partials.append(x)
+    ret = 0.0
+    for p in partials:
+        ret += p
+    return ret
+
+
+def native_radians(arg):
+    return arg.nonref_expr.mul(native_ast.const_float_expr(pi / 180))
+
+
+def native_degrees(arg):
+    return arg.nonref_expr.mul(native_ast.const_float_expr(180 / pi))
+
+
+def native_hypot(arg1, arg2):
+    return runtime_functions.sqrt64.call(arg1 * arg1 + arg2 * arg2)
+
+
 class MathFunctionWrapper(Wrapper):
     is_pod = True
     is_empty = False
     is_pass_by_ref = False
 
-    SUPPORTED_FUNCTIONS = (acos, acosh, asin, asinh, atan, atan2, atanh,
-                           copysign, cos, cosh, degrees, erf, erfc, exp, expm1, fabs, factorial,
-                           fmod, frexp, fsum, hypot, gamma, gcd, isclose, isnan, isfinite, isinf, ldexp, lgamma,
-                           log, log2, log10, log1p, modf, pow, radians,
-                           sin, sinh, sqrt, tan, tanh)
+    MathImpl = NamedTuple(f=object, args=TupleOf(object), ret=object, check_inf=bool)
+    # f is a runtime_function, or a function returning a native expression, or None.
+    #   None means this implementation is a special case
+    # args is the tuple of argument types, if it's not just (float,), with elements float, int, "index", or "iterable".
+    #   None means arg_types=(float,)
+    # ret is the appropriate type or Wrapper for the return value, if it's not float.
+    #   None means float.
+    #   A tuple is permitted, meaning that a MasqueradedTuple of those types should be returned.
+    # check_inf=True means we should generate code to raise an error if the inputs were finite but the output was not finite
+    #    This is only needed if the runtime_function doesn't do this already, for example, if it is an LLVM intrinsic.
+    math_impls = Dict(object, MathImpl)({
+        acos: MathImpl(f=runtime_functions.acos64),
+        acosh: MathImpl(f=runtime_functions.acosh64),
+        asin: MathImpl(f=runtime_functions.asin64),
+        asinh: MathImpl(f=runtime_functions.asinh64),
+        atan: MathImpl(f=runtime_functions.atan64),
+        atanh: MathImpl(f=runtime_functions.atanh64),
+        # ceil: MathImpl(f=runtime_functions.ceil64),  # see BuiltinWrapper
+        cos: MathImpl(f=runtime_functions.cos64),
+        cosh: MathImpl(f=runtime_functions.cosh64),
+        degrees: MathImpl(f=native_degrees),
+        erf: MathImpl(f=runtime_functions.erf64),
+        erfc: MathImpl(f=runtime_functions.erfc64),
+        exp: MathImpl(f=runtime_functions.exp64, check_inf=True),
+        expm1: MathImpl(f=runtime_functions.expm1_64),
+        fabs: MathImpl(f=runtime_functions.fabs64),
+        factorial: MathImpl(f=runtime_functions.factorial64),
+        # floor: MathImpl(f=runtime_functions.floor64),  # see BuiltinWrapper
+        frexp: MathImpl(f=runtime_functions.frexp64, ret=(float, int)),
+        fsum: MathImpl(f=None, args=("iterable",)),  # special case, in this table for completeness
+        gamma: MathImpl(f=runtime_functions.gamma64),
+        isfinite: MathImpl(f=runtime_functions.isfinite_float64, ret=bool),
+        isinf: MathImpl(f=runtime_functions.isinf_float64, ret=bool),
+        isnan: MathImpl(f=runtime_functions.isnan_float64, ret=bool),
+        ldexp: MathImpl(f=runtime_functions.ldexp64, args=(float, int)),
+        lgamma: MathImpl(f=runtime_functions.lgamma64),
+        log: MathImpl(f=runtime_functions.log64),
+        log1p: MathImpl(f=runtime_functions.log1p64),
+        log2: MathImpl(f=runtime_functions.log2_64),
+        log10: MathImpl(f=runtime_functions.log10_64),
+        modf: MathImpl(f=runtime_functions.modf64, ret=(float, float)),
+        radians: MathImpl(f=native_radians),
+        sin: MathImpl(f=runtime_functions.sin64),
+        sinh: MathImpl(f=runtime_functions.sinh64, check_inf=True),
+        sqrt: MathImpl(f=runtime_functions.sqrt64),
+        tan: MathImpl(f=runtime_functions.tan64),
+        tanh: MathImpl(f=runtime_functions.tanh64),
+        atan2: MathImpl(f=runtime_functions.atan2_64, args=(float, float)),
+        copysign: MathImpl(f=runtime_functions.copysign64, args=(float, float)),
+        fmod: MathImpl(f=runtime_functions.fmod64, args=(float, float)),
+        gcd: MathImpl(f=runtime_functions.gcd, args=("index", "index"), ret=int),
+        hypot: MathImpl(f=native_hypot, args=(float, float)),
+        isclose: MathImpl(f=runtime_functions.isclose64, ret=bool),  # special case, in this table for completeness
+        pow: MathImpl(f=runtime_functions.pow64, args=(float, float), check_inf=True),
+        # trunc: MathImpl(f=runtime_functions.trunc64),  # see BuiltinWrapper
+    })
+
+    SUPPORTED_FUNCTIONS = tuple(math_impls.keys())
 
     def __init__(self, mathFun):
         assert mathFun in self.SUPPORTED_FUNCTIONS
@@ -137,318 +260,190 @@ class MathFunctionWrapper(Wrapper):
     def getNativeLayoutType(self):
         return native_ast.Type.Void()
 
+    @Wrapper.unwrapOneOfAndValue
     def convert_call(self, context, expr, args, kwargs):
-        if len(args) == 2 and not kwargs and self.typeRepresentation is ldexp:
-            arg1 = args[0]
-            if not arg1.expr_type.is_arithmetic:
-                return context.pushException(TypeError, f"must be a real number, not {arg1.expr_type}")
-            arg2 = args[1]
-            if not arg2.expr_type.is_arithmetic:
-                return context.pushException(TypeError, "Expected an int as second argument to ldexp.")
-            argType1 = arg1.expr_type.typeRepresentation
-            argType2 = arg2.expr_type.typeRepresentation
-            if argType1 not in (Float32, float):
-                arg1 = arg1.toFloat64()
-                if arg1 is None:
-                    return None
-                argType1 = float
-            if argType2 not in (int,):
-                arg2 = arg2.toInt64()
-                if arg2 is None:
-                    return context.pushException(TypeError, "Expected an int as second argument to ldexp.")
-            # argType2 == int
-            outT = argType1
-            func = runtime_functions.ldexp32 if argType1 is Float32 else runtime_functions.ldexp64
-            return context.pushPod(outT, func.call(arg1.nonref_expr, arg2.nonref_expr))
+        # Special cases
+        if self.typeRepresentation is fsum and len(args) == 1 and not kwargs:
+            # fsum behaves differently in 3.8+
+            if sys.version_info.major >= 3 and sys.version_info.minor >= 8:
+                return context.call_py_function(sumIterable38, (args[0],), {})
+            return context.call_py_function(sumIterable, (args[0],), {})
 
-        if len(args) == 2 and not kwargs and self.typeRepresentation is gcd:
-            arg1 = args[0]
-            arg2 = args[1]
-            argType1 = arg1.expr_type.typeRepresentation
-            argType2 = arg2.expr_type.typeRepresentation
-            if argType1 in (Float32, float) or not arg1.expr_type.is_arithmetic:
-                return context.pushException(ValueError, f"'{argType1}' object cannot be interpreted as an integer")
-            if argType2 in (Float32, float) or not arg2.expr_type.is_arithmetic:
-                return context.pushException(ValueError, f"'{argType2}' object cannot be interpreted as an integer")
-            arg1 = arg1.convert_abs()
+        if self.typeRepresentation is isclose and 2 <= len(args) <= 4:
+            arg1 = args[0].convert_to_type(float, ConversionLevel.Math)
             if arg1 is None:
                 return None
-            arg1 = arg1.convert_to_type(UInt64, ConversionLevel.Implicit)
-            if arg1 is None:
-                return None
-            arg2 = arg2.convert_abs()
+            arg2 = args[1].convert_to_type(float, ConversionLevel.Math)
             if arg2 is None:
                 return None
-            arg2 = arg2.convert_to_type(UInt64, ConversionLevel.Implicit)
-            if arg2 is None:
+
+            if "rel_tol" in kwargs:
+                rel_tol = kwargs["rel_tol"].convert_to_type(float, ConversionLevel.Math)
+                if rel_tol is None:
+                    return None
+                with context.ifelse(rel_tol < 0.0) as (ifTrue, ifFalse):
+                    with ifTrue:
+                        context.pushException(ValueError, "tolerances must be non-negative")
+            else:
+                rel_tol = native_ast.const_float_expr(1e-9)
+                # This is a bad default if the arguments are Float32, but leave it to the user to select a better value.
+
+            if "abs_tol" in kwargs:
+                abs_tol = kwargs["abs_tol"].convert_to_type(float, ConversionLevel.Math)
+                if abs_tol is None:
+                    return None
+                with context.ifelse(abs_tol < 0.0) as (ifTrue, ifFalse):
+                    with ifTrue:
+                        context.pushException(ValueError, "tolerances must be non-negative")
+            else:
+                abs_tol = native_ast.const_float_expr(0.0)
+
+            return context.pushPod(bool, runtime_functions.isclose64.call(arg1, arg2, rel_tol, abs_tol))
+
+        # Implementation from table
+        impl = self.math_impls.get(self.typeRepresentation)
+        impl_args = impl.args if impl.args else (float,)
+        outT = impl.ret if impl.ret else float
+
+        # Check number of arguments and kwargs.
+        if len(args) != len(impl_args) or kwargs:
+            return super().convert_call(context, expr, args, kwargs)
+
+        # Check for constant arguments.
+        if all([a.isConstant for a in args]):
+            try:
+                return context.constant(self.typeRepresentation(*(a.constantValue for a in args)))
+            except Exception:
+                # For compatibility, exceptions in constants are not optimized, and so will be raised at runtime,
+                # rather than during compilation.
+                pass
+
+        # Convert arguments.
+        converted_args = []
+        for i, a in enumerate(args):
+            arg_type = impl_args[i]
+            if arg_type == float:
+                converted_a = a.convert_to_type(arg_type, ConversionLevel.Math)
+            elif arg_type == int:
+                converted_a = a.convert_to_type(arg_type, ConversionLevel.Signature)
+            elif arg_type == "index":
+                converted_a = a.toIndex()
+            if converted_a is None:
                 return None
-            return context.pushPod(UInt64, runtime_functions.gcd.call(arg1.nonref_expr, arg2.nonref_expr))
+            converted_args.append(converted_a)
 
-        if len(args) == 2 and (not kwargs or self.typeRepresentation is isclose):
-            arg1 = args[0]
-            if not arg1.expr_type.is_arithmetic:
-                return context.pushException(TypeError, f"must be a real number, not {arg1.expr_type}")
-            arg2 = args[1]
-            if not arg2.expr_type.is_arithmetic:
-                return context.pushException(TypeError, f"must be a real number, not {arg2.expr_type}")
-            argType1 = arg1.expr_type.typeRepresentation
-            argType2 = arg2.expr_type.typeRepresentation
-            if argType1 not in (Float32, float):
-                arg1 = arg1.toFloat64()
-                if arg1 is None:
-                    return None
-                argType1 = float
-            if argType2 not in (Float32, float):
-                arg2 = arg2.toFloat64()
-                if arg2 is None:
-                    return None
-                argType2 = float
-            if argType1 == Float32 and argType2 == float:
-                arg1 = arg1.toFloat64()
-                argType1 = float
-            if argType1 == float and argType2 == Float32:
-                arg2 = arg2.toFloat64()
-                argType2 = float
-            assert argType1 == argType2
+        # convenience variables
+        arg1 = converted_args[0]
+        arg2 = converted_args[1] if len(args) > 1 else None
 
-            outT = argType1  # default behavior is to return same type as arguments
-            if self.typeRepresentation is atan2:
-                func = runtime_functions.atan2_32 if argType1 is Float32 else runtime_functions.atan2_64
-            elif self.typeRepresentation is copysign:
-                func = runtime_functions.copysign32 if argType1 is Float32 else runtime_functions.copysign64
-            elif self.typeRepresentation is fmod:
-                with context.ifelse(arg2.nonref_expr.eq(0.0)) as (ifTrue, ifFalse):
-                    with ifTrue:
-                        context.pushException(ValueError, "math domain error")
-                func = runtime_functions.fmod32 if argType1 is Float32 else runtime_functions.fmod64
-            elif self.typeRepresentation is hypot:
-                # calculate this one directly
-                func = runtime_functions.sqrt32 if argType1 is Float32 else runtime_functions.sqrt64
-                return context.pushPod(outT, func.call(arg1.nonref_expr.mul(arg1.nonref_expr).add(arg2.nonref_expr.mul(arg2.nonref_expr))))
-            elif self.typeRepresentation is isclose:
-                func = runtime_functions.isclose32 if argType1 is Float32 else runtime_functions.isclose64
+        # Validate arguments
+        if self.typeRepresentation is fmod:
+            with context.ifelse(arg2 == 0.0) as (ifTrue, ifFalse):
+                with ifTrue:
+                    context.pushException(ValueError, "math domain error")
+        if self.typeRepresentation is pow:
+            with context.ifelse(arg1 <= 0.0) as (ifTrue, ifFalse):
+                with ifTrue:
+                    with context.ifelse(arg1 == 0.0) as (ifTrue2, ifFalse2):
+                        with ifTrue2:  # arg1 == 0
+                            with context.ifelse(arg2 < 0.0) as (ifTrue3, ifFalse3):
+                                with ifTrue3:  # arg1 == 0, arg2 < 0
+                                    context.pushException(ValueError, "math domain error")
+                        with ifFalse2:  # arg1 < 0
+                            f_isinf = runtime_functions.isinf_float64
+                            with context.ifelse(f_isinf.call(arg1)) as (ifTrue4, ifFalse4):
+                                with ifFalse4:  # arg1 < 0 and arg1 is finite
+                                    f_floor = runtime_functions.floor64
+                                    with context.ifelse(f_floor.call(arg2).sub(arg2).neq(0.0)) as (ifTrue5, ifFalse5):
+                                        with ifTrue5:  # arg1 < 0, arg1 is finite, arg2 not an integer
+                                            context.pushException(ValueError, "math domain error")
+        if self.typeRepresentation in (cos, sin, tan):
+            with context.ifelse(runtime_functions.isinf_float64.call(arg1)) as (ifTrue, ifFalse):
+                with ifTrue:
+                    context.pushException(ValueError, "math domain error")
+        elif self.typeRepresentation in (acos, asin):
+            with context.ifelse(arg1 > 1.0) as (ifTrue, ifFalse):
+                with ifTrue:
+                    context.pushException(ValueError, "math domain error")
+            with context.ifelse(arg1 < -1.0) as (ifTrue, ifFalse):
+                with ifTrue:
+                    context.pushException(ValueError, "math domain error")
+        elif self.typeRepresentation is acosh:
+            with context.ifelse(arg1 < 1.0) as (ifTrue, ifFalse):
+                with ifTrue:
+                    context.pushException(ValueError, "math domain error")
+        elif self.typeRepresentation is atanh:
+            with context.ifelse(arg1 >= 1.0) as (ifTrue, ifFalse):
+                with ifTrue:
+                    context.pushException(ValueError, "math domain error")
+            with context.ifelse(arg1 <= -1.0) as (ifTrue, ifFalse):
+                with ifTrue:
+                    context.pushException(ValueError, "math domain error")
+        elif self.typeRepresentation is factorial:
+            with context.ifelse(arg1 >= 0.0) as (ifTrue, ifFalse):
+                with ifTrue:
+                    f_floor = runtime_functions.floor64
+                    with context.ifelse(f_floor.call(arg1).sub(arg1).neq(0.0)) as (ifTrue2, ifFalse2):
+                        with ifTrue2:  # arg >= 0, arg not an integer
+                            context.pushException(ValueError, "factorial() only accepts integral values")
+                with ifFalse:  # arg1 < 0
+                    context.pushException(ValueError, "factorial() not defined for negative values")
+        elif self.typeRepresentation is gamma:
+            with context.ifelse(arg1 <= 0.0) as (ifTrue, ifFalse):
+                with ifTrue:
+                    with context.ifelse(runtime_functions.isinf_float64.call(arg1)) as (ifTrue2, ifFalse2):
+                        with ifTrue2:  # arg1 == -inf   Note: inf is ok but not -inf
+                            context.pushException(ValueError, "math domain error")
+                    f_floor = runtime_functions.floor64
+                    with context.ifelse(f_floor.call(arg1).sub(arg1).eq(0.0)) as (ifTrue2, ifFalse2):
+                        with ifTrue2:  # arg1 <= 0, arg1 an integer
+                            context.pushException(ValueError, "math domain error")
+        elif self.typeRepresentation is lgamma:
+            with context.ifelse(arg1 <= 0.0) as (ifTrue, ifFalse):
+                with ifTrue:
+                    f_floor = runtime_functions.floor64
+                    with context.ifelse(f_floor.call(arg1).sub(arg1).eq(0.0)) as (ifTrue2, ifFalse2):
+                        with ifTrue2:  # arg1 <= 0, arg1 an integer
+                            context.pushException(ValueError, "math domain error")
+        elif self.typeRepresentation in (log, log2, log10):
+            with context.ifelse(arg1 <= 0.0) as (ifTrue, ifFalse):
+                with ifTrue:
+                    context.pushException(ValueError, "math domain error")
+        elif self.typeRepresentation is log1p:
+            with context.ifelse(arg1 <= -1.0) as (ifTrue, ifFalse):
+                with ifTrue:
+                    context.pushException(ValueError, "math domain error")
+        elif self.typeRepresentation is sqrt:
+            with context.ifelse(arg1 < 0.0) as (ifTrue, ifFalse):
+                with ifTrue:
+                    context.pushException(ValueError, "math domain error")
 
-                if "rel_tol" in kwargs:
-                    rel_tol = kwargs["rel_tol"].convert_to_type(argType1, ConversionLevel.Implicit)
-                    if rel_tol is None:
-                        return None
-                else:
-                    rel_tol = native_ast.const_float32_expr(1e-5) if argType1 is Float32 else native_ast.const_float_expr(1e-9)
+        if not isinstance(impl.f, native_ast.CallTarget):
+            # Implementation as a native expression
+            return context.pushPod(outT, impl.f(*converted_args))
+        else:
+            # Implementation as C++ function or LLVM intrinsic...
 
-                if "abs_tol" in kwargs:
-                    abs_tol = kwargs["abs_tol"].convert_to_type(argType1, ConversionLevel.Implicit)
-                    if abs_tol is None:
-                        return None
-                else:
-                    abs_tol = native_ast.const_float32_expr(0.0) if argType1 is Float32 else native_ast.const_float_expr(0.0)
-
-                return context.pushPod(bool, func.call(arg1.nonref_expr, arg2.nonref_expr, rel_tol, abs_tol))
-            elif self.typeRepresentation is pow:
-                f_func = runtime_functions.floor32 if argType1 is Float32 else runtime_functions.floor64
-                with context.ifelse(arg1.nonref_expr.lte(0.0)) as (ifTrue, ifFalse):
-                    with ifTrue:  # arg1 <= 0
-                        with context.ifelse(arg1.nonref_expr.eq(0.0)) as (ifTrue2, ifFalse2):
-                            with ifTrue2:  # arg1 == 0
-                                with context.ifelse(arg2.nonref_expr.lt(0.0)) as (ifTrue3, ifFalse3):
-                                    with ifTrue3:  # arg1 == 0, arg2 < 0
-                                        context.pushException(ValueError, "math domain error")
-                            with ifFalse2:  # arg1 < 0
-                                with context.ifelse(f_func.call(arg2.nonref_expr).sub(arg2.nonref_expr).eq(0.0)) as (ifTrue4, ifFalse4):
-                                    with ifFalse4:  # arg1 < 0, arg2 not an integer
-                                        context.pushException(ValueError, "math domain error")
-                func = runtime_functions.pow32 if argType1 is Float32 else runtime_functions.pow64
-            else:
-                assert False, "Unreachable"
-
-            return context.pushPod(outT, func.call(arg1.nonref_expr, arg2.nonref_expr))
-
-        # handle integer factorial here
-        if len(args) == 1 and not kwargs and self.typeRepresentation is factorial:
-            arg = args[0]
-            if not arg.expr_type.is_arithmetic:
-                return context.pushException(TypeError, f"must be a real number, not {arg.expr_type}")
-
-            argType = arg.expr_type.typeRepresentation
-            if argType not in (Float32, float):
-                if argType not in (int,):
-                    arg = arg.convert_to_type(int, ConversionLevel.New)
-                    if arg is None:
-                        return None
-                with context.ifelse(arg.nonref_expr.lt(0)) as (ifTrue, ifFalse):
-                    with ifTrue:
-                        context.pushException(ValueError, "factorial() not defined for negative values")
-                return context.pushPod(int, runtime_functions.factorial.call(arg.nonref_expr))
-            # let Float32 and float args fall through to later section, which will handle float factorials
-
-        if len(args) == 1 and not kwargs and self.typeRepresentation is fsum:
-            arg = args[0]
-            return context.call_py_function(sumIterable, (arg,), {})
-
-        if len(args) == 1 and not kwargs:
-            arg = args[0]
-            if not arg.expr_type.is_arithmetic:
-                return context.pushException(TypeError, f"must be a real number, not {arg.expr_type}")
-
-            argType = arg.expr_type.typeRepresentation
-
-            if argType not in (Float32, float):
-                if self.typeRepresentation in (isnan, isinf):
-                    return context.constant(False)
-                elif self.typeRepresentation in (isfinite,):
-                    return context.constant(True)
-                else:
-                    arg = arg.toFloat64()
-                    if arg is None:
-                        return None
-                    argType = float
-
-            outT = argType  # default behavior is to return same type as argument
-            if self.typeRepresentation is acos:
-                with context.ifelse(arg.nonref_expr.gt(1.0)) as (ifTrue, ifFalse):
-                    with ifTrue:
-                        context.pushException(ValueError, "math domain error")
-                with context.ifelse(arg.nonref_expr.lt(-1.0)) as (ifTrue, ifFalse):
-                    with ifTrue:
-                        context.pushException(ValueError, "math domain error")
-                func = runtime_functions.acos32 if argType is Float32 else runtime_functions.acos64
-            elif self.typeRepresentation is acosh:
-                with context.ifelse(arg.nonref_expr.lt(1.0)) as (ifTrue, ifFalse):
-                    with ifTrue:
-                        context.pushException(ValueError, "math domain error")
-                func = runtime_functions.acosh32 if argType is Float32 else runtime_functions.acosh64
-            elif self.typeRepresentation is asin:
-                with context.ifelse(arg.nonref_expr.gt(1.0)) as (ifTrue, ifFalse):
-                    with ifTrue:
-                        context.pushException(ValueError, "math domain error")
-                with context.ifelse(arg.nonref_expr.lt(-1.0)) as (ifTrue, ifFalse):
-                    with ifTrue:
-                        context.pushException(ValueError, "math domain error")
-                func = runtime_functions.asin32 if argType is Float32 else runtime_functions.asin64
-            elif self.typeRepresentation is asinh:
-                func = runtime_functions.asinh32 if argType is Float32 else runtime_functions.asinh64
-            elif self.typeRepresentation is atan:
-                func = runtime_functions.atan32 if argType is Float32 else runtime_functions.atan64
-            elif self.typeRepresentation is atanh:
-                with context.ifelse(arg.nonref_expr.gte(1.0)) as (ifTrue, ifFalse):
-                    with ifTrue:
-                        context.pushException(ValueError, "math domain error")
-                with context.ifelse(arg.nonref_expr.lte(-1.0)) as (ifTrue, ifFalse):
-                    with ifTrue:
-                        context.pushException(ValueError, "math domain error")
-                func = runtime_functions.atanh32 if argType is Float32 else runtime_functions.atanh64
-            elif self.typeRepresentation is ceil:
-                func = runtime_functions.ceil32 if argType is Float32 else runtime_functions.ceil64
-            elif self.typeRepresentation is cos:
-                func = runtime_functions.cos32 if argType is Float32 else runtime_functions.cos64
-            elif self.typeRepresentation is cosh:
-                func = runtime_functions.cosh32 if argType is Float32 else runtime_functions.cosh64
-            elif self.typeRepresentation is degrees:
-                if argType is Float32:
-                    return context.pushPod(outT, arg.nonref_expr.mul(native_ast.const_float32_expr(180 / pi)))
-                else:
-                    return context.pushPod(outT, arg.nonref_expr.mul(native_ast.const_float_expr(180 / pi)))
-            elif self.typeRepresentation is erf:
-                func = runtime_functions.erf32 if argType is Float32 else runtime_functions.erf64
-            elif self.typeRepresentation is erfc:
-                func = runtime_functions.erfc32 if argType is Float32 else runtime_functions.erfc64
-            elif self.typeRepresentation is exp:
-                func = runtime_functions.exp32 if argType is Float32 else runtime_functions.exp64
-            elif self.typeRepresentation is expm1:
-                func = runtime_functions.expm1_32 if argType is Float32 else runtime_functions.expm1_64
-            elif self.typeRepresentation is fabs:
-                func = runtime_functions.fabs32 if argType is Float32 else runtime_functions.fabs64
-            elif self.typeRepresentation is factorial:
-                f_func = runtime_functions.floor32 if argType is Float32 else runtime_functions.floor64
-                with context.ifelse(arg.nonref_expr.gte(0.0)) as (ifTrue, ifFalse):
-                    with ifTrue:  # arg >= 0
-                        with context.ifelse(f_func.call(arg.nonref_expr).sub(arg.nonref_expr).neq(0.0)) as (ifTrue2, ifFalse2):
-                            with ifTrue2:  # arg >= 0, arg not an integer
-                                context.pushException(ValueError, "factorial() only accepts integral values")
-                    with ifFalse:  # arg < 0
-                        context.pushException(ValueError, "factorial() not defined for negative values")
-                func = runtime_functions.factorial32 if argType is Float32 else runtime_functions.factorial64
-            elif self.typeRepresentation is floor:
-                func = runtime_functions.floor32 if argType is Float32 else runtime_functions.floor64
-            elif self.typeRepresentation is frexp:
-                outT = MasqueradingTupleWrapper(Tuple(argType, int))
+            # ... returning a tuple.
+            if isinstance(outT, tuple):
+                outT = MasqueradingTupleWrapper(Tuple(*impl.ret))
                 return_tuple = native_ast.Expression.StackSlot(name=".return_tuple", type=outT.layoutType)
-                func = runtime_functions.frexp32 if argType is Float32 else runtime_functions.frexp64
-                context.pushEffect(func.call(arg.nonref_expr, return_tuple.elemPtr(0).cast(native_ast.VoidPtr)))
-                return typed_python.compiler.typed_expression.TypedExpression(self, return_tuple, outT, True)
-            elif self.typeRepresentation is gamma:
-                f_func = runtime_functions.floor32 if argType is Float32 else runtime_functions.floor64
-                with context.ifelse(arg.nonref_expr.lte(0.0)) as (ifTrue, ifFalse):
-                    with ifTrue:  # arg <= 0
-                        with context.ifelse(f_func.call(arg.nonref_expr).sub(arg.nonref_expr).eq(0.0)) as (ifTrue2, ifFalse2):
-                            with ifTrue2:  # arg <= 0, arg an integer
-                                context.pushException(ValueError, "math domain error")
-                func = runtime_functions.gamma32 if argType is Float32 else runtime_functions.gamma64
-            elif self.typeRepresentation is isnan:
-                func = runtime_functions.isnan_float32 if argType is Float32 else runtime_functions.isnan_float64
-                outT = bool
-            elif self.typeRepresentation is isfinite:
-                func = runtime_functions.isfinite_float32 if argType is Float32 else runtime_functions.isfinite_float64
-                outT = bool
-            elif self.typeRepresentation is isinf:
-                func = runtime_functions.isinf_float32 if argType is Float32 else runtime_functions.isinf_float64
-                outT = bool
-            elif self.typeRepresentation is lgamma:
-                f_func = runtime_functions.floor32 if argType is Float32 else runtime_functions.floor64
-                with context.ifelse(arg.nonref_expr.lte(0.0)) as (ifTrue, ifFalse):
-                    with ifTrue:  # arg <= 0
-                        with context.ifelse(f_func.call(arg.nonref_expr).sub(arg.nonref_expr).eq(0.0)) as (ifTrue2, ifFalse2):
-                            with ifTrue2:  # arg <= 0, arg an integer
-                                context.pushException(ValueError, "math domain error")
-                func = runtime_functions.lgamma32 if argType is Float32 else runtime_functions.lgamma64
-            elif self.typeRepresentation is log:
-                with context.ifelse(arg.nonref_expr.gt(0.0)) as (ifTrue, ifFalse):
-                    with ifFalse:  # arg <= 0
-                        context.pushException(ValueError, "math domain error")
-                func = runtime_functions.log32 if argType is Float32 else runtime_functions.log64
-            elif self.typeRepresentation is log1p:
-                with context.ifelse(arg.nonref_expr.gt(-1.0)) as (ifTrue, ifFalse):
-                    with ifFalse:  # arg <= -1
-                        context.pushException(ValueError, "math domain error")
-                func = runtime_functions.log1p32 if argType is Float32 else runtime_functions.log1p64
-            elif self.typeRepresentation is log2:
-                with context.ifelse(arg.nonref_expr.gt(0.0)) as (ifTrue, ifFalse):
-                    with ifFalse:  # arg <= 0
-                        context.pushException(ValueError, "math domain error")
-                func = runtime_functions.log2_32 if argType is Float32 else runtime_functions.log2_64
-            elif self.typeRepresentation is log10:
-                with context.ifelse(arg.nonref_expr.gt(0.0)) as (ifTrue, ifFalse):
-                    with ifFalse:
-                        context.pushException(ValueError, "math domain error")
-                func = runtime_functions.log10_32 if argType is Float32 else runtime_functions.log10_64
-            elif self.typeRepresentation is radians:
-                if argType is Float32:
-                    return context.pushPod(outT, arg.nonref_expr.mul(native_ast.const_float32_expr(pi / 180)))
-                else:
-                    return context.pushPod(outT, arg.nonref_expr.mul(native_ast.const_float_expr(pi / 180)))
-            elif self.typeRepresentation is modf:
-                outT = MasqueradingTupleWrapper(Tuple(argType, argType))
-                return_tuple = native_ast.Expression.StackSlot(name=".return_tuple", type=outT.layoutType)
-                func = runtime_functions.modf32 if argType is Float32 else runtime_functions.modf64
-                context.pushEffect(func.call(arg.nonref_expr, return_tuple.elemPtr(0).cast(native_ast.VoidPtr)))
-                return typed_python.compiler.typed_expression.TypedExpression(self, return_tuple, outT, True)
-            elif self.typeRepresentation is sin:
-                func = runtime_functions.sin32 if argType is Float32 else runtime_functions.sin64
-            elif self.typeRepresentation is sinh:
-                func = runtime_functions.sinh32 if argType is Float32 else runtime_functions.sinh64
-            elif self.typeRepresentation is sqrt:
-                with context.ifelse(arg.nonref_expr.gte(0.0)) as (ifTrue, ifFalse):
-                    with ifFalse:  # arg < 0
-                        context.pushException(ValueError, "math domain error")
-                func = runtime_functions.sqrt32 if argType is Float32 else runtime_functions.sqrt64
-            elif self.typeRepresentation is tan:
-                func = runtime_functions.tan32 if argType is Float32 else runtime_functions.tan64
-            elif self.typeRepresentation is tanh:
-                func = runtime_functions.tanh32 if argType is Float32 else runtime_functions.tanh64
-            elif self.typeRepresentation is trunc:
-                func = runtime_functions.trunc32 if argType is Float32 else runtime_functions.trunc64
-            else:
-                assert False, "Unreachable"
+                context.pushEffect(impl.f.call(arg1, return_tuple.elemPtr(0).cast(native_ast.VoidPtr)))
+                return typed_python.compiler.typed_expression.TypedExpression(context, return_tuple, outT, True)
 
-            return context.pushPod(outT, func.call(arg.nonref_expr))
+            # ... returning a single value.
+            ret = context.pushPod(outT, impl.f.call(*converted_args))
 
-        return super().convert_call(context, expr, args, kwargs)
+            # Check for nonfinite return value with finite arguments passed in
+            if impl.check_inf:
+                f_isinf = runtime_functions.isinf_float64
+                with context.ifelse(f_isinf.call(ret)) as (ifTrue, ifFalse):
+                    with ifTrue:
+                        f_isfinite = runtime_functions.isfinite_float64
+                        with context.ifelse(
+                            f_isfinite.call(arg1) if len(args) == 1 else
+                            f_isfinite.call(arg1).bitand(f_isfinite.call(arg2))
+                        ) as (ifTrue2, ifFalse2):
+                            with ifTrue2:
+                                context.pushException(OverflowError, 'math range error')
+            return ret

--- a/typed_python/compiler/type_wrappers/python_object_of_type_wrapper.py
+++ b/typed_python/compiler/type_wrappers/python_object_of_type_wrapper.py
@@ -23,6 +23,7 @@ import typed_python.compiler.native_ast as native_ast
 from typed_python.compiler.native_ast import VoidPtr, UInt64
 import typed_python
 import typed_python.compiler.type_wrappers.runtime_functions as runtime_functions
+from math import trunc, floor, ceil
 
 
 typeWrapper = lambda t: typed_python.compiler.python_object_representation.typedPythonTypeToTypeWrapper(t)
@@ -233,6 +234,15 @@ class PythonObjectOfTypeWrapper(RefcountedWrapper):
 
         return context.constant(None)
 
+    def convert_builtin(self, f, context, expr, a1=None):
+        if f == ceil:
+            return context.pushPod(float, runtime_functions.pyobj_ceil.call(expr.nonref_expr.cast(VoidPtr)))
+        elif f == floor:
+            return context.pushPod(float, runtime_functions.pyobj_floor.call(expr.nonref_expr.cast(VoidPtr)))
+        elif f == trunc:
+            return context.pushPod(float, runtime_functions.pyobj_trunc.call(expr.nonref_expr.cast(VoidPtr)))
+        return super().convert_builtin(f, context, expr, a1)
+
     def convert_call(self, context, instance, args, kwargs):
         argsAsObjects = []
         for a in args:
@@ -315,6 +325,25 @@ class PythonObjectOfTypeWrapper(RefcountedWrapper):
             return context.constant(True)
 
         t = target_type.typeRepresentation
+        if conversionLevel == ConversionLevel.Math:
+            if t is float:
+                context.pushEffect(
+                    targetVal.expr.store(
+                        runtime_functions.pyobj_to_float64.call(
+                            instance.nonref_expr.cast(VoidPtr)
+                        )
+                    )
+                )
+                return context.constant(True)
+            if t is int:
+                context.pushEffect(
+                    targetVal.expr.store(
+                        runtime_functions.pyobj_to_int64.call(
+                            instance.nonref_expr.cast(VoidPtr)
+                        )
+                    )
+                )
+                return context.constant(True)
 
         if not issubclass(t, OneOf):
             return context.pushPod(

--- a/typed_python/compiler/type_wrappers/runtime_functions.py
+++ b/typed_python/compiler/type_wrappers/runtime_functions.py
@@ -114,118 +114,81 @@ realloc = externalCallTarget("realloc", UInt8Ptr, UInt8Ptr, Int64)
 memcpy = externalCallTarget("memcpy", UInt8Ptr, UInt8Ptr, UInt8Ptr, Int64)
 memmove = externalCallTarget("memmove", UInt8Ptr, UInt8Ptr, UInt8Ptr, Int64)
 
-acos32 = externalCallTarget("np_acos_float32", Float32, Float32)
 acos64 = externalCallTarget("np_acos_float64", Float64, Float64)
 
-acosh32 = externalCallTarget("np_acosh_float32", Float32, Float32)
 acosh64 = externalCallTarget("np_acosh_float64", Float64, Float64)
 
-asin32 = externalCallTarget("np_asin_float32", Float32, Float32)
 asin64 = externalCallTarget("np_asin_float64", Float64, Float64)
 
-asinh32 = externalCallTarget("np_asinh_float32", Float32, Float32)
 asinh64 = externalCallTarget("np_asinh_float64", Float64, Float64)
 
-atan32 = externalCallTarget("np_atan_float32", Float32, Float32)
 atan64 = externalCallTarget("np_atan_float64", Float64, Float64)
 
-atan2_32 = externalCallTarget("np_atan2_float32", Float32, Float32, Float32)
 atan2_64 = externalCallTarget("np_atan2_float64", Float64, Float64, Float64)
 
-atanh32 = externalCallTarget("np_atanh_float32", Float32, Float32)
 atanh64 = externalCallTarget("np_atanh_float64", Float64, Float64)
 
-ceil32 = externalCallTarget("llvm.ceil.f32", Float32, Float32, intrinsic=True)
 ceil64 = externalCallTarget("llvm.ceil.f64", Float64, Float64, intrinsic=True)
 
-copysign32 = externalCallTarget("llvm.copysign.f32", Float32, Float32, Float32, intrinsic=True)
 copysign64 = externalCallTarget("llvm.copysign.f64", Float64, Float64, Float64, intrinsic=True)
 
-cos32 = externalCallTarget("llvm.cos.f32", Float32, Float32, intrinsic=True)
 cos64 = externalCallTarget("llvm.cos.f64", Float64, Float64, intrinsic=True)
 
-cosh32 = externalCallTarget("np_cosh_float32", Float32, Float32)
 cosh64 = externalCallTarget("np_cosh_float64", Float64, Float64)
 
-erf32 = externalCallTarget("np_erf_float32", Float32, Float32)
 erf64 = externalCallTarget("np_erf_float64", Float64, Float64)
 
-erfc32 = externalCallTarget("np_erfc_float32", Float32, Float32)
 erfc64 = externalCallTarget("np_erfc_float64", Float64, Float64)
 
-exp32 = externalCallTarget("llvm.exp.f32", Float32, Float32, intrinsic=True)
 exp64 = externalCallTarget("llvm.exp.f64", Float64, Float64, intrinsic=True)
 
-expm1_32 = externalCallTarget("np_expm1_float32", Float32, Float32)
 expm1_64 = externalCallTarget("np_expm1_float64", Float64, Float64)
 
-fabs32 = externalCallTarget("llvm.fabs.f32", Float32, Float32, intrinsic=True)
 fabs64 = externalCallTarget("llvm.fabs.f64", Float64, Float64, intrinsic=True)
 
 factorial = externalCallTarget("np_factorial", Int64, Int64)
-factorial32 = externalCallTarget("np_factorial32", Float32, Float32)
 factorial64 = externalCallTarget("np_factorial64", Float64, Float64)
 
-floor32 = externalCallTarget("llvm.floor.f32", Float32, Float32, intrinsic=True)
 floor64 = externalCallTarget("llvm.floor.f64", Float64, Float64, intrinsic=True)
 
-fmod32 = externalCallTarget("np_fmod_float32", Float32, Float32, Float32)
 fmod64 = externalCallTarget("np_fmod_float64", Float64, Float64, Float64)
 
-frexp32 = externalCallTarget("np_frexp_float32", Void, Float32, Void.pointer())
 frexp64 = externalCallTarget("np_frexp_float64", Void, Float64, Void.pointer())
 
-gamma32 = externalCallTarget("np_gamma_float32", Float32, Float32)
 gamma64 = externalCallTarget("np_gamma_float64", Float64, Float64)
 
-gcd = externalCallTarget("np_gcd", UInt64, UInt64, UInt64)
+gcd = externalCallTarget("np_gcd", Int64, Int64, Int64)
 
-isclose32 = externalCallTarget("np_isclose_float32", Bool, Float32, Float32, Float32, Float32)
 isclose64 = externalCallTarget("np_isclose_float64", Bool, Float64, Float64, Float64, Float64)
 
-ldexp32 = externalCallTarget("np_ldexp_float32", Float32, Float32, Int64)
 ldexp64 = externalCallTarget("np_ldexp_float64", Float64, Float64, Int64)
 
-lgamma32 = externalCallTarget("np_lgamma_float32", Float32, Float32)
 lgamma64 = externalCallTarget("np_lgamma_float64", Float64, Float64)
 
-log32 = externalCallTarget("llvm.log.f32", Float32, Float32, intrinsic=True)
 log64 = externalCallTarget("llvm.log.f64", Float64, Float64, intrinsic=True)
 
-log1p32 = externalCallTarget("np_log1p_float32", Float32, Float32)
 log1p64 = externalCallTarget("np_log1p_float64", Float64, Float64)
 
-log2_32 = externalCallTarget("llvm.log2.f32", Float32, Float32, intrinsic=True)
 log2_64 = externalCallTarget("llvm.log2.f64", Float64, Float64, intrinsic=True)
 
-log10_32 = externalCallTarget("llvm.log10.f32", Float32, Float32, intrinsic=True)
 log10_64 = externalCallTarget("llvm.log10.f64", Float64, Float64, intrinsic=True)
 
-modf32 = externalCallTarget("np_modf_float32", Void, Float32, Void.pointer())
 modf64 = externalCallTarget("np_modf_float64", Void, Float64, Void.pointer())
 
-pow32 = externalCallTarget("llvm.pow.f32", Float32, Float32, Float32, intrinsic=True)
 pow64 = externalCallTarget("llvm.pow.f64", Float64, Float64, Float64, intrinsic=True)
 
-remainder32 = externalCallTarget("llvm.frem.f32", Float32, Float32, Float32, intrinsic=True)
 remainder64 = externalCallTarget("llvm.frem.f64", Float64, Float64, Float64, intrinsic=True)
 
-sin32 = externalCallTarget("llvm.sin.f32", Float32, Float32, intrinsic=True)
 sin64 = externalCallTarget("llvm.sin.f64", Float64, Float64, intrinsic=True)
 
-sinh32 = externalCallTarget("np_sinh_float32", Float32, Float32)
 sinh64 = externalCallTarget("np_sinh_float64", Float64, Float64)
 
-sqrt32 = externalCallTarget("llvm.sqrt.f32", Float32, Float32, intrinsic=True)
 sqrt64 = externalCallTarget("llvm.sqrt.f64", Float64, Float64, intrinsic=True)
 
-tan32 = externalCallTarget("np_tan_float32", Float32, Float32)
 tan64 = externalCallTarget("np_tan_float64", Float64, Float64)
 
-tanh32 = externalCallTarget("np_tanh_float32", Float32, Float32)
 tanh64 = externalCallTarget("np_tanh_float64", Float64, Float64)
 
-trunc32 = externalCallTarget("llvm.trunc.f32", Float32, Float32, intrinsic=True)
 trunc64 = externalCallTarget("llvm.trunc.f64", Float64, Float64, intrinsic=True)
 
 initialize_exception = externalCallTarget(
@@ -1105,6 +1068,24 @@ pyobj_to_int64 = externalCallTarget(
 
 pyobj_to_float64 = externalCallTarget(
     "np_pyobj_to_float64",
+    Float64,
+    Void.pointer()
+)
+
+pyobj_ceil = externalCallTarget(
+    "np_pyobj_ceil",
+    Float64,
+    Void.pointer()
+)
+
+pyobj_floor = externalCallTarget(
+    "np_pyobj_floor",
+    Float64,
+    Void.pointer()
+)
+
+pyobj_trunc = externalCallTarget(
+    "np_pyobj_trunc",
     Float64,
     Void.pointer()
 )


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->

## Motivation and Context
Addresses issue# 364. 

<!-- Why is this change required? -->
<!-- What problem does it solve? -->
<!--  If it fixes an open issue, please link to the issue here.-->

## Approach
* Math functions now produce results of type float consistently (never `Float32`).
* Better handling of nonfinite values and exceptions (more consistent with interpreter).
* No longer accidentally convert str to float.
* Define conversion level Math that does implicit numeric conversion and `__float__`
  [and `__index__` for 3.8].  This is not a complete conversion level, since it only
  applies to conversions to float.
* Needed to adjust conversion tests since I moved ConversionLevel.New from 5 to 6.
* Compiling ceil, floor: account for python 3.8 changes.
* Rework MathWrapper so most functions are compiled from a table.

## How Has This Been Tested?
<!-- Describe in reasonable detail how you tested your changes. -->
<!-- If appropriate, include details of your testing environment, -->
<!-- tests ran to see how your change affects other areas of the code, etc. -->
* Tests include `OneOf` and `Value` types. 
* Tests include Classes with and without `__float__`, `__ceil__`, `__index__`, and `__int__`.

## Screenshots or console output (if appropriate)
<!-- if not appropriate, remove this section -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.