### PR TITLE
Add readthedocs support

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,14 @@
+version: 2
+
+build:
+  os: "ubuntu-20.04"
+  tools:
+    python: "3.10"
+  jobs:
+    pre_build:
+      - sphinx-apidoc -fo docs/api typed_python typed_python/*test* typed_python/*/*test*
+
+
+python:
+  install:
+    - requirements: docs/doc_requirements.txt

--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ hedge fund in New York.  If you're interested in working with us, drop us a line
 
 ## Getting started
 
-You can read the [introductory tutorial](docs/introduction.md) for using `typed_python` or
-check out the documentation [typed_python](docs/typed_python.md).
+You can read the [introductory tutorial](https://github.com/APrioriInvestments/typed_python/docs/introduction.md) for using `typed_python` or
+check out the documentation [here](https://typed-python.readthedocs.io/en/latest/).
 
 ## Where did this come from?
 

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,6 +1,7 @@
 # Minimal makefile for Sphinx documentation
-
-
+SHELL        = /bin/bash
+# SHELL        = /bin/zsh
+.SHELLFLAGS   = -O globstar -c  # enable globstar operator
 
 # You can set these variables from the command line, and also
 # from the environment for the first two.
@@ -8,9 +9,8 @@ SPHINXOPTS    ?=
 SPHINXBUILD   ?= sphinx-build
 SOURCEDIR     = .
 BUILDDIR      = _build
-APIBUILDDIR    = api
+APIBUILDDIR   = api
 MODULEDIR     = ../typed_python
-
 # Put it first so that "make" without argument is like "make help".
 help:
 	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
@@ -18,7 +18,7 @@ help:
 .PHONY: help clean apidocs Makefile
 
 apidocs:
-	@sphinx-apidoc -fo "$(APIBUILDDIR)" "$(MODULEDIR)"
+	@sphinx-apidoc -fo "$(APIBUILDDIR)" "$(MODULEDIR)" $(MODULEDIR)/**/*test*
 
 clean:
 	-rm -rf "$(BUILDDIR)"/*

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -8,27 +8,33 @@
 import os
 import sys
 
-project = 'typed_python'
-copyright = '2022, Braxton McKee'
-author = 'Braxton McKee'
-release = '0.2.6'
+project = "typed_python"
+copyright = "2022, Braxton McKee"
+author = "Braxton McKee"
+release = "0.2.6"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
 
-extensions = ['myst_parser',
-              'sphinx.ext.autodoc',
-              'sphinx.ext.napoleon',
-              'sphinx.ext.viewcode'
-              ]
+extensions = [
+    "myst_parser",
+    "sphinx.ext.autodoc",
+    "sphinx.ext.napoleon",
+    "sphinx.ext.viewcode",
+]
 
-templates_path = ['_templates']
-exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+source_suffix = {
+    ".rst": "restructuredtext",
+    ".md": "markdown",
+}
+
+templates_path = ["_templates"]
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 
-html_theme = 'sphinx_book_theme'
-html_static_path = ['_static']
+html_theme = "sphinx_book_theme"
+html_static_path = ["_static"]
 
-sys.path.insert(0, os.path.abspath('..'))
+sys.path.insert(0, os.path.abspath(".."))

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -7,6 +7,13 @@ typed_python
 ========================================
 Strong typing and an LLVM-based JIT compiler for Python.
 
+.. include::  ../README.md
+   :parser: myst_parser.sphinx_
+
+
+Contents
+========================================
+
 .. toctree::
    :maxdepth: 1
    :caption: For Users


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Motivation and Context
Once merged, this will allow the Sphinx docs in docs/ (and the docstrings) to be built and served at [typed-python.readthedocs.io](http://typed-python.readthedocs.io/). With an appropriate webhook the docs would be rebuilt automatically with every commit to `dev` but that's a separate discussion.

Apologies for the many commits - the RTD/sphinx-apidoc documentation is sparse, and learning which shells RTD and Make like to use, and which of those support the globstar operator, was non-trivial.

## How Has This Been Tested?
This branch's docs are viewable at https://typed-python.readthedocs.io/en/will_grant-add_markdown_rtd_support/. Will delete once merged.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.