### PR TITLE
Revert IR printing to pre-ApplyIntermediates state

### DIFF
--- a/typed_python/compiler/native_ast.py
+++ b/typed_python/compiler/native_ast.py
@@ -426,9 +426,14 @@ def expr_str(self):
             "rethrow with %s:\n" % self.varname + indent(str(self.handler)).rstrip()
         )
     if self.matches.ApplyIntermediates:
-        return (
-            "apply intermediates:\n" + "\n".join(str(x) for x in self.intermediates) + "\nto " + str(self.base)
-        )
+        expr = self.base
+        for i in reversed(self.intermediates):
+            if i.matches.Terminal or i.matches.Effect or i.matches.StackSlot:
+                expr = i.expr >> expr if str(expr) != 'void' else i.expr
+            elif i.matches.Simple:
+                expr = Expression.Let(var=i.name, val=i.expr, within=expr)
+
+        return str(expr)
 
     assert False, type(self)
 


### PR DESCRIPTION
## Motivation and Context
The changes in  [# 72169e2 ](https://github.com/APrioriInvestments/typed_python/commit/72169e2c874a12f9569575a73ce8431577039779) caused the native ast printing to be much more difficult to read - this PR changes the `str_expr` logic to reproduce the pre-commit behaviour.

NB: printing could still be made more legible, and this will cause printing to throw a RecursionError in complex cases (the reason for the above commit being to avoid this happening in the wild). However, if the stack is >1000 layers deep, printing is unlikely to ever give you useful output. 

## How Has This Been Tested?

- See [here](https://gist.github.com/wllgrnt/7d037e7cb7eccfb91aa07a34e55dc8fa)  for the original behaviour
- See [here](https://gist.github.com/wllgrnt/abf77840872578276334fb0154d0ea22) for the current HEAD behaviour
- See [here](https://gist.github.com/wllgrnt/31699c10167b3b09b2c8351784d58635) for the behaviour of this branch.

All the above were generated on
```python
def naive_sum(someList, startingInt):
    for x in someList:
        startingInt += x
    return startingInt
```
compiled and run for a `ListOf(int).`

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.