### PR TITLE
fix typo in `StringType::cmpStatic`

### DIFF
--- a/typed_python/MutuallyRecursiveTypeGroup.cpp
+++ b/typed_python/MutuallyRecursiveTypeGroup.cpp
@@ -18,7 +18,7 @@
 
 bool isCanonicalName(std::string name) {
     // this is the list of standard library modules in python 3.8
-    static std::set<string> canonicalPythonModuleNames({
+    static std::set<std::string> canonicalPythonModuleNames({
         "abc", "aifc", "antigravity", "argparse", "ast", "asynchat", "asyncio", "asyncore",
         "base64", "bdb", "binhex", "bisect", "_bootlocale", "bz2", "calendar", "cgi", "cgitb",
         "chunk", "cmd", "codecs", "codeop", "code", "collections", "_collections_abc",
@@ -71,7 +71,7 @@ bool isCanonicalName(std::string name) {
 // is this a special name in a dict, module, or class that we shouldn't hash?
 // we do want to hash methods like __init__
 bool isSpecialIgnorableName(const std::string& name) {
-    static std::set<string> canonicalMagicMethods({
+    static std::set<std::string> canonicalMagicMethods({
         "__abs__", "__add__", "__and__", "__bool__",
         "__bytes__", "__call__", "__contains__", "__del__",
         "__delattr__", "__eq__", "__float__", "__floordiv__",

--- a/typed_python/StringType.cpp
+++ b/typed_python/StringType.cpp
@@ -1444,13 +1444,13 @@ char StringType::cmpStatic(layout* left, layout* right) {
 }
 
 char StringType::cmpStatic(layout* left, uint8_t* right_data, int right_pointcount, int right_bytes_per_codepoint) {
-    if ( !left && !right ) {
+    if ( !left && !right_data ) {
         return 0;
     }
-    if ( !left && right ) {
+    if ( !left && right_data ) {
         return -1;
     }
-    if ( left && !right ) {
+    if ( left && !right_data ) {
         return 1;
     }
 

--- a/typed_python/StringType.cpp
+++ b/typed_python/StringType.cpp
@@ -17,7 +17,6 @@
 #include "AllTypes.hpp"
 #include  <iostream>
 #include "UnicodeProps.hpp"
-using namespace std;
 
 StringType::layout* StringType::upgradeCodePoints(layout* lhs, int32_t newBytesPerCodepoint) {
     if (!lhs) {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!-- Why is this change required? -->
<!-- What problem does it solve? -->
<!--  If it fixes an open issue, please link to the issue here.-->

A typo in StringType.cpp causes a logical error in `StringType::cmpStatic`

## Approach
<!-- Describe your changes in reasonable detail -->

Fix the typo, remove the `using namespace std` directive. See the commit messages for more detail, included below

* StringType.cpp: remove `using namespace std` directive

    As demonstrated in the previous commit, and as a general principle,
    the `using namespace std` directive can lead to surprising results
    and is not generally recommended.

    Remove it to avoid further similar bugs in the future.
* StringType::cmpStatic: fix accidental reference to std::right

    Because of the `using namespace std` directive at the top of
    StringType.cpp, within `StringType::cmpStatic`, `right` is
    resolved to the function `std::right`, from the `<ios>` header,
    included indirectly by `<iostream>`. `std::right`, a function,
    is always non-null. The intention here was clearly to use
    the parameter `right_data`, not `std::right`.

    Fix that bug.

## How Has This Been Tested?
<!-- Describe in reasonable detail how you tested your changes. -->
<!-- If appropriate, include details of your testing environment, -->
<!-- tests ran to see how your change affects other areas of the code, etc. -->

Not tested.

## Screenshots or console output (if appropriate)
<!-- if not appropriate, remove this section -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.