### PR TITLE
Add llvmlite version pinning in requirements.txt

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -60,7 +60,7 @@ jobs:
         export PIPENV_PIPFILE="Pipfile_$PYTHON_VERSION"
         echo "PIPFILE IS $PIPENV_PIPFILE"
         echo "**** PIPENV LOCK"
-        pipenv lock --dev --requirements > dev-reqs.txt
+        pipenv requirements --dev > dev-reqs.txt
         echo "**** dev-reqs.txt"
         cat dev-reqs.txt
         echo "**** pip install requirements"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-llvmlite
+llvmlite==0.38
 numpy
 psutil
 pytz


### PR DESCRIPTION
## Motivation and Context
Currently installing typed_python using `pip installl -e  .` (standard Python package editable install) will install an importable version of typed_python but one that doesn't build and that causes pytest failures whenever Entrypoint is used (`RuntimeError: LandingPadInst needs to be in a function with a personality.`) - pinning llvmlite to be compatible with the pip lockfile fixes this.

## Approach
N/A, change trivial

## How Has This Been Tested?
`pytest` from repo root has only performance-related flaky test failures.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.