### PR TITLE
Improvements for compiled math functions to work on object arguments.  Refs #364

### DIFF
--- a/typed_python/compiler/tests/math_functions_compilation_test.py
+++ b/typed_python/compiler/tests/math_functions_compilation_test.py
@@ -18,14 +18,29 @@ import time
 import numpy
 
 from typed_python import (
-    Float32, UInt64, UInt32, UInt16, UInt8, Int32, Int16, Int8, ListOf, TupleOf
+    Float32, UInt64, UInt32, UInt16, UInt8, Int32, Int16, Int8, ListOf, Tuple, TupleOf, OneOf
 )
 
 from typed_python import Entrypoint
-
-
 import typed_python.compiler
+from typed_python.compiler.type_wrappers.math_wrappers import sumIterable, sumIterable38
+
+
 typeWrapper = lambda t: typed_python.compiler.python_object_representation.typedPythonTypeToTypeWrapper(t)
+
+
+def callOrExcept(f, *args):
+    try:
+        return ("Normal", f(*args))
+    except Exception as e:
+        return ("Exception", str(e))
+
+
+def callOrExceptType(f, *args):
+    try:
+        return ("Normal", f(*args))
+    except Exception as e:
+        return ("Exception", str(type(e)))
 
 
 @Entrypoint
@@ -156,13 +171,13 @@ class TestMathFunctionsCompilation(unittest.TestCase):
             return math.log10(x)
 
         def f_pow1(x):
-            return math.pow(x, type(x)(2.0))
+            return math.pow(x, 2.0)
 
         def f_pow2(x):
-            return math.pow(x, type(x)(0.8))
+            return math.pow(x, 0.8)
 
         def f_pow3(x):
-            return math.pow(x, type(x)(-2.5))
+            return math.pow(x, -2.5)
 
         def f_sin(x):
             return math.sin(x)
@@ -185,6 +200,11 @@ class TestMathFunctionsCompilation(unittest.TestCase):
         def f_atan2(x, y):
             return math.atan2(x, y)
 
+        cases = [-2.34, -1.0, -0.6, -0.5, 0.0, 0.5, 0.6, 1.0, 2.34, 1e30, -1e30, 1e100, -1e100, math.inf, -math.inf, math.nan]
+        cases += [Float32(v) for v in cases]
+        cases += [Int8(-127), UInt8(255), Int16(-32767), UInt16(65535), Int32(-1), UInt32(1), UInt64(123)]
+        cases += ['1234', set(), {1.1, }, list(), [1.1], tuple()]
+
         for mathFun in [f_acos, f_acosh, f_asin, f_asinh,
                         f_cos, f_cosh, f_sin, f_sinh,
                         f_atan, f_atanh, f_tan, f_tanh,
@@ -195,64 +215,50 @@ class TestMathFunctionsCompilation(unittest.TestCase):
                         f_sqrt]:
             compiled = Entrypoint(mathFun)
 
-            self.assertEqual(compiled.resultTypeFor(float).typeRepresentation, float)
-            self.assertEqual(compiled.resultTypeFor(Float32).typeRepresentation, Float32)
+            self.assertEqual(compiled.resultTypeFor(float).typeRepresentation, float, mathFun)
+            self.assertEqual(compiled.resultTypeFor(Float32).typeRepresentation, float, mathFun)
 
-            for v in [-2.34, -1.0, -0.6, -0.5, 0.0, 0.5, 0.6, 1.0, 2.34]:
-                raisesValueError = False
-                try:
-                    r1 = mathFun(v)
-                except ValueError:
-                    raisesValueError = True
+            for v in cases:
+                r1 = callOrExceptType(mathFun, v)
+                r2 = callOrExceptType(compiled, v)
+                self.assertEqual(r1[0], r2[0], (mathFun, v, r1, r2))
+                if r2[0] == "Normal":
+                    self.assertIsInstance(r2[1], float)
 
-                if raisesValueError:
-                    with self.assertRaises(ValueError):
-                        compiled(v)
-                    with self.assertRaises(ValueError):
-                        compiled(Float32(v))
+                if r1[0] == "Normal" and math.isnan(r1[1]):
+                    self.assertTrue(math.isnan(r2[1]))
+                elif r1[0] == "Normal" and mathFun in (f_erf, f_erfc, f_gamma, f_lgamma) \
+                        and r1[1] != 0.0 and math.isfinite(r1[1]):
+                    # I'm seeing a small difference between python math.erf and C++ std:erf.
+                    # I'm seeing a small difference between python math.erfcand C++ std:erfc
+                    # I'm seeing a small difference between python math.gamma and C++ std:gamma.
+                    # I'm seeing a small difference between python math.lgamma and C++ std:lgamma.
+                    self.assertLess(abs((r2[1] - r1[1]) / r1[1]), 1e-10, (mathFun, v, r1[1], r2[1]))
                 else:
-                    r2 = compiled(v)
-                    self.assertIsInstance(r2, float)
-                    if r1 == 0.0:
-                        self.assertLess(abs(r2 - r1), 1e-10, (mathFun, v, r1, r2))
-                    else:
-                        self.assertLess(abs((r2 - r1) / r1), 1e-10, (mathFun, v, r1, r2))
-
-                    r3 = compiled(Float32(v))
-                    self.assertIsInstance(r3, Float32, (mathFun, v))
-                    if r1 == 0.0:
-                        self.assertLess(abs(r3 - r1), 1e-6, (mathFun, v, r1, r3))
-                    else:
-                        self.assertLess(abs((r3 - r1) / r1), 1e-6, (mathFun, v, r1, r3))
+                    self.assertEqual(r1, r2, (mathFun, v))
 
         for mathFun in [f_pow, f_atan2]:
             compiled = Entrypoint(mathFun)
             self.assertEqual(compiled.resultTypeFor(float, float).typeRepresentation, float)
             self.assertEqual(compiled.resultTypeFor(Float32, float).typeRepresentation, float)
             self.assertEqual(compiled.resultTypeFor(float, Float32).typeRepresentation, float)
-            self.assertEqual(compiled.resultTypeFor(Float32, Float32).typeRepresentation, Float32)
+            self.assertEqual(compiled.resultTypeFor(Float32, Float32).typeRepresentation, float)
 
-            for v1 in [-5.4, -3.0, -1.0, -0.6, -0.5, 0.0, 0.5, 0.6, 1.0, 3.0, 5.4]:
-                for v2 in [-5.4, -3.0, -1.0, -0.6, -0.5, 0.0, 0.5, 0.6, 1.0, 3.0, 5.4]:
-                    raisesValueError = False
-                    try:
-                        r1 = mathFun(v1, v2)
-                    except ValueError:
-                        raisesValueError = True
+            for v1 in [-5.4, -3.0, -1.0, -0.6, -0.5, 0.0, 0.5, 0.6, 1.0, 3.0, 5.4, math.inf, -math.inf, math.nan]:
+                for v2 in [-5.4, -3.0, -1.0, -0.6, -0.5, 0.0, 0.5, 0.6, 1.0, 3.0, 5.4, math.inf, -math.inf, math.nan]:
+                    r1 = callOrExceptType(mathFun, v1, v2)
+                    r2 = callOrExceptType(compiled, v1, v2)
+                    self.assertEqual(r1[0], r2[0], (mathFun, v1, v2, r1, r2))
+                    if r2[0] == "Normal":
+                        self.assertIsInstance(r2[1], float)
 
-                    if raisesValueError:
-                        with self.assertRaises(ValueError):
-                            compiled(v1, v2)
-                        with self.assertRaises(ValueError):
-                            compiled(Float32(v1), Float32(v2))
+                    if r1[0] == "Normal" and math.isnan(r1[1]):
+                        self.assertTrue(math.isnan(r2[1]))
+                    elif r1[0] == "Normal" and mathFun in (f_erf, f_erfc, f_gamma, f_lgamma) \
+                            and r1[1] != 0.0 and math.isfinite(r1[1]):
+                        self.assertLess(abs((r2[1] - r1[1]) / r1[1]), 1e-10, (mathFun, v1, v2, r1[1], r2[1]))
                     else:
-                        r2 = compiled(v1, v2)
-                        self.assertEqual(r1, r2)
-                        r3 = compiled(Float32(v1), Float32(v2))
-                        if r1 == 0.0:
-                            self.assertLess(abs(r3 - r1), 1e-6, (mathFun, v1, v2, r1, r3))
-                        else:
-                            self.assertLess(abs((r3 - r1)/r1), 1e-6, (mathFun, v1, v2, r1, r3))
+                        self.assertEqual(r1, r2, (mathFun, v1, v2))
 
     def test_math_other_one(self):
         def f_fabs(x):
@@ -286,7 +292,7 @@ class TestMathFunctionsCompilation(unittest.TestCase):
             compiled = Entrypoint(mathFun)
 
             self.assertEqual(compiled.resultTypeFor(float).typeRepresentation, float)
-            self.assertEqual(compiled.resultTypeFor(Float32).typeRepresentation, Float32)
+            self.assertEqual(compiled.resultTypeFor(Float32).typeRepresentation, float)
 
             for v in [-1234.5, -12.34, -1.0, -0.5, 0.0, 0.5, 1.0, 12.34, 1234.5]:
                 r1 = mathFun(v)
@@ -295,7 +301,7 @@ class TestMathFunctionsCompilation(unittest.TestCase):
                 self.assertEqual(r1, r2, (mathFun, v))
 
                 r3 = compiled(Float32(v))
-                self.assertIsInstance(r3, Float32)
+                self.assertIsInstance(r3, float)
                 if r1 == 0.0:
                     self.assertLess(abs(r3 - r1), 1e-6, (mathFun, v, r1, r3))
                 else:
@@ -304,14 +310,14 @@ class TestMathFunctionsCompilation(unittest.TestCase):
         for mathFun in [f_factorial]:
             compiled = Entrypoint(mathFun)
 
-            self.assertEqual(compiled.resultTypeFor(int).typeRepresentation, int)
-            self.assertEqual(compiled.resultTypeFor(Int32).typeRepresentation, int)
-            self.assertEqual(compiled.resultTypeFor(UInt8).typeRepresentation, int)
+            self.assertEqual(compiled.resultTypeFor(int).typeRepresentation, float)
+            self.assertEqual(compiled.resultTypeFor(Int32).typeRepresentation, float)
+            self.assertEqual(compiled.resultTypeFor(UInt8).typeRepresentation, float)
 
             for v in range(21):
                 r1 = mathFun(v)
                 r2 = compiled(v)
-                self.assertIsInstance(r2, int)
+                self.assertIsInstance(r2, float)
                 self.assertEqual(r1, r2, (mathFun, v))
 
             with self.assertRaises(ValueError):
@@ -324,8 +330,8 @@ class TestMathFunctionsCompilation(unittest.TestCase):
             for v in range(34):
                 r1 = mathFun(v)
                 r2 = compiled(Float32(v))
-                self.assertIsInstance(r2, Float32)
-                self.assertTrue(abs(Float32(r1) - r2) / Float32(r1) < 1e-6, (mathFun, v))
+                self.assertIsInstance(r2, float)
+                self.assertTrue(abs(r1 - r2) / r1 < 1e-6, (mathFun, v))
 
             for v in range(170):
                 r1 = mathFun(v)
@@ -353,9 +359,9 @@ class TestMathFunctionsCompilation(unittest.TestCase):
                 self.assertEqual(r1, r2, (mathFun, v))
 
                 r3 = compiled(Float32(v))
-                self.assertTrue(type(r3[0]) is Float32)
+                self.assertTrue(type(r3[0]) is float)
                 # self.assertIsInstance(r2[0], Float32) fails for some reason
-                self.assertTrue(type(r3[1]) is (Float32 if mathFun is f_modf else int))
+                self.assertTrue(type(r3[1]) is (float if mathFun is f_modf else int))
                 for i in range(2):
                     self.assertLess(abs((r1[i] - r3[i])/r1[i]) if r1[i] else abs(r1[i] - r3[i]), 1e-6)
 
@@ -366,14 +372,14 @@ class TestMathFunctionsCompilation(unittest.TestCase):
         def f_fmod(x, y):
             return math.fmod(x, y)
 
-        test_values = [-1234.5, -12.34, -1.0, -0.5, 0.0, 0.5, 1.0, 12.34, 1234.5]
+        test_values = [12.34, -1234.5, -12.34, -1.0, -0.5, 0.0, 0.5, 1.0, 12.34, 1234.5]
         for mathFun in [f_hypot, f_fmod]:
             compiled = Entrypoint(mathFun)
 
             self.assertEqual(compiled.resultTypeFor(float, float).typeRepresentation, float)
             self.assertEqual(compiled.resultTypeFor(Float32, float).typeRepresentation, float)
             self.assertEqual(compiled.resultTypeFor(float, Float32).typeRepresentation, float)
-            self.assertEqual(compiled.resultTypeFor(Float32, Float32).typeRepresentation, Float32)
+            self.assertEqual(compiled.resultTypeFor(Float32, Float32).typeRepresentation, float)
 
             for v1 in test_values:
                 for v2 in test_values:
@@ -396,7 +402,7 @@ class TestMathFunctionsCompilation(unittest.TestCase):
                             compiled(Float32(v1), Float32(v2))
                     else:
                         r3 = compiled(Float32(v1), Float32(v2))
-                        self.assertIsInstance(r3, Float32)
+                        self.assertIsInstance(r3, float)
                         if r1 == 0.0:
                             self.assertLess(abs(r3 - r1), 1e-6, (mathFun, v1, v2, r1, r3))
                         else:
@@ -427,12 +433,7 @@ class TestMathFunctionsCompilation(unittest.TestCase):
                             self.assertIsInstance(r2, bool)
                             self.assertEqual(r1, r2, (mathFun, v1, v2, rel_tol, abs_tol))
 
-                            # don't bother testing Float32 if rel_tol is too small
-                            if rel_tol is not None and rel_tol < 1e-5:
-                                continue
-
-                            # default rel_tol is different for Float32
-                            r3 = mathFun(v1, v2, 1e-5 if rel_tol is None else rel_tol, abs_tol)
+                            r3 = mathFun(Float32(v1), Float32(v2), rel_tol, abs_tol)
                             r4 = compiled(Float32(v1), Float32(v2), rel_tol, abs_tol)
                             self.assertIsInstance(r4, bool)
                             self.assertEqual(r3, r4, (mathFun, v1, v2, rel_tol, abs_tol))
@@ -442,11 +443,11 @@ class TestMathFunctionsCompilation(unittest.TestCase):
 
         for mathFun in [f_gcd]:
             compiled = Entrypoint(mathFun)
-            self.assertEqual(compiled.resultTypeFor(int, int).typeRepresentation, UInt64)
-            self.assertEqual(compiled.resultTypeFor(Int32, Int32).typeRepresentation, UInt64)
-            self.assertEqual(compiled.resultTypeFor(UInt32, Int16).typeRepresentation, UInt64)
-            self.assertEqual(compiled.resultTypeFor(Int8, UInt64).typeRepresentation, UInt64)
-            self.assertEqual(compiled.resultTypeFor(UInt64, UInt64).typeRepresentation, UInt64)
+            self.assertEqual(compiled.resultTypeFor(int, int).typeRepresentation, int)
+            self.assertEqual(compiled.resultTypeFor(Int32, Int32).typeRepresentation, int)
+            self.assertEqual(compiled.resultTypeFor(UInt32, Int16).typeRepresentation, int)
+            self.assertEqual(compiled.resultTypeFor(Int8, UInt64).typeRepresentation, int)
+            self.assertEqual(compiled.resultTypeFor(UInt64, UInt64).typeRepresentation, int)
 
             test_values = [-2**63+1, -35, 0, 1, 2, 3, 12, 15, 81, 90, 360, 1000, 1080, 2**16 * 3 * 5 * 7, 2**63-1]
             for v1 in test_values:
@@ -469,9 +470,9 @@ class TestMathFunctionsCompilation(unittest.TestCase):
         for mathFun in [f_ldexp]:
             compiled = Entrypoint(mathFun)
             self.assertEqual(compiled.resultTypeFor(float, int).typeRepresentation, float)
-            self.assertEqual(compiled.resultTypeFor(Float32, int).typeRepresentation, Float32)
-            self.assertEqual(compiled.resultTypeFor(float, Int32).typeRepresentation, float)
-            self.assertEqual(compiled.resultTypeFor(Float32, Int32).typeRepresentation, Float32)
+            self.assertEqual(compiled.resultTypeFor(Float32, int).typeRepresentation, float)
+            self.assertEqual(compiled.resultTypeFor(float, Int32), None)
+            self.assertEqual(compiled.resultTypeFor(Float32, Int32), None)
 
             for v1 in [-123.45, -2.0, -1.0, -0.999, -0.7, -0.5, 0.0, 0.5, 0.7, 0.999, 1.0, 2.0, 123.45]:
                 for v2 in range(-10, 10):
@@ -481,7 +482,7 @@ class TestMathFunctionsCompilation(unittest.TestCase):
                     self.assertEqual(r1, r2, (mathFun, v1, v2))
 
                     r3 = Float32(r1)
-                    r4 = compiled(Float32(v1), Float32(v2))
+                    r4 = compiled(Float32(v1), v2)
                     self.assertEqual(r3, r4, (mathFun, v1, v2))
 
     def test_math_fsum(self):
@@ -503,7 +504,7 @@ class TestMathFunctionsCompilation(unittest.TestCase):
             r2 = compiled(v)
             self.assertEqual(r1, r2)
 
-        with self.assertRaises(ValueError):
+        with self.assertRaises(TypeError):
             compiled([0.1, 0.2, 0.3, "abc"])
 
         with self.assertRaises(TypeError):
@@ -520,6 +521,25 @@ class TestMathFunctionsCompilation(unittest.TestCase):
         self.assertTrue(math.isnan(r2[5]))
         # Note r1 != r2 because nan != nan
         self.assertEqual(r1[0:-1], r2[0:-1])
+
+        def f_calculated_const():
+            return math.log(math.atan(math.exp(math.sin(math.pi))))
+
+        r1 = f_calculated_const()
+        r2 = Entrypoint(f_calculated_const)()
+        # Ensure that any constant propagation optimization does not affect the value.
+        self.assertEqual(r1, r2)
+
+        def f_runtime_error():
+            return math.log(math.log(math.atan(math.exp(math.sin(math.pi)))))
+
+        # Ensure that any constant propagation optimization does not affect runtime errors
+        with self.assertRaises(ValueError):
+            f_runtime_error()
+
+        c_runtime_error = Entrypoint(f_runtime_error)
+        with self.assertRaises(ValueError):
+            c_runtime_error()
 
     def test_math_functions_perf_other(self):
         count = 1000000
@@ -630,3 +650,266 @@ class TestMathFunctionsCompilation(unittest.TestCase):
 
                 del f
                 del g
+
+    def test_math_functions_on_object(self):
+        class ClassCeil:
+            def __ceil__(self):
+                return 123.45
+
+        class ClassFloor:
+            def __floor__(self):
+                return 123.45
+
+        class ClassTrunc:
+            def __trunc__(self):
+                return 123
+
+        class ClassFloat:
+            def __float__(self):
+                return 1.24
+
+        class ClassInt:
+            def __int__(self):
+                return 13
+
+        class ClassIndex:
+            def __index__(self):
+                return 17
+
+        class ClassCeilFloat:
+            def __ceil__(self):
+                return 1.23
+
+            def __float__(self):
+                return 2.34
+
+        def f_ceil(t: object):
+            return math.ceil(t)
+
+        def f_floor(t: object):
+            return math.floor(t)
+
+        def f_trunc(t: object):
+            return math.trunc(t)
+
+        def f_acos(t: object):
+            return math.acos(t)
+
+        def f_acosh(t: object):
+            return math.acosh(t)
+
+        def f_asin(t: object):
+            return math.asin(t)
+
+        def f_asinh(t: object):
+            return math.asinh(t)
+
+        def f_atan(t: object):
+            return math.atan(t)
+
+        def f_atan2(t: object):
+            return math.atan2(t, t)
+
+        def f_atanh(t: object):
+            return math.atanh(t)
+
+        def f_copysign(t: object):
+            return math.copysign(t, t)
+
+        def f_cos(t: object):
+            return math.cos(t)
+
+        def f_cosh(t: object):
+            return math.cosh(t)
+
+        def f_degrees(t: object):
+            return math.degrees(t)
+
+        def f_erf(t: object):
+            return math.erf(t)
+
+        def f_erfc(t: object):
+            return math.erfc(t)
+
+        def f_exp(t: object):
+            return math.exp(t)
+
+        def f_expm1(t: object):
+            return math.expm1(t)
+
+        def f_fabs(t: object):
+            return math.fabs(t)
+
+        def f_fmod(t: object):
+            return math.fmod(t, t)
+
+        def f_frexp(t: object):
+            x = math.frexp(t)
+            return x[0] + x[1]
+
+        def f_fsum(t: object):
+            return math.fsum([t, t, t])
+
+        def f_gamma(t: object):
+            return math.gamma(t)
+
+        def f_gcd(t: object):
+            return math.gcd(t, t)
+
+        def f_hypot(t: object):
+            return math.hypot(t, t)
+
+        def f_isclose(t: object):
+            return math.isclose(t, t)
+
+        def f_isclose2(t: object):
+            return math.isclose(t, t, rel_tol=t)
+
+        def f_isclose3(t: object):
+            return math.isclose(t, t, abs_tol=t)
+
+        def f_isclose4(t: object):
+            return math.isclose(t, t, rel_tol=t, abs_tol=t)
+
+        def f_isfinite(t: object):
+            return math.isfinite(t)
+
+        def f_isinf(t: object):
+            return math.isinf(t)
+
+        def f_isnan(t: object):
+            return math.isnan(t)
+
+        def f_ldexp1(t: object):
+            return math.ldexp(t, 5)
+
+        def f_ldexp2(t: object):
+            return math.ldexp(2.0, t)
+
+        def f_lgamma(t: object):
+            return math.lgamma(t)
+
+        def f_log(t: object):
+            return math.log(t)
+
+        def f_log10(t: object):
+            return math.log10(t)
+
+        def f_log1p(t: object):
+            return math.log1p(t)
+
+        def f_log2(t: object):
+            return math.log2(t)
+
+        def f_modf(t: object):
+            return math.modf(t)
+
+        def f_pow(t: object):
+            return math.pow(t, t)
+
+        def f_radians(t: object):
+            return math.radians(t)
+
+        def f_sin(t: object):
+            return math.sin(t)
+
+        def f_sinh(t: object):
+            return math.sinh(t)
+
+        def f_sqrt(t: object):
+            return math.sqrt(t)
+
+        def f_tan(t: object):
+            return math.tan(t)
+
+        def f_tanh(t: object):
+            return math.tanh(t)
+
+        self.assertEqual(Entrypoint(f_ceil)(1.5), 2.0)
+        self.assertEqual(Entrypoint(f_sin)(0.0), 0.0)
+
+        fns = [f_trunc, f_ceil, f_floor, f_acos, f_acosh, f_asin, f_asinh, f_atan, f_atan2, f_atanh, f_copysign,
+               f_cos, f_cosh, f_degrees, f_erf, f_erfc, f_exp, f_expm1, f_fabs, f_fmod, f_frexp, f_fsum, f_gamma, f_gcd,
+               f_hypot, f_isclose, f_isclose2, f_isclose3, f_isclose4, f_isfinite, f_isinf, f_isnan, f_ldexp1, f_ldexp2, f_lgamma,
+               f_log, f_log10, f_log1p, f_log2, f_modf, f_pow, f_radians, f_sin, f_sinh, f_sqrt, f_tan, f_tanh]
+        values = [
+            0, 0.5, -0.5, 1.0, -1.0, 7, -7, 1e100, -1e100,
+            ClassCeil(), ClassFloor(), ClassTrunc(), ClassFloat(), ClassInt(), ClassIndex(), ClassCeilFloat(),
+            Int32(0), Float32(0.5), None, set(), "1234", "0.0",
+        ]
+        for f in fns:
+            c_f = Entrypoint(f)
+            for v in values:
+                r1 = callOrExceptType(f, v)
+                r2 = callOrExceptType(c_f, v)
+                if r1[0] == 'Normal' and r2[0] == 'Normal' and isinstance(r1[1], (float, int)):
+                    if r1[1] == 0.0:
+                        self.assertLess(abs(r2[1] - r1[1]), 1e-10, (f, v))
+                    else:
+                        self.assertLess(abs((r2[1] - r1[1]) / r1[1]), 1e-10, (f, v))
+                else:
+                    self.assertEqual(r1, r2, (f, v))
+
+    def test_math_functions_on_oneof(self):
+        class ClassIndex:
+            def __index__(self):
+                return 6
+
+        T = OneOf(int, str, 1.99)
+
+        def f_sin(x: T) -> float:
+            return math.sin(x)
+
+        compiled = Entrypoint(f_sin)
+        cases = ListOf(T)([12, "987", 1.99])
+        for v in cases:
+            r1 = callOrExceptType(f_sin, v)
+            r2 = callOrExceptType(compiled, v)
+            self.assertEqual(r1, r2, v)
+
+        T2 = OneOf(int, float, str)
+
+        def f_factorial(x: T2) -> float:
+            return math.factorial(x)
+
+        compiled = Entrypoint(f_factorial)
+        cases = ListOf(T2)([12, 50, 50.0, "string"])
+        for v in cases:
+            r1 = callOrExceptType(f_factorial, v)
+            r2 = callOrExceptType(compiled, v)
+            self.assertEqual(r1[0], r2[0], (v, r1, r2))
+            if r1[0] == 'Exception':
+                self.assertEqual(r1[1], r2[1], v)
+            else:
+                # Python factorial is an exact integer, but our factorial is a float,
+                # so convert python result to float before comparing.
+                self.assertEqual(float(r1[1]), r2[1], v)
+
+        T3 = OneOf(int, float, str, ClassIndex)
+
+        def f_gcd(x: T3, y: T3) -> int:
+            return math.gcd(x, y)
+
+        compiled = Entrypoint(f_gcd)
+        cases = ListOf(Tuple(T3, T3))([(6, 8), (6.0, 8.0), ("6", "8"), (ClassIndex(), ClassIndex())])
+        for v in cases:
+            r1 = callOrExceptType(f_gcd, *v)
+            r2 = callOrExceptType(compiled, *v)
+            self.assertEqual(r1[0], r2[0], (v, r1, r2))
+            if r1[0] == 'Exception':
+                self.assertEqual(r1[1], r2[1], v)
+            else:
+                self.assertEqual(r1[1], r2[1], v)
+
+    def test_math_internal_fns(self):
+        self.assertEqual(sumIterable([1, 2, 3]), 6)
+        self.assertEqual(sumIterable([1e100, 1e-100, -1e100]), 1e-100)
+        self.assertLess(sumIterable(x/1e6 for x in range(-1000000, 1000000, 999)), 0)
+        with self.assertRaises(TypeError):
+            sumIterable([1, 2, "3"])
+
+        self.assertEqual(sumIterable38([1, 2, 3]), 6)
+        self.assertEqual(sumIterable38([1e100, 1e-100, -1e100]), 1e-100)
+        self.assertLess(sumIterable38(x/1e6 for x in range(-1000000, 1000000, 999)), 0)
+        with self.assertRaises(TypeError):
+            sumIterable38([1, 2, "3"])

--- a/typed_python/compiler/type_wrappers/python_object_of_type_wrapper.py
+++ b/typed_python/compiler/type_wrappers/python_object_of_type_wrapper.py
@@ -23,6 +23,7 @@ import typed_python.compiler.native_ast as native_ast
 from typed_python.compiler.native_ast import VoidPtr, UInt64
 import typed_python
 import typed_python.compiler.type_wrappers.runtime_functions as runtime_functions
+from math import trunc, floor, ceil
 
 
 typeWrapper = lambda t: typed_python.compiler.python_object_representation.typedPythonTypeToTypeWrapper(t)
@@ -233,6 +234,15 @@ class PythonObjectOfTypeWrapper(RefcountedWrapper):
 
         return context.constant(None)
 
+    def convert_builtin(self, f, context, expr, a1=None):
+        if f == ceil:
+            return context.pushPod(float, runtime_functions.pyobj_ceil.call(expr.nonref_expr.cast(VoidPtr)))
+        elif f == floor:
+            return context.pushPod(float, runtime_functions.pyobj_floor.call(expr.nonref_expr.cast(VoidPtr)))
+        elif f == trunc:
+            return context.pushPod(float, runtime_functions.pyobj_trunc.call(expr.nonref_expr.cast(VoidPtr)))
+        return super().convert_builtin(f, context, expr, a1)
+
     def convert_call(self, context, instance, args, kwargs):
         argsAsObjects = []
         for a in args:
@@ -299,6 +309,14 @@ class PythonObjectOfTypeWrapper(RefcountedWrapper):
         return context.pushPod(
             int,
             runtime_functions.pyobj_pynumber_index.call(
+                e.nonref_expr.cast(VoidPtr)
+            )
+        )
+
+    def convert_math_float_cast(self, context, e):
+        return context.pushPod(
+            float,
+            runtime_functions.pyobj_to_float64.call(
                 e.nonref_expr.cast(VoidPtr)
             )
         )

--- a/typed_python/compiler/type_wrappers/runtime_functions.py
+++ b/typed_python/compiler/type_wrappers/runtime_functions.py
@@ -114,118 +114,81 @@ realloc = externalCallTarget("realloc", UInt8Ptr, UInt8Ptr, Int64)
 memcpy = externalCallTarget("memcpy", UInt8Ptr, UInt8Ptr, UInt8Ptr, Int64)
 memmove = externalCallTarget("memmove", UInt8Ptr, UInt8Ptr, UInt8Ptr, Int64)
 
-acos32 = externalCallTarget("np_acos_float32", Float32, Float32)
 acos64 = externalCallTarget("np_acos_float64", Float64, Float64)
 
-acosh32 = externalCallTarget("np_acosh_float32", Float32, Float32)
 acosh64 = externalCallTarget("np_acosh_float64", Float64, Float64)
 
-asin32 = externalCallTarget("np_asin_float32", Float32, Float32)
 asin64 = externalCallTarget("np_asin_float64", Float64, Float64)
 
-asinh32 = externalCallTarget("np_asinh_float32", Float32, Float32)
 asinh64 = externalCallTarget("np_asinh_float64", Float64, Float64)
 
-atan32 = externalCallTarget("np_atan_float32", Float32, Float32)
 atan64 = externalCallTarget("np_atan_float64", Float64, Float64)
 
-atan2_32 = externalCallTarget("np_atan2_float32", Float32, Float32, Float32)
 atan2_64 = externalCallTarget("np_atan2_float64", Float64, Float64, Float64)
 
-atanh32 = externalCallTarget("np_atanh_float32", Float32, Float32)
 atanh64 = externalCallTarget("np_atanh_float64", Float64, Float64)
 
-ceil32 = externalCallTarget("llvm.ceil.f32", Float32, Float32, intrinsic=True)
 ceil64 = externalCallTarget("llvm.ceil.f64", Float64, Float64, intrinsic=True)
 
-copysign32 = externalCallTarget("llvm.copysign.f32", Float32, Float32, Float32, intrinsic=True)
 copysign64 = externalCallTarget("llvm.copysign.f64", Float64, Float64, Float64, intrinsic=True)
 
-cos32 = externalCallTarget("llvm.cos.f32", Float32, Float32, intrinsic=True)
 cos64 = externalCallTarget("llvm.cos.f64", Float64, Float64, intrinsic=True)
 
-cosh32 = externalCallTarget("np_cosh_float32", Float32, Float32)
 cosh64 = externalCallTarget("np_cosh_float64", Float64, Float64)
 
-erf32 = externalCallTarget("np_erf_float32", Float32, Float32)
 erf64 = externalCallTarget("np_erf_float64", Float64, Float64)
 
-erfc32 = externalCallTarget("np_erfc_float32", Float32, Float32)
 erfc64 = externalCallTarget("np_erfc_float64", Float64, Float64)
 
-exp32 = externalCallTarget("llvm.exp.f32", Float32, Float32, intrinsic=True)
 exp64 = externalCallTarget("llvm.exp.f64", Float64, Float64, intrinsic=True)
 
-expm1_32 = externalCallTarget("np_expm1_float32", Float32, Float32)
 expm1_64 = externalCallTarget("np_expm1_float64", Float64, Float64)
 
-fabs32 = externalCallTarget("llvm.fabs.f32", Float32, Float32, intrinsic=True)
 fabs64 = externalCallTarget("llvm.fabs.f64", Float64, Float64, intrinsic=True)
 
 factorial = externalCallTarget("np_factorial", Int64, Int64)
-factorial32 = externalCallTarget("np_factorial32", Float32, Float32)
 factorial64 = externalCallTarget("np_factorial64", Float64, Float64)
 
-floor32 = externalCallTarget("llvm.floor.f32", Float32, Float32, intrinsic=True)
 floor64 = externalCallTarget("llvm.floor.f64", Float64, Float64, intrinsic=True)
 
-fmod32 = externalCallTarget("np_fmod_float32", Float32, Float32, Float32)
 fmod64 = externalCallTarget("np_fmod_float64", Float64, Float64, Float64)
 
-frexp32 = externalCallTarget("np_frexp_float32", Void, Float32, Void.pointer())
 frexp64 = externalCallTarget("np_frexp_float64", Void, Float64, Void.pointer())
 
-gamma32 = externalCallTarget("np_gamma_float32", Float32, Float32)
 gamma64 = externalCallTarget("np_gamma_float64", Float64, Float64)
 
-gcd = externalCallTarget("np_gcd", UInt64, UInt64, UInt64)
+gcd = externalCallTarget("np_gcd", Int64, Int64, Int64)
 
-isclose32 = externalCallTarget("np_isclose_float32", Bool, Float32, Float32, Float32, Float32)
 isclose64 = externalCallTarget("np_isclose_float64", Bool, Float64, Float64, Float64, Float64)
 
-ldexp32 = externalCallTarget("np_ldexp_float32", Float32, Float32, Int64)
 ldexp64 = externalCallTarget("np_ldexp_float64", Float64, Float64, Int64)
 
-lgamma32 = externalCallTarget("np_lgamma_float32", Float32, Float32)
 lgamma64 = externalCallTarget("np_lgamma_float64", Float64, Float64)
 
-log32 = externalCallTarget("llvm.log.f32", Float32, Float32, intrinsic=True)
 log64 = externalCallTarget("llvm.log.f64", Float64, Float64, intrinsic=True)
 
-log1p32 = externalCallTarget("np_log1p_float32", Float32, Float32)
 log1p64 = externalCallTarget("np_log1p_float64", Float64, Float64)
 
-log2_32 = externalCallTarget("llvm.log2.f32", Float32, Float32, intrinsic=True)
 log2_64 = externalCallTarget("llvm.log2.f64", Float64, Float64, intrinsic=True)
 
-log10_32 = externalCallTarget("llvm.log10.f32", Float32, Float32, intrinsic=True)
 log10_64 = externalCallTarget("llvm.log10.f64", Float64, Float64, intrinsic=True)
 
-modf32 = externalCallTarget("np_modf_float32", Void, Float32, Void.pointer())
 modf64 = externalCallTarget("np_modf_float64", Void, Float64, Void.pointer())
 
-pow32 = externalCallTarget("llvm.pow.f32", Float32, Float32, Float32, intrinsic=True)
 pow64 = externalCallTarget("llvm.pow.f64", Float64, Float64, Float64, intrinsic=True)
 
-remainder32 = externalCallTarget("llvm.frem.f32", Float32, Float32, Float32, intrinsic=True)
 remainder64 = externalCallTarget("llvm.frem.f64", Float64, Float64, Float64, intrinsic=True)
 
-sin32 = externalCallTarget("llvm.sin.f32", Float32, Float32, intrinsic=True)
 sin64 = externalCallTarget("llvm.sin.f64", Float64, Float64, intrinsic=True)
 
-sinh32 = externalCallTarget("np_sinh_float32", Float32, Float32)
 sinh64 = externalCallTarget("np_sinh_float64", Float64, Float64)
 
-sqrt32 = externalCallTarget("llvm.sqrt.f32", Float32, Float32, intrinsic=True)
 sqrt64 = externalCallTarget("llvm.sqrt.f64", Float64, Float64, intrinsic=True)
 
-tan32 = externalCallTarget("np_tan_float32", Float32, Float32)
 tan64 = externalCallTarget("np_tan_float64", Float64, Float64)
 
-tanh32 = externalCallTarget("np_tanh_float32", Float32, Float32)
 tanh64 = externalCallTarget("np_tanh_float64", Float64, Float64)
 
-trunc32 = externalCallTarget("llvm.trunc.f32", Float32, Float32, intrinsic=True)
 trunc64 = externalCallTarget("llvm.trunc.f64", Float64, Float64, intrinsic=True)
 
 initialize_exception = externalCallTarget(
@@ -1105,6 +1068,24 @@ pyobj_to_int64 = externalCallTarget(
 
 pyobj_to_float64 = externalCallTarget(
     "np_pyobj_to_float64",
+    Float64,
+    Void.pointer()
+)
+
+pyobj_ceil = externalCallTarget(
+    "np_pyobj_ceil",
+    Float64,
+    Void.pointer()
+)
+
+pyobj_floor = externalCallTarget(
+    "np_pyobj_floor",
+    Float64,
+    Void.pointer()
+)
+
+pyobj_trunc = externalCallTarget(
+    "np_pyobj_trunc",
     Float64,
     Void.pointer()
 )

--- a/typed_python/compiler/type_wrappers/wrapper.py
+++ b/typed_python/compiler/type_wrappers/wrapper.py
@@ -264,6 +264,12 @@ class Wrapper:
             "Can't take instance of type '%s' to an integer index" % (str(self),)
         )
 
+    def convert_math_float_cast(self, context, expr):
+        return context.pushException(
+            TypeError,
+            "Can't take instance of type '%s' to an float" % (str(self),)
+        )
+
     def convert_builtin(self, f, context, expr, a1=None):
         if f is dir and a1 is None:
             if not expr.isReference:

--- a/typed_python/compiler/typed_expression.py
+++ b/typed_python/compiler/typed_expression.py
@@ -309,6 +309,18 @@ class TypedExpression:
 
         return res
 
+    def toFloatMath(self):
+        """Equivalent to __float__"""
+        res = self.expr_type.convert_math_float_cast(self.context, self)
+
+        if not res:
+            return None
+
+        if res.expr_type.typeRepresentation is not float:
+            raise Exception(f"{self.expr_type}.toFloatMath() returned {res.expr_type}, not float.")
+
+        return res
+
     def refAs(self, i):
         return self.expr_type.refAs(self.context, self, i)
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Motivation and Context
Addresses issue# 364. 

<!-- Why is this change required? -->
<!-- What problem does it solve? -->
<!--  If it fixes an open issue, please link to the issue here.-->

## Approach
* Math functions now produce results of type float consistently (never `Float32`).
* Better handling of nonfinite values and exceptions (more consistent with interpreter).
* No longer accidentally convert str to float.
* Compiling ceil, floor: account for python 3.8 changes.
* Rework MathWrapper so most functions are compiled from a table.

## How Has This Been Tested?
<!-- Describe in reasonable detail how you tested your changes. -->
<!-- If appropriate, include details of your testing environment, -->
<!-- tests ran to see how your change affects other areas of the code, etc. -->
* Tests include `OneOf` and `Value` types. 
* Tests include Classes with and without `__float__`, `__ceil__`, `__index__`, and `__int__`.

## Screenshots or console output (if appropriate)
<!-- if not appropriate, remove this section -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.