### PR TITLE
Compile str.split with an argument.  Refs #377.

### DIFF
--- a/typed_python/StringType.hpp
+++ b/typed_python/StringType.hpp
@@ -67,11 +67,12 @@ public:
     static layout* swapcase(layout* l);
     static layout* title(layout* l);
 
-    static layout* strip(layout *l, bool fromLeft=true, bool fromRight=true);
+    static layout* strip_whitespace(layout* l, bool fromLeft=true, bool fromRight=true);
+    static layout* strip(layout* l, bool whiteSpace=true, layout* values=nullptr, bool fromLeft=true, bool fromRight=true);
 
-    static layout* lstrip(layout *l);
+    static layout* lstrip(layout *l, bool whiteSpace=true, layout* values=nullptr);
 
-    static layout* rstrip(layout *l);
+    static layout* rstrip(layout *l, bool whiteSpace=true, layout* values=nullptr);
 
     //return the lowest index in the string where substring sub is found within l[start, end]
     static int64_t find(layout* l, layout* sub, int64_t start, int64_t end);

--- a/typed_python/_runtime.cpp
+++ b/typed_python/_runtime.cpp
@@ -483,9 +483,8 @@ extern "C" {
         return StringType::title(l);
     }
 
-
-    StringType::layout* nativepython_runtime_string_strip(StringType::layout* l, bool fromLeft, bool fromRight) {
-        return StringType::strip(l, fromLeft, fromRight);
+    StringType::layout* nativepython_runtime_string_strip(StringType::layout* l, bool whitespace, StringType::layout* values, bool fromLeft, bool fromRight) {
+        return StringType::strip(l, whitespace, values, fromLeft, fromRight);
     }
 
     int64_t nativepython_runtime_string_find(StringType::layout* l, StringType::layout* sub, int64_t start, int64_t end) {

--- a/typed_python/compiler/tests/string_compilation_test.py
+++ b/typed_python/compiler/tests/string_compilation_test.py
@@ -677,6 +677,28 @@ class TestStringCompilation(unittest.TestCase):
             self.assertEqual(s.rstrip(), rstrip(s), s)
             self.assertEqual(s.lstrip(), lstrip(s), s)
 
+        def strip2(s, p):
+            return s.strip(p)
+
+        def lstrip2(s, p):
+            return s.lstrip(p)
+
+        def rstrip2(s, p):
+            return s.rstrip(p)
+
+        chars = 'a\u20ACa\U0001F000a'
+        strings = {c for c in chars} | {chars, ''}
+        cases = {x+y+z for x in strings for y in strings for z in strings}
+
+        for f in [strip2, lstrip2, rstrip2]:
+            with self.assertRaises(TypeError):
+                Entrypoint(f)("asdf", 10)
+            for s in cases:
+                for p in cases:
+                    r1 = f(s, p)
+                    r2 = Entrypoint(f)(s, p)
+                    self.assertEqual(r1, r2, (f, s, p))
+
     @pytest.mark.skip(reason='just for comparing performance when changing implementation')
     def test_string_find_perf(self):
         @Compiled

--- a/typed_python/compiler/type_wrappers/runtime_functions.py
+++ b/typed_python/compiler/type_wrappers/runtime_functions.py
@@ -577,6 +577,8 @@ string_strip = externalCallTarget(
     Void.pointer(),
     Void.pointer(),
     Bool,
+    Void.pointer(),
+    Bool,
     Bool
 )
 

--- a/typed_python/compiler/type_wrappers/string_wrapper.py
+++ b/typed_python/compiler/type_wrappers/string_wrapper.py
@@ -708,12 +708,15 @@ class StringWrapper(RefcountedWrapper):
         if methodname in ['strip', 'lstrip', 'rstrip'] and not kwargs:
             fromLeft = methodname in ['strip', 'lstrip']
             fromRight = methodname in ['strip', 'rstrip']
-            if len(args) == 0 and not kwargs:
+            if len(args) == 0 or (len(args) == 1 and args[0].expr_type.typeRepresentation == str):
+                arg0 = VoidPtr.zero() if len(args) == 0 else args[0].nonref_expr
                 return context.push(
                     str,
                     lambda strRef: strRef.expr.store(
                         runtime_functions.string_strip.call(
                             instance.nonref_expr.cast(VoidPtr),
+                            native_ast.const_bool_expr(len(args) == 0),
+                            arg0.cast(VoidPtr),
                             native_ast.const_bool_expr(fromLeft),
                             native_ast.const_bool_expr(fromRight)
                         ).cast(self.layoutType)


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

Support compilation of str.split, str.lsplit, and str.rsplit with an argument.  
This functionality is currently missing.
<!-- Why is this change required? -->
<!-- What problem does it solve? -->
<!--  If it fixes an open issue, please link to the issue here.-->

## Approach
Use a single entry point from python into C++ this time (instead of one entry point for each possible signature).

## How Has This Been Tested?
Tested with arguments of various point sizes (1, 2, 4 bytes).  
Tested on invalid types -- should raise TypeError.
<!-- Describe in reasonable detail how you tested your changes. -->
<!-- If appropriate, include details of your testing environment, -->
<!-- tests ran to see how your change affects other areas of the code, etc. -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.