### PR TITLE
Remove name arg from installInflightFunctions as it's never used

### DIFF
--- a/typed_python/compiler/expression_conversion_context.py
+++ b/typed_python/compiler/expression_conversion_context.py
@@ -119,7 +119,7 @@ class ExpressionConversionContext:
         # the first argument indicates whether this is an instance or type-level dispatch
         assert argTupleType.ElementTypes[0].Value in ('type', 'instance')
 
-        identHash = self.converter.hashObjectToIdentity(
+        identHash = self.converter.hash_object_to_identity(
             (clsType, methodName, retType, argTupleType, kwargTupleType)
         )
 
@@ -1470,7 +1470,7 @@ class ExpressionConversionContext:
         return None
 
     def expressionAsFunctionCall(self, name, args, generatingFunction, identity, outputType=None, alwaysRaises=False):
-        callTarget = self.converter.defineNonPythonFunction(
+        callTarget = self.converter.define_non_python_function(
             name,
             ("expression", identity),
             typed_python.compiler.function_conversion_context.ExpressionFunctionConversionContext(

--- a/typed_python/compiler/expression_conversion_context.py
+++ b/typed_python/compiler/expression_conversion_context.py
@@ -1138,7 +1138,7 @@ class ExpressionConversionContext:
                 funcGlobals[f.__code__.co_freevars[i]] = f.__closure__[i].cell_contents
                 globalsInCells.append(f.__code__.co_freevars[i])
 
-        call_target = self.functionContext.converter.convert(
+        call_target = self.functionContext.converter.convert_python_to_native(
             f.__name__,
             f.__code__,
             funcGlobals,
@@ -1182,7 +1182,7 @@ class ExpressionConversionContext:
         else:
             returnType = typeWrapper(overload.returnType) if overload.returnType is not None else None
 
-        call_target = self.functionContext.converter.convert(
+        call_target = self.functionContext.converter.convert_python_to_native(
             overload.name,
             overload.functionCode,
             overload.realizedGlobals,

--- a/typed_python/compiler/python_to_native_converter.py
+++ b/typed_python/compiler/python_to_native_converter.py
@@ -31,6 +31,7 @@ from typed_python.compiler.directed_graph import DirectedGraph
 from typed_python.compiler.type_wrappers.wrapper import Wrapper
 from typed_python.compiler.type_wrappers.class_wrapper import ClassWrapper
 from typed_python.compiler.python_object_representation import typedPythonTypeToTypeWrapper
+# from typed_python.compiler.runtime import RuntimeEventVisitor (not possible until 3.11 due to circular imports)
 from typed_python.compiler.function_conversion_context import FunctionConversionContext, FunctionOutput, FunctionYield
 from typed_python.compiler.native_function_conversion_context import NativeFunctionConversionContext
 from typed_python.compiler.type_wrappers.python_typed_function_wrapper import (
@@ -47,6 +48,11 @@ VALIDATE_FUNCTION_DEFINITIONS_STABLE = False
 
 
 class FunctionDependencyGraph:
+    """
+    A wrapper for DirectedGraph with identity levels and the ability to tag nodes for
+    recomputation. The nodes of the graph are function hashes, and the edges represent
+    dependency.
+    """
     def __init__(self):
         self.dependency_graph = DirectedGraph()
 
@@ -122,27 +128,77 @@ class FunctionDependencyGraph:
 
 class PythonToNativeConverter:
     """
-    Short description
+    What do you do?
+    - init
 
-    Long description
+    Parses Python functions into an intermediate representation of the AST. These representations
+    are held in self._definitions, and added how?!
+
+    'installed' but new (and hence not fully converted) definitions are stored in
+    _new_native_functions, and are sent downstream when build_and_link_new_module is called.
+
+
+    Holds optional
+
+
+    Usage is effectively, in compileFunctionOverload, we do convert_typed_function_call,
+    then demasquerade_call_target_output, then generate_call_converter, then
+    build_and_link_new_module,
+    then function_pointer_by_name.
+
+    x = understanding
+
+    'identity' is the hexdigest of the function hash
+    'link_name' is the symbol name, prefix + func_name + hash
 
     Attributes:
-        llvm_compiler: The WHAT?
-        compiler_cache: The WHAT?
-        all_defined_names: ?
-        all_cached_names:
-        _link_name_for_identity: ?
-        _identity_for_link_name: ?
-        _definitions: ?
-        _targets: ?
-        _inflight_definitions: ?
-        _inflight_function_conversions: ?
-        _identifier_to_pyfunc: ?
-        _times_calculated: ?
-        _new_native_functions:
-        _visitors:
-        _currentlyConverting:
+        x   llvm_compiler: The WHAT?
+        x   compiler_cache: The WHAT?
+            generate_debug_checks: ?
+            all_defined_names: ?
+            all_cached_names:
+            _link_name_for_identity: ?
+            _identity_for_link_name: ?
+            _definitions: definition blablabla
+            _targets: ?
+            _inflight_definitions: ?
+            _inflight_function_conversions: ?
+            _identifier_to_pyfunc: ?
+            _times_calculated: ?
+            _new_native_functions:
+        x   _visitors: A list of context managers which run on each new function installed with
+                _install_inflight_functions, giving info on e.g. compilation counts.
+            _currently_converting:
 
+
+    Methods:
+        x   __init__
+            is_currently_converting
+            get_definition_count
+        x   add_visitor
+        x   remove_visitor
+            build_and_link_new_module
+            _extract_new_function_definitions
+            _identity_hash_to_linker_name
+            _create_conversion_context
+        x   _define_link_name
+        x   _load_from_compiler_cache
+            define_non_python_function
+            define_native_function
+            _get_typed_call_target
+            _code_to_ast
+            demasquerade_call_target_output
+            generate_call_converter
+            _resolve_all_inflight_functions
+            compile_single_class_dispatch
+            compile_class_destructor
+            function_pointer_by_name
+            convert_typed_function_call
+            hash_object_to_identity
+            _hash_globals
+            _hash_dot_seq
+            convert
+            _install_inflight_functions
     """
     def __init__(self, llvm_compiler: Compiler, compiler_cache: CompilerCache):
         self.llvm_compiler = llvm_compiler
@@ -159,7 +215,7 @@ class PythonToNativeConverter:
 
         self._link_name_for_identity = {}
         self._identity_for_link_name = {}
-        self._definitions = {}
+        self._definitions: Dict[str, native_ast.Function] = {}
         self._targets = {}
         self._inflight_definitions = {}
         self._inflight_function_conversions = {}
@@ -177,482 +233,6 @@ class PythonToNativeConverter:
         self._currently_converting = None
 
         self._dependencies = FunctionDependencyGraph()
-
-    def is_currently_converting(self) -> bool:
-        return len(self._inflight_function_conversions) > 0
-
-    def get_definition_count(self) -> int:
-        """Used by runtime"""
-        return len(self._definitions)
-
-    def add_visitor(self, visitor) -> None:
-        """placeholder - used by runtime. what is visitor?"""
-        self._visitors.append(visitor)
-
-    def remove_visitor(self, visitor) -> None:
-        """placeholder - used by runtime"""
-        self._visitors.remove(visitor)
-
-    def build_and_link_new_module(self) -> None:
-        """
-        grabs all in-flight function definitions (from _inflight_function_conversions) and generates a module.
-
-        placeholder - explain what's afoot.
-
-        """
-        targets = self._extract_new_function_definitions()
-
-        if not targets:
-            return
-
-        if self.compiler_cache is None:
-            # todo - what is loadedModule doing? what is stored?
-            loaded_module = self.llvm_compiler.buildModule(targets)
-            loaded_module.linkGlobalVariables()
-            return
-
-        # get a set of function names that we depend on
-        externally_used = set()
-
-        for funcName in targets:
-            ident = self._identity_for_link_name.get(funcName)
-            if ident is not None:
-                for dep in self._dependencies.get_names_depended_on(ident):
-                    depLN = self._link_name_for_identity.get(dep)
-                    if depLN not in targets:
-                        externally_used.add(depLN)
-
-        binary = self.llvm_compiler.buildSharedObject(targets)
-
-        self.compiler_cache.addModule(
-            binary,
-            {name: self._targets[name] for name in targets if name in self._targets},
-            externally_used
-        )
-
-    def _extract_new_function_definitions(self) -> Dict:  # TODO what kind?
-        """Return a list of all new function definitions since the last conversion."""
-        res = {}
-
-        for u in self._new_native_functions:
-            res[u] = self._definitions[u]
-
-        self._new_native_functions = set()
-        return res
-
-    def _identity_hash_to_linker_name(self, name: str, identity_hash: str, prefix: str = "tp.") -> str:
-        assert isinstance(name, str)
-        assert isinstance(identity_hash, str)
-        assert isinstance(prefix, str)
-
-        return prefix + name + "." + identity_hash
-
-    def _create_conversion_context(
-        self,
-        identity,
-        func_name,
-        func_code,
-        func_globals,
-        func_globals_raw,
-        closure_vars,
-        input_types,
-        output_type,
-        conversion_type
-    ):
-        """placeholder"""
-        ConverterType = conversion_type or FunctionConversionContext
-
-        pyast = self._code_to_ast(func_code)
-
-        return ConverterType(
-            self,
-            func_name,
-            identity,
-            input_types,
-            output_type,
-            closure_vars,
-            func_globals,
-            func_globals_raw,
-            pyast.args,
-            pyast,
-        )
-
-    def _define_link_name(self, identity, link_name: str) -> bool:
-        """placeholder"""
-        if identity in self._link_name_for_identity:
-            if self._link_name_for_identity[identity] != link_name:
-                raise Exception(
-                    f"For identity {identity}:\n\n"
-                    f"{self._link_name_for_identity[identity]}\n\n!=\n\n{link_name}"
-                )
-            assert self._identity_for_link_name[link_name] == identity
-        else:
-            self._link_name_for_identity[identity] = link_name
-            self._identity_for_link_name[link_name] = identity
-
-        if link_name in self._all_defined_names:
-            return False
-
-        self._all_defined_names.add(link_name)
-
-        self._load_from_compiler_cache(link_name)
-
-        return True
-
-    def _load_from_compiler_cache(self, link_name: str) -> None:
-        """placeholder"""
-        if self.compiler_cache:
-            if self.compiler_cache.hasSymbol(link_name):
-                callTargetsAndTypes = self.compiler_cache.loadForSymbol(link_name)
-
-                if callTargetsAndTypes is not None:
-                    newTypedCallTargets, newNativeFunctionTypes = callTargetsAndTypes
-
-                    self._targets.update(newTypedCallTargets)
-                    self.llvm_compiler.markExternal(newNativeFunctionTypes)
-
-                    self._all_defined_names.update(newNativeFunctionTypes)
-                    self._all_cached_names.update(newNativeFunctionTypes)
-
-    def define_non_python_function(self, name, identity_tuple, context) -> Optional[TypedCallTarget]:
-        """Define a non-python generating function (if we haven't defined it before already)
-
-            name - the name to actually give the function.
-            identity_tuple - a unique (sha)hashable tuple
-            context - a FunctionConversionContext lookalike
-
-        returns a TypedCallTarget, or None if it's not known yet
-        """
-        identity = self.hash_object_to_identity(identity_tuple).hexdigest
-        link_name = self._identity_hash_to_linker_name(name, identity, "runtime.")
-
-        self._define_link_name(identity, link_name)
-
-        if self._currently_converting is not None:
-            self._dependencies.add_edge(self._currently_converting, identity)
-        else:
-            self._dependencies.add_root(identity)
-
-        if link_name in self._targets:
-            return self._targets.get(link_name)
-
-        self._inflight_function_conversions[identity] = context
-
-        if context.knownOutputType() is not None or context.alwaysRaises():
-            self._targets[link_name] = self._get_typed_call_target(
-                name,
-                context.getInputTypes(),
-                context.knownOutputType(),
-                alwaysRaises=context.alwaysRaises(),
-                functionMetadata=context.functionMetadata
-            )
-
-        if self._currently_converting is None:
-            # force the function to resolve immediately
-            self._resolve_all_inflight_functions()
-            self._install_inflight_functions()
-            self._inflight_function_conversions.clear()
-
-        return self._targets.get(link_name)
-
-    def define_native_function(self, name, identity, input_types, output_type, generating_function):
-        """Define a native function if we haven't defined it before already.
-
-            name - the name to actually give the function.
-            identity - a tuple consisting of strings, ints, type wrappers, and tuples of same
-            input_types - list of Wrapper objects for the incoming types
-            output_type - Wrapper object for the output type.
-            generating_function - a function producing a native_function_definition.
-                It should accept an expression_conversion_context, an expression for the output
-                if it's not pass-by-value (or None if it is), and a bunch of TypedExpressions
-                and produce code that always ends in a terminal expression, (or if it's pass by value,
-                flows off the end of the function)
-
-        returns a TypedCallTarget. 'generating_function' may call this recursively if it wants.
-        """
-        output_type = type_wrapper(output_type)
-        input_types = [type_wrapper(x) for x in input_types]
-
-        identity = (
-            Hash.from_integer(2) +
-            self.hash_object_to_identity(identity) +
-            self.hash_object_to_identity(output_type) +
-            self.hash_object_to_identity(input_types)
-        ).hexdigest
-
-        return self.define_non_python_function(
-            name,
-            identity,
-            NativeFunctionConversionContext(
-                self, input_types, output_type, generating_function, identity
-            )
-        )
-
-    def _get_typed_call_target(self, name, input_types, output_type, alwaysRaises=False, functionMetadata=None) -> TypedCallTarget:
-        """placeholder"""
-        native_input_types = [a.getNativePassingType() for a in input_types if not a.is_empty]
-        if output_type is None:
-            native_output_type = native_ast.Type.Void()
-        elif output_type.is_pass_by_ref:
-            native_input_types = [output_type.getNativePassingType()] + native_input_types
-            native_output_type = native_ast.Type.Void()
-        else:
-            native_output_type = output_type.getNativeLayoutType()
-
-        res = TypedCallTarget(
-            native_ast.NamedCallTarget(
-                name=name,
-                arg_types=native_input_types,
-                output_type=native_output_type,
-                external=False,
-                varargs=False,
-                intrinsic=False,
-                can_throw=True
-            ),
-            input_types,
-            output_type,
-            alwaysRaises=alwaysRaises,
-            functionMetadata=functionMetadata
-        )
-
-        return res
-
-    def _code_to_ast(self, f):
-        return python_ast.convertFunctionToAlgebraicPyAst(f)
-
-    def demasquerade_call_target_output(self, call_target):
-        """Ensure we are returning the correct 'interpreterType' from callTarget.
-
-        In some cases, we may return a 'masquerade' type in compiled code. This is fine
-        for other compiled code, but the interpreter needs us to transform the result back
-        to the right interpreter type. For instance, we may be returning a *args tuple.
-
-        Returns:
-            a new TypedCallTarget where the output type has the right return type.
-        """
-        if call_target.output_type is None:
-            return call_target
-
-        if call_target.output_type.interpreterTypeRepresentation == call_target.output_type.typeRepresentation:
-            return call_target
-
-        def generator(context, out, *args):
-            assert out is not None, "we should have an output because no masquerade types are pass-by-value"
-
-            res = context.call_typed_call_target(call_target, args)
-
-            out.convert_copy_initialize(res.convert_masquerade_to_untyped())
-
-        res = self.define_native_function(
-            "demasquerade_" + call_target.name,
-            ("demasquerade", call_target.name),
-            call_target.input_types,
-            type_wrapper(call_target.output_type.interpreterTypeRepresentation),
-            generator
-        )
-
-        return res
-
-    def generate_call_converter(self, call_target: TypedCallTarget) -> str:
-        """Given a call target that's optimized for llvm-level dispatch (with individual
-        arguments packed into registers), produce a (native) call-target that
-        we can dispatch to from our C extension, where arguments are packed into
-        an array.
-
-        For instance, we are given
-            T f(A1, A2, A3 ...)
-        and want to produce
-            f(T*, X**)
-        where X is the union of A1, A2, etc.
-
-        Args:
-            callTarget - a TypedCallTarget giving the function we need
-                to generate an alternative entrypoint for
-        Returns:
-            the linker name of the defined native function
-        """
-        identifier = "call_converter_" + call_target.name
-        link_name = call_target.name + ".dispatch"
-
-        # consider something better
-        if link_name in self._all_defined_names:
-            return link_name
-
-        self._load_from_compiler_cache(link_name)
-        if link_name in self._all_defined_names:
-            return link_name
-
-        args = []
-        for i in range(len(call_target.input_types)):
-            if not call_target.input_types[i].is_empty:
-                argtype = call_target.input_types[i].getNativeLayoutType()
-
-                untypedPtr = native_ast.var('input').ElementPtrIntegers(i).load()
-
-                if call_target.input_types[i].is_pass_by_ref:
-                    # we've been handed a pointer, and it's already a pointer
-                    args.append(untypedPtr.cast(argtype.pointer()))
-                else:
-                    args.append(untypedPtr.cast(argtype.pointer()).load())
-
-        if call_target.output_type is not None and call_target.output_type.is_pass_by_ref:
-            body = call_target.call(
-                native_ast.var('return').cast(call_target.output_type.getNativeLayoutType().pointer()),
-                *args
-            )
-        else:
-            body = call_target.call(*args)
-
-            if not (call_target.output_type is None or call_target.output_type.is_empty):
-                body = native_ast.var('return').cast(call_target.output_type.getNativeLayoutType().pointer()).store(body)
-
-        body = native_ast.FunctionBody.Internal(body=body)
-
-        definition = native_ast.Function(
-            args=(
-                ('return', native_ast.Type.Void().pointer()),
-                ('input', native_ast.Type.Void().pointer().pointer())
-            ),
-            body=body,
-            output_type=native_ast.Type.Void()
-        )
-
-        self._link_name_for_identity[identifier] = link_name
-        self._identity_for_link_name[link_name] = identifier
-        self._all_defined_names.add(link_name)
-
-        self._definitions[link_name] = definition
-        self._new_native_functions.add(link_name)
-
-        return link_name
-
-    def _resolve_all_inflight_functions(self):
-        """placeholder"""
-        while True:
-            identity = self._dependencies.get_next_dirty_node()
-            if not identity:
-                return
-
-            link_name = self._link_name_for_identity[identity]
-            if link_name in self._all_cached_names:
-                continue
-
-            function_converter = self._inflight_function_conversions[identity]
-
-            has_definition_before_conversion = identity in self._inflight_definitions
-
-            try:
-                self._currently_converting = identity
-
-                self._times_calculated[identity] = self._times_calculated.get(identity, 0) + 1
-
-                native_function, actual_output_type = function_converter.convertToNativeFunction()
-
-                if native_function is not None:
-                    self._inflight_definitions[identity] = (native_function, actual_output_type)
-            except Exception:
-                for i in self._inflight_function_conversions:
-                    if i in self._link_name_for_identity:
-                        name = self._link_name_for_identity[i]
-                        if name in self._targets:
-                            self._targets.pop(name)
-                        self._all_defined_names.discard(name)
-                        ln = self._link_name_for_identity.pop(i)
-                        self._identity_for_link_name.pop(ln)
-
-                    self._dependencies.drop_node(i)
-
-                self._inflight_function_conversions.clear()
-                self._inflight_definitions.clear()
-                raise
-            finally:
-                self._currently_converting = None
-
-            dirty_upstream = False
-
-            # figure out whether we ought to recalculate all the upstream nodes of this
-            # node. we do that if we get a definition and we didn't have one before, or if
-            # our type stability changed
-            if native_function is not None:
-                if not has_definition_before_conversion:
-                    dirty_upstream = True
-
-                if function_converter.typesAreUnstable():
-                    function_converter.resetTypeInstabilityFlag()
-                    self._dependencies.mark_dirty_with_low_priority(identity)
-                    dirty_upstream = True
-
-                name = self._link_name_for_identity[identity]
-
-                self._targets[name] = self._get_typed_call_target(
-                    name,
-                    function_converter._input_types,
-                    actual_output_type,
-                    alwaysRaises=function_converter.alwaysRaises(),
-                    functionMetadata=function_converter.functionMetadata
-                )
-
-            if dirty_upstream:
-                self._dependencies.function_return_signature_changed(identity)
-
-    def compile_single_class_dispatch(self, interface_class, implementing_class, slot_index):
-        """placeholder"""
-        name, ret_type, arg_type_tuple, kwarg_type_tuple = _types.getClassMethodDispatchSignature(interface_class,
-                                                                                                  implementing_class,
-                                                                                                  slot_index)
-
-        # we are compiling the function 'name' in 'implementingClass' to be installed when
-        # viewing an instance of 'implementingClass' as 'interfaceClass' that's function
-        # 'name' called with signature '(*argTypeTuple, **kwargTypeTuple) -> retType'
-        typed_call_target = ClassWrapper.compileVirtualMethodInstantiation(
-            self,
-            interface_class,
-            implementing_class,
-            name,
-            ret_type,
-            arg_type_tuple,
-            kwarg_type_tuple
-        )
-
-        assert typed_call_target is not None
-
-        self.build_and_link_new_module()
-
-        fp = self.function_pointer_by_name(typed_call_target.name)
-
-        if fp is None:
-            raise Exception(f"Couldn't find a function pointer for {typed_call_target.name}")
-
-        _types.installClassMethodDispatch(interface_class, implementing_class, slot_index, fp.fp)
-
-    def compile_class_destructor(self, cls):
-        """placeholder"""
-        typedCallTarget = type_wrapper(cls).compileDestructor(self)
-
-        assert typedCallTarget is not None
-
-        self.build_and_link_new_module()
-
-        fp = self.function_pointer_by_name(typedCallTarget.name)
-
-        _types.installClassDestructor(cls, fp.fp)
-
-    def function_pointer_by_name(self, link_name) -> NativeFunctionPointer:
-        """Find a NativeFunctionPointer for a given link-time name.
-
-        Args:
-            link_name (str) - the name of the compiled symbol we want
-
-        Returns:
-            a NativeFunctionPointer or None
-        """
-        if self.compiler_cache is None:
-            # the llvm compiler holds it all
-            return self.llvm_compiler.function_pointer_by_name(link_name)
-        else:
-            # the llvm compiler is just building shared objects, but the
-            # compiler cache has all the pointers.
-            return self.compiler_cache.function_pointer_by_name(link_name)
 
     def convert_typed_function_call(self, function_type, overload_index, input_wrappers, assert_is_root=False):
         """placeholder"""
@@ -683,7 +263,7 @@ class PythonToNativeConverter:
         if return_type is NoReturnTypeSpecified:
             return_type = None
 
-        return self.convert(
+        return self.convert_python_to_native(
             overload.name,
             overload.functionCode,
             overload.realizedGlobals,
@@ -695,69 +275,7 @@ class PythonToNativeConverter:
             assert_is_root=assert_is_root
         )
 
-    def hash_object_to_identity(self, hashable, is_module_val=False):
-        """placeholder"""
-        if isinstance(hashable, Hash):
-            return hashable
-
-        if isinstance(hashable, int):
-            return Hash.from_integer(hashable)
-
-        if isinstance(hashable, str):
-            return Hash.from_string(hashable)
-
-        if hashable is None:
-            return Hash.from_integer(1) + Hash.from_integer(0)
-
-        if isinstance(hashable, (dict, list)) and is_module_val:
-            # don't look into dicts and lists at module level
-            return Hash.from_integer(2)
-
-        if isinstance(hashable, (tuple, list)):
-            res = Hash.from_integer(len(hashable))
-            for t in hashable:
-                res += self.hash_object_to_identity(t, is_module_val)
-            return res
-
-        if isinstance(hashable, Wrapper):
-            return hashable.identityHash()
-
-        return Hash(_types.identityHash(hashable))
-
-    def _hash_globals(self, func_globals, code, func_globals_from_cells):
-        """Hash a given piece of code's accesses to funcGlobals.
-
-        We're trying to make sure that if we have a reference to module 'x'
-        in our globals, but we only ever use 'x' by writing 'x.f' or 'x.g', then
-        we shouldn't depend on the entirety of the definition of 'x'.
-        """
-
-        res = Hash.from_integer(0)
-
-        for dot_seq in _types.getCodeGlobalDotAccesses(code):
-            res += self._hash_dot_seq(dot_seq, func_globals)
-
-        for global_name in func_globals_from_cells:
-            res += self._hash_dot_seq([global_name], func_globals)
-
-        return res
-
-    def _hash_dot_seq(self, dot_seq, func_globals):
-        """placeholder"""
-        if not dot_seq or dot_seq[0] not in func_globals:
-            return Hash.from_integer(0)
-
-        item = func_globals[dot_seq[0]]
-
-        if not isinstance(item, ModuleType) or len(dot_seq) == 1:
-            return Hash.from_string(dot_seq[0]) + self.hash_object_to_identity(item, True)
-
-        if not hasattr(item, dot_seq[1]):
-            return Hash.from_integer(0)
-
-        return Hash.from_string(dot_seq[0] + "." + dot_seq[1]) + self.hash_object_to_identity(getattr(item, dot_seq[1]), True)
-
-    def convert(
+    def convert_python_to_native(
         self,
         func_name,
         func_code,
@@ -876,6 +394,474 @@ class PythonToNativeConverter:
             else:
                 return None
 
+    def demasquerade_call_target_output(self, call_target):
+        """Ensure we are returning the correct 'interpreterType' from callTarget.
+
+        In some cases, we may return a 'masquerade' type in compiled code. This is fine
+        for other compiled code, but the interpreter needs us to transform the result back
+        to the right interpreter type. For instance, we may be returning a *args tuple.
+
+        Returns:
+            a new TypedCallTarget where the output type has the right return type.
+        """
+        if call_target.output_type is None:
+            return call_target
+
+        if call_target.output_type.interpreterTypeRepresentation == call_target.output_type.typeRepresentation:
+            return call_target
+
+        def generator(context, out, *args):
+            assert out is not None, "we should have an output because no masquerade types are pass-by-value"
+
+            res = context.call_typed_call_target(call_target, args)
+
+            out.convert_copy_initialize(res.convert_masquerade_to_untyped())
+
+        res = self.define_native_function(
+            "demasquerade_" + call_target.name,
+            ("demasquerade", call_target.name),
+            call_target.input_types,
+            type_wrapper(call_target.output_type.interpreterTypeRepresentation),
+            generator
+        )
+
+        return res
+
+    def generate_call_converter(self, call_target: TypedCallTarget) -> str:
+        """Given a call target that's optimized for llvm-level dispatch (with individual
+        arguments packed into registers), produce a (native) call-target that
+        we can dispatch to from our C extension, where arguments are packed into
+        an array.
+
+        For instance, we are given
+            T f(A1, A2, A3 ...)
+        and want to produce
+            f(T*, X**)
+        where X is the union of A1, A2, etc.
+
+        Args:
+            callTarget - a TypedCallTarget giving the function we need
+                to generate an alternative entrypoint for
+        Returns:
+            the linker name of the defined native function
+        """
+        identifier = "call_converter_" + call_target.name
+        link_name = call_target.name + ".dispatch"
+
+        # consider something better
+        if link_name in self._all_defined_names:
+            return link_name
+
+        self._load_from_compiler_cache(link_name)
+        if link_name in self._all_defined_names:
+            return link_name
+
+        args = []
+        for i in range(len(call_target.input_types)):
+            if not call_target.input_types[i].is_empty:
+                argtype = call_target.input_types[i].getNativeLayoutType()
+
+                untypedPtr = native_ast.var('input').ElementPtrIntegers(i).load()
+
+                if call_target.input_types[i].is_pass_by_ref:
+                    # we've been handed a pointer, and it's already a pointer
+                    args.append(untypedPtr.cast(argtype.pointer()))
+                else:
+                    args.append(untypedPtr.cast(argtype.pointer()).load())
+
+        if call_target.output_type is not None and call_target.output_type.is_pass_by_ref:
+            body = call_target.call(
+                native_ast.var('return').cast(call_target.output_type.getNativeLayoutType().pointer()),
+                *args
+            )
+        else:
+            body = call_target.call(*args)
+
+            if not (call_target.output_type is None or call_target.output_type.is_empty):
+                body = native_ast.var('return').cast(call_target.output_type.getNativeLayoutType().pointer()).store(body)
+
+        body = native_ast.FunctionBody.Internal(body=body)
+
+        definition = native_ast.Function(
+            args=(
+                ('return', native_ast.Type.Void().pointer()),
+                ('input', native_ast.Type.Void().pointer().pointer())
+            ),
+            body=body,
+            output_type=native_ast.Type.Void()
+        )
+
+        self._link_name_for_identity[identifier] = link_name
+        self._identity_for_link_name[link_name] = identifier
+        self._all_defined_names.add(link_name)
+
+        self._definitions[link_name] = definition
+        self._new_native_functions.add(link_name)
+
+        return link_name
+
+    def build_and_link_new_module(self) -> None:
+        """
+        grabs all in-flight function definitions (from _inflight_function_conversions) and generates a module.
+
+        placeholder - explain what's afoot.
+
+        """
+        targets = self._extract_new_function_definitions()
+
+        if not targets:
+            return
+
+        if self.compiler_cache is None:
+            # todo - what is loadedModule doing? what is stored?
+            loaded_module = self.llvm_compiler.buildModule(targets)
+            loaded_module.linkGlobalVariables()
+            return
+
+        # get a set of function names that we depend on
+        externally_used = set()
+
+        for funcName in targets:
+            ident = self._identity_for_link_name.get(funcName)
+            if ident is not None:
+                for dep in self._dependencies.get_names_depended_on(ident):
+                    depLN = self._link_name_for_identity.get(dep)
+                    if depLN not in targets:
+                        externally_used.add(depLN)
+
+        binary = self.llvm_compiler.buildSharedObject(targets)
+
+        self.compiler_cache.addModule(
+            binary,
+            {name: self._targets[name] for name in targets if name in self._targets},
+            externally_used
+        )
+
+    def define_non_python_function(self, name, identity_tuple, context) -> Optional[TypedCallTarget]:
+        """Define a non-python generating function (if we haven't defined it before already)
+
+            name - the name to actually give the function.
+            identity_tuple - a unique (sha)hashable tuple
+            context - a FunctionConversionContext lookalike
+
+        returns a TypedCallTarget, or None if it's not known yet
+        """
+        identity = self.hash_object_to_identity(identity_tuple).hexdigest
+        link_name = self._identity_hash_to_linker_name(name, identity, "runtime.")
+
+        self._define_link_name(identity, link_name)
+
+        if self._currently_converting is not None:
+            self._dependencies.add_edge(self._currently_converting, identity)
+        else:
+            self._dependencies.add_root(identity)
+
+        if link_name in self._targets:
+            return self._targets.get(link_name)
+
+        self._inflight_function_conversions[identity] = context
+
+        if context.knownOutputType() is not None or context.alwaysRaises():
+            self._targets[link_name] = self._get_typed_call_target(
+                name,
+                context.getInputTypes(),
+                context.knownOutputType(),
+                alwaysRaises=context.alwaysRaises(),
+                functionMetadata=context.functionMetadata
+            )
+
+        if self._currently_converting is None:
+            # force the function to resolve immediately
+            self._resolve_all_inflight_functions()
+            self._install_inflight_functions()
+            self._inflight_function_conversions.clear()
+
+        return self._targets.get(link_name)
+
+    def define_native_function(self, name, identity, input_types, output_type, generating_function):
+        """Define a native function if we haven't defined it before already.
+
+            name - the name to actually give the function.
+            identity - a tuple consisting of strings, ints, type wrappers, and tuples of same
+            input_types - list of Wrapper objects for the incoming types
+            output_type - Wrapper object for the output type.
+            generating_function - a function producing a native_function_definition.
+                It should accept an expression_conversion_context, an expression for the output
+                if it's not pass-by-value (or None if it is), and a bunch of TypedExpressions
+                and produce code that always ends in a terminal expression, (or if it's pass by value,
+                flows off the end of the function)
+
+        returns a TypedCallTarget. 'generating_function' may call this recursively if it wants.
+        """
+        output_type = type_wrapper(output_type)
+        input_types = [type_wrapper(x) for x in input_types]
+
+        identity = (
+            Hash.from_integer(2) +
+            self.hash_object_to_identity(identity) +
+            self.hash_object_to_identity(output_type) +
+            self.hash_object_to_identity(input_types)
+        ).hexdigest
+
+        return self.define_non_python_function(
+            name,
+            identity,
+            NativeFunctionConversionContext(
+                self, input_types, output_type, generating_function, identity
+            )
+        )
+
+    def compile_single_class_dispatch(self, interface_class, implementing_class, slot_index):
+        """placeholder"""
+        name, ret_type, arg_type_tuple, kwarg_type_tuple = _types.getClassMethodDispatchSignature(interface_class,
+                                                                                                  implementing_class,
+                                                                                                  slot_index)
+
+        # we are compiling the function 'name' in 'implementingClass' to be installed when
+        # viewing an instance of 'implementingClass' as 'interfaceClass' that's function
+        # 'name' called with signature '(*argTypeTuple, **kwargTypeTuple) -> retType'
+        typed_call_target = ClassWrapper.compileVirtualMethodInstantiation(
+            self,
+            interface_class,
+            implementing_class,
+            name,
+            ret_type,
+            arg_type_tuple,
+            kwarg_type_tuple
+        )
+
+        assert typed_call_target is not None
+
+        self.build_and_link_new_module()
+
+        fp = self.function_pointer_by_name(typed_call_target.name)
+
+        if fp is None:
+            raise Exception(f"Couldn't find a function pointer for {typed_call_target.name}")
+
+        _types.installClassMethodDispatch(interface_class, implementing_class, slot_index, fp.fp)
+
+    def compile_class_destructor(self, cls):
+        """placeholder"""
+        typedCallTarget = type_wrapper(cls).compileDestructor(self)
+
+        assert typedCallTarget is not None
+
+        self.build_and_link_new_module()
+
+        fp = self.function_pointer_by_name(typedCallTarget.name)
+
+        _types.installClassDestructor(cls, fp.fp)
+
+    def function_pointer_by_name(self, link_name) -> NativeFunctionPointer:
+        """Find a NativeFunctionPointer for a given link-time name.
+
+        Args:
+            link_name (str) - the name of the compiled symbol we want
+
+        Returns:
+            a NativeFunctionPointer or None
+        """
+        if self.compiler_cache is None:
+            # the llvm compiler holds it all
+            return self.llvm_compiler.function_pointer_by_name(link_name)
+        else:
+            # the llvm compiler is just building shared objects, but the
+            # compiler cache has all the pointers.
+            return self.compiler_cache.function_pointer_by_name(link_name)
+
+    def hash_object_to_identity(self, hashable, is_module_val=False):
+        """placeholder"""
+        if isinstance(hashable, Hash):
+            return hashable
+
+        if isinstance(hashable, int):
+            return Hash.from_integer(hashable)
+
+        if isinstance(hashable, str):
+            return Hash.from_string(hashable)
+
+        if hashable is None:
+            return Hash.from_integer(1) + Hash.from_integer(0)
+
+        if isinstance(hashable, (dict, list)) and is_module_val:
+            # don't look into dicts and lists at module level
+            return Hash.from_integer(2)
+
+        if isinstance(hashable, (tuple, list)):
+            res = Hash.from_integer(len(hashable))
+            for t in hashable:
+                res += self.hash_object_to_identity(t, is_module_val)
+            return res
+
+        if isinstance(hashable, Wrapper):
+            return hashable.identityHash()
+
+        return Hash(_types.identityHash(hashable))
+
+    def is_currently_converting(self) -> bool:
+        return len(self._inflight_function_conversions) > 0
+
+    def get_definition_count(self) -> int:
+        """Returns the total number of functions in _definitions TODO naff"""
+        return len(self._definitions)
+
+    def add_visitor(self, visitor) -> None:
+        """Add a RuntimeEventVisitor to instrument the conversion process"""
+        self._visitors.append(visitor)
+
+    def remove_visitor(self, visitor) -> None:
+        """Remove a RuntimeEventVisitor from the set of conversion process instruments."""
+        self._visitors.remove(visitor)
+
+    def _define_link_name(self, identity: str, link_name: str) -> bool:
+        """
+        Registers the identity <-> link_name mapping, and tries to load the link_name
+        from the cache.
+
+        Args:
+            identity: The hash for the function
+            link_name: The unique function name (prefix+func_name+hash)
+
+        Returns:
+            False if the link_name is already defined, True otherwise.
+        """
+        if identity in self._link_name_for_identity:
+            if self._link_name_for_identity[identity] != link_name:
+                raise Exception(
+                    f"For identity {identity}:\n\n"
+                    f"{self._link_name_for_identity[identity]}\n\n!=\n\n{link_name}"
+                )
+            assert self._identity_for_link_name[link_name] == identity
+        else:
+            self._link_name_for_identity[identity] = link_name
+            self._identity_for_link_name[link_name] = identity
+
+        if link_name in self._all_defined_names:
+            return False
+
+        self._all_defined_names.add(link_name)
+
+        self._load_from_compiler_cache(link_name)
+
+        return True
+
+    def _load_from_compiler_cache(self, link_name: str) -> None:
+        """Attempt to load `link_name` from the cache, and add the contents of the function's
+        module to relevant registers if successful.
+        """
+        if self.compiler_cache:
+            if self.compiler_cache.hasSymbol(link_name):
+                callTargetsAndTypes = self.compiler_cache.loadForSymbol(link_name)
+
+                if callTargetsAndTypes is not None:
+                    newTypedCallTargets, newNativeFunctionTypes = callTargetsAndTypes
+
+                    self._targets.update(newTypedCallTargets)
+                    self.llvm_compiler.markExternal(newNativeFunctionTypes)
+
+                    self._all_defined_names.update(newNativeFunctionTypes)
+                    self._all_cached_names.update(newNativeFunctionTypes)
+
+    def _create_conversion_context(
+        self,
+        identity,
+        func_name,
+        func_code,
+        func_globals,
+        func_globals_raw,
+        closure_vars,
+        input_types,
+        output_type,
+        conversion_type
+    ):
+        """placeholder"""
+        ConverterType = conversion_type or FunctionConversionContext
+
+        pyast = self._code_to_ast(func_code)
+
+        return ConverterType(
+            self,
+            func_name,
+            identity,
+            input_types,
+            output_type,
+            closure_vars,
+            func_globals,
+            func_globals_raw,
+            pyast.args,
+            pyast,
+        )
+
+    def _resolve_all_inflight_functions(self):
+        """placeholder"""
+        while True:
+            identity = self._dependencies.get_next_dirty_node()
+            if not identity:
+                return
+
+            link_name = self._link_name_for_identity[identity]
+            if link_name in self._all_cached_names:
+                continue
+
+            function_converter = self._inflight_function_conversions[identity]
+
+            has_definition_before_conversion = identity in self._inflight_definitions
+
+            try:
+                self._currently_converting = identity
+
+                self._times_calculated[identity] = self._times_calculated.get(identity, 0) + 1
+
+                native_function, actual_output_type = function_converter.convertToNativeFunction()
+
+                if native_function is not None:
+                    self._inflight_definitions[identity] = (native_function, actual_output_type)
+            except Exception:
+                for i in self._inflight_function_conversions:
+                    if i in self._link_name_for_identity:
+                        name = self._link_name_for_identity[i]
+                        if name in self._targets:
+                            self._targets.pop(name)
+                        self._all_defined_names.discard(name)
+                        ln = self._link_name_for_identity.pop(i)
+                        self._identity_for_link_name.pop(ln)
+
+                    self._dependencies.drop_node(i)
+
+                self._inflight_function_conversions.clear()
+                self._inflight_definitions.clear()
+                raise
+            finally:
+                self._currently_converting = None
+
+            dirty_upstream = False
+
+            # figure out whether we ought to recalculate all the upstream nodes of this
+            # node. we do that if we get a definition and we didn't have one before, or if
+            # our type stability changed
+            if native_function is not None:
+                if not has_definition_before_conversion:
+                    dirty_upstream = True
+
+                if function_converter.typesAreUnstable():
+                    function_converter.resetTypeInstabilityFlag()
+                    self._dependencies.mark_dirty_with_low_priority(identity)
+                    dirty_upstream = True
+
+                name = self._link_name_for_identity[identity]
+
+                self._targets[name] = self._get_typed_call_target(
+                    name,
+                    function_converter._input_types,
+                    actual_output_type,
+                    alwaysRaises=function_converter.alwaysRaises(),
+                    functionMetadata=function_converter.functionMetadata
+                )
+
+            if dirty_upstream:
+                self._dependencies.function_return_signature_changed(identity)
+
     def _install_inflight_functions(self):
         """placeholder"""
         if VALIDATE_FUNCTION_DEFINITIONS_STABLE:
@@ -930,3 +916,85 @@ class PythonToNativeConverter:
 
             self._definitions[name] = native_function
             self._new_native_functions.add(name)
+
+    def _get_typed_call_target(self, name, input_types, output_type, alwaysRaises=False, functionMetadata=None) -> TypedCallTarget:
+        """placeholder"""
+        native_input_types = [a.getNativePassingType() for a in input_types if not a.is_empty]
+        if output_type is None:
+            native_output_type = native_ast.Type.Void()
+        elif output_type.is_pass_by_ref:
+            native_input_types = [output_type.getNativePassingType()] + native_input_types
+            native_output_type = native_ast.Type.Void()
+        else:
+            native_output_type = output_type.getNativeLayoutType()
+
+        res = TypedCallTarget(
+            native_ast.NamedCallTarget(
+                name=name,
+                arg_types=native_input_types,
+                output_type=native_output_type,
+                external=False,
+                varargs=False,
+                intrinsic=False,
+                can_throw=True
+            ),
+            input_types,
+            output_type,
+            alwaysRaises=alwaysRaises,
+            functionMetadata=functionMetadata
+        )
+
+        return res
+
+    def _extract_new_function_definitions(self) -> Dict:  # TODO what kind?
+        """Return a list of all new function definitions since the last conversion."""
+        res = {}
+
+        for u in self._new_native_functions:
+            res[u] = self._definitions[u]
+
+        self._new_native_functions = set()
+        return res
+
+    def _identity_hash_to_linker_name(self, name: str, identity_hash: str, prefix: str = "tp.") -> str:
+        assert isinstance(name, str)
+        assert isinstance(identity_hash, str)
+        assert isinstance(prefix, str)
+
+        return prefix + name + "." + identity_hash
+
+    def _code_to_ast(self, f):
+        return python_ast.convertFunctionToAlgebraicPyAst(f)
+
+    def _hash_globals(self, func_globals, code, func_globals_from_cells):
+        """Hash a given piece of code's accesses to funcGlobals.
+
+        We're trying to make sure that if we have a reference to module 'x'
+        in our globals, but we only ever use 'x' by writing 'x.f' or 'x.g', then
+        we shouldn't depend on the entirety of the definition of 'x'.
+        """
+
+        res = Hash.from_integer(0)
+
+        for dot_seq in _types.getCodeGlobalDotAccesses(code):
+            res += self._hash_dot_seq(dot_seq, func_globals)
+
+        for global_name in func_globals_from_cells:
+            res += self._hash_dot_seq([global_name], func_globals)
+
+        return res
+
+    def _hash_dot_seq(self, dot_seq, func_globals):
+        """placeholder"""
+        if not dot_seq or dot_seq[0] not in func_globals:
+            return Hash.from_integer(0)
+
+        item = func_globals[dot_seq[0]]
+
+        if not isinstance(item, ModuleType) or len(dot_seq) == 1:
+            return Hash.from_string(dot_seq[0]) + self.hash_object_to_identity(item, True)
+
+        if not hasattr(item, dot_seq[1]):
+            return Hash.from_integer(0)
+
+        return Hash.from_string(dot_seq[0] + "." + dot_seq[1]) + self.hash_object_to_identity(getattr(item, dot_seq[1]), True)

--- a/typed_python/compiler/python_to_native_converter.py
+++ b/typed_python/compiler/python_to_native_converter.py
@@ -323,7 +323,7 @@ class PythonToNativeConverter:
         if self._currentlyConverting is None:
             # force the function to resolve immediately
             self._resolveAllInflightFunctions()
-            self._installInflightFunctions(name)
+            self._installInflightFunctions()
             self._inflight_function_conversions.clear()
 
         return self._targets.get(linkName)
@@ -819,7 +819,7 @@ class PythonToNativeConverter:
         if isRoot:
             try:
                 self._resolveAllInflightFunctions()
-                self._installInflightFunctions(name)
+                self._installInflightFunctions()
                 return self._targets[name]
             finally:
                 self._inflight_function_conversions.clear()
@@ -835,7 +835,7 @@ class PythonToNativeConverter:
             else:
                 return None
 
-    def _installInflightFunctions(self, name):
+    def _installInflightFunctions(self):
         if VALIDATE_FUNCTION_DEFINITIONS_STABLE:
             # this should always be true, but its expensive so we have it off by default
             for identifier, functionConverter in self._inflight_function_conversions.items():

--- a/typed_python/compiler/runtime.py
+++ b/typed_python/compiler/runtime.py
@@ -264,7 +264,6 @@ class Runtime:
         overload = functionType.overloads[overloadIx]
 
         assert len(arguments) == len(overload.args)
-
         try:
             t0 = time.time()
             t1 = None
@@ -349,7 +348,6 @@ class Runtime:
         # walk over the closure of funcObj and figure out the appropriate types
         # of each cell.
         funcObj = _types.prepareArgumentToBePassedToCompiler(funcObj)
-
         argTypes = [typeWrapper(a) for a in argTypes]
         kwargTypes = {k: typeWrapper(v) for k, v in kwargTypes.items()}
 

--- a/typed_python/compiler/runtime.py
+++ b/typed_python/compiler/runtime.py
@@ -187,10 +187,10 @@ class Runtime:
             self.verbosityLevel = 0
 
     def addEventVisitor(self, visitor: RuntimeEventVisitor):
-        self.converter.addVisitor(visitor)
+        self.converter.add_visitor(visitor)
 
     def removeEventVisitor(self, visitor: RuntimeEventVisitor):
-        self.converter.removeVisitor(visitor)
+        self.converter.remove_visitor(visitor)
 
     @staticmethod
     def passingTypeForValue(arg):
@@ -269,7 +269,7 @@ class Runtime:
             t0 = time.time()
             t1 = None
             t2 = None
-            defCount = self.converter.getDefinitionCount()
+            defCount = self.converter.get_definition_count()
 
             with self.lock:
                 inputWrappers = []
@@ -285,24 +285,24 @@ class Runtime:
 
                 self.timesCompiled += 1
 
-                callTarget = self.converter.convertTypedFunctionCall(
+                callTarget = self.converter.convert_typed_function_call(
                     functionType,
                     overloadIx,
                     inputWrappers,
-                    assertIsRoot=True
+                    assert_is_root=True
                 )
 
-                callTarget = self.converter.demasqueradeCallTargetOutput(callTarget)
+                callTarget = self.converter.demasquerade_call_target_output(callTarget)
 
                 assert callTarget is not None
 
-                wrappingCallTargetName = self.converter.generateCallConverter(callTarget)
+                wrappingCallTargetName = self.converter.generate_call_converter(callTarget)
 
                 t1 = time.time()
-                self.converter.buildAndLinkNewModule()
+                self.converter.build_and_link_new_module()
                 t2 = time.time()
 
-                fp = self.converter.functionPointerByName(wrappingCallTargetName)
+                fp = self.converter.function_pointer_by_name(wrappingCallTargetName)
 
                 overload._installNativePointer(
                     fp.fp,
@@ -317,18 +317,18 @@ class Runtime:
                     f"typed_python runtime spent {time.time()-t0:.3f} seconds "
                     + (f"({t2 - t1:.3f})" if t2 is not None else "")
                     + " adding " +
-                    f"{self.converter.getDefinitionCount() - defCount} functions."
+                    f"{self.converter.get_definition_count() - defCount} functions."
                 )
 
     def compileClassDispatch(self, interfaceClass, implementingClass, slotIndex):
         with self.lock:
-            self.converter.compileSingleClassDispatch(interfaceClass, implementingClass, slotIndex)
+            self.converter.compile_single_class_dispatch(interfaceClass, implementingClass, slotIndex)
 
         return True
 
     def compileClassDestructor(self, cls):
         with self.lock:
-            self.converter.compileClassDestructor(cls)
+            self.converter.compile_class_destructor(cls)
 
         return True
 

--- a/typed_python/compiler/type_wrappers/alternative_wrapper.py
+++ b/typed_python/compiler/type_wrappers/alternative_wrapper.py
@@ -238,7 +238,7 @@ class AlternativeWrapper(AlternativeWrapperMixin, RefcountedWrapper):
 
     def on_refcount_zero(self, context, instance):
         return (
-            context.converter.defineNativeFunction(
+            context.converter.define_native_function(
                 "destructor_" + str(self.typeRepresentation),
                 ('destructor', self),
                 [self],
@@ -415,7 +415,7 @@ class ConcreteAlternativeWrapper(AlternativeWrapperMixin, RefcountedWrapper):
         return context.push(
             self,
             lambda new_alt:
-                context.converter.defineNativeFunction(
+                context.converter.define_native_function(
                     'construct(' + str(self) + ")",
                     ('util', self, 'construct'),
                     tupletype.ElementTypes,

--- a/typed_python/compiler/type_wrappers/class_wrapper.py
+++ b/typed_python/compiler/type_wrappers/class_wrapper.py
@@ -487,7 +487,7 @@ class ClassWrapper(ClassOrAlternativeWrapperMixin, RefcountedWrapper):
             )
 
     def compileDestructor(self, converter):
-        return converter.defineNativeFunction(
+        return converter.define_native_function(
             "destructor_" + str(self.typeRepresentation),
             ('destructor', self),
             [self],
@@ -789,7 +789,7 @@ class ClassWrapper(ClassOrAlternativeWrapperMixin, RefcountedWrapper):
         argSignatureStrings = [str(x) for x in matchArgTypes[1:]]
         argSignatureStrings.extend([f"{k}={v}" for k, v in kwargTypes.items()])
 
-        dispatchToOverloads = context.converter.defineNativeFunction(
+        dispatchToOverloads = context.converter.define_native_function(
             f'call_method.{self}.{methodName}({",".join(argSignatureStrings)})',
             ('call_method', self, methodName, tuple(matchArgTypes), tuple(kwargTypes.items())),
             list(argTypes) + list(kwargTypes.values()),
@@ -874,7 +874,7 @@ class ClassWrapper(ClassOrAlternativeWrapperMixin, RefcountedWrapper):
 
                     assert isinstance(overloadRetType, type), type(overloadRetType)
 
-                    testSingleOverloadForm = context.converter.defineNativeFunction(
+                    testSingleOverloadForm = context.converter.define_native_function(
                         f'call_overload.{self}.{methodName}.{overloadIndex}.'
                         f'{conversionLevel.LEVEL}.{argTypes[1:]}.{kwargTypes}->{overloadRetType}',
                         ('call_overload', self, methodName, overloadIndex, conversionLevel.LEVEL,
@@ -1341,7 +1341,7 @@ class ClassWrapper(ClassOrAlternativeWrapperMixin, RefcountedWrapper):
         return context.push(
             self,
             lambda new_class:
-                context.converter.defineNativeFunction(
+                context.converter.define_native_function(
                     'construct(' + self.typeRepresentation.__name__ + ")("
                     + ",".join([
                         (argNames[i] + '=' if argNames[i] is not None else "") +

--- a/typed_python/compiler/type_wrappers/const_dict_wrapper.py
+++ b/typed_python/compiler/type_wrappers/const_dict_wrapper.py
@@ -190,7 +190,7 @@ class ConstDictWrapperBase(RefcountedWrapper):
             return runtime_functions.free.call(instance.nonref_expr.cast(native_ast.UInt8Ptr))
         else:
             return (
-                context.converter.defineNativeFunction(
+                context.converter.define_native_function(
                     "destructor_" + str(self.constDictType),
                     ('destructor', self),
                     [self],

--- a/typed_python/compiler/type_wrappers/dict_wrapper.py
+++ b/typed_python/compiler/type_wrappers/dict_wrapper.py
@@ -145,7 +145,7 @@ class DictWrapperBase(RefcountedWrapper):
         assert instance.isReference
 
         return (
-            context.converter.defineNativeFunction(
+            context.converter.define_native_function(
                 "destructor_" + str(self.typeRepresentation),
                 ('destructor', self),
                 [self],

--- a/typed_python/compiler/type_wrappers/held_class_wrapper.py
+++ b/typed_python/compiler/type_wrappers/held_class_wrapper.py
@@ -159,7 +159,7 @@ class HeldClassWrapper(ClassOrAlternativeWrapperMixin, Wrapper):
         return context.push(
             self,
             lambda new_class:
-                context.converter.defineNativeFunction(
+                context.converter.define_native_function(
                     'construct(' + self.typeRepresentation.__name__ + ")("
                     + ",".join([
                         (argNames[i] + '=' if argNames[i] is not None else "") +

--- a/typed_python/compiler/type_wrappers/list_of_wrapper.py
+++ b/typed_python/compiler/type_wrappers/list_of_wrapper.py
@@ -77,7 +77,7 @@ class ListOfWrapper(TupleOrListOfWrapper):
                 if count is None:
                     return
 
-                native = context.converter.defineNativeFunction(
+                native = context.converter.define_native_function(
                     'pop(' + self.typeRepresentation.__name__ + ")",
                     ('util', self, 'pop'),
                     [self, int],
@@ -104,7 +104,7 @@ class ListOfWrapper(TupleOrListOfWrapper):
 
                 return context.pushPod(
                     None,
-                    context.converter.defineNativeFunction(
+                    context.converter.define_native_function(
                         'resize(' + self.typeRepresentation.__name__ + ")",
                         ('util', self, 'resize'),
                         [self, int],
@@ -123,7 +123,7 @@ class ListOfWrapper(TupleOrListOfWrapper):
 
                 return context.pushPod(
                     None,
-                    context.converter.defineNativeFunction(
+                    context.converter.define_native_function(
                         'resize(' + self.typeRepresentation.__name__ + ")",
                         ('util', self, 'resize'),
                         [self, int, self.underlyingWrapperType],
@@ -144,7 +144,7 @@ class ListOfWrapper(TupleOrListOfWrapper):
 
                 return context.pushPod(
                     None,
-                    context.converter.defineNativeFunction(
+                    context.converter.define_native_function(
                         'append(' + self.typeRepresentation.__name__ + ")",
                         ('util', self, 'append'),
                         [self, self.underlyingWrapperType],
@@ -158,7 +158,7 @@ class ListOfWrapper(TupleOrListOfWrapper):
                 return context.push(
                     self,
                     lambda out:
-                        context.converter.defineNativeFunction(
+                        context.converter.define_native_function(
                             'copy(' + self.typeRepresentation.__name__ + ")",
                             ('util', self, 'copy'),
                             [self],
@@ -170,7 +170,7 @@ class ListOfWrapper(TupleOrListOfWrapper):
             if len(args) == 0:
                 return context.pushPod(
                     None,
-                    context.converter.defineNativeFunction(
+                    context.converter.define_native_function(
                         'clear(' + self.typeRepresentation.__name__ + ")",
                         ('util', self, 'clear'),
                         [self],
@@ -187,7 +187,7 @@ class ListOfWrapper(TupleOrListOfWrapper):
 
                 return context.pushPod(
                     None,
-                    context.converter.defineNativeFunction(
+                    context.converter.define_native_function(
                         'reserve(' + self.typeRepresentation.__name__ + ")",
                         ('util', self, 'reserve'),
                         [self, int],
@@ -199,7 +199,7 @@ class ListOfWrapper(TupleOrListOfWrapper):
             if len(args) == 0:
                 return context.pushPod(
                     int,
-                    context.converter.defineNativeFunction(
+                    context.converter.define_native_function(
                         'reserved(' + self.typeRepresentation.__name__ + ")",
                         ('util', self, 'reserved'),
                         [self],
@@ -346,7 +346,7 @@ class ListOfWrapper(TupleOrListOfWrapper):
 
     def convert_default_initialize(self, context, tgt):
         context.pushEffect(
-            context.converter.defineNativeFunction(
+            context.converter.define_native_function(
                 'empty(' + self.typeRepresentation.__name__ + ")",
                 ('util', self, 'empty'),
                 [],
@@ -395,7 +395,7 @@ class ListOfWrapper(TupleOrListOfWrapper):
             return context.push(
                 self,
                 lambda out:
-                    context.converter.defineNativeFunction(
+                    context.converter.define_native_function(
                         'copy(' + str(self) + "," + str(args[0].expr_type) + ")",
                         ('util', self, 'copy'),
                         [args[0].expr_type],

--- a/typed_python/compiler/type_wrappers/one_of_wrapper.py
+++ b/typed_python/compiler/type_wrappers/one_of_wrapper.py
@@ -446,7 +446,7 @@ class OneOfWrapper(Wrapper):
     def convert_to_self_with_target(self, context, targetVal, otherExpr, conversionLevel, mayThrowOnFailure=False):
         assert targetVal.isReference
 
-        native = context.converter.defineNativeFunction(
+        native = context.converter.define_native_function(
             f'type_convert({otherExpr.expr_type} -> {targetVal.expr_type}, conversionLevel={conversionLevel.LEVEL})',
             ('type_convert', otherExpr.expr_type, targetVal.expr_type, conversionLevel.LEVEL),
             [PointerTo(self.typeRepresentation), otherExpr.expr_type],

--- a/typed_python/compiler/type_wrappers/python_typed_function_wrapper.py
+++ b/typed_python/compiler/type_wrappers/python_typed_function_wrapper.py
@@ -342,7 +342,7 @@ class PythonTypedFunctionWrapper(Wrapper):
         # import this wrapper. Note that we have to import it here to break the import cycles.
         # there's definitely a better way to organize this code.
 
-        singleConvertedOverload = context.functionContext.converter.convert(
+        singleConvertedOverload = context.functionContext.converter.convert_python_to_native(
             overload.name,
             overload.functionCode,
             overload.realizedGlobals,
@@ -506,7 +506,7 @@ class PythonTypedFunctionWrapper(Wrapper):
 
             # just one overload will do. We can just instantiate this particular function
             # with a signature that comes from the method overload signature itself.
-            singleConvertedOverload = context.functionContext.converter.convert(
+            singleConvertedOverload = context.functionContext.converter.convert_python_to_native(
                 overload.name,
                 overload.functionCode,
                 overload.realizedGlobals,
@@ -729,7 +729,7 @@ class PythonTypedFunctionWrapper(Wrapper):
                             kwargTypes
                         )
 
-                        callTarget = converter.convert(
+                        callTarget = converter.convert_python_to_native(
                             o.name,
                             o.functionCode,
                             o.realizedGlobals,

--- a/typed_python/compiler/type_wrappers/python_typed_function_wrapper.py
+++ b/typed_python/compiler/type_wrappers/python_typed_function_wrapper.py
@@ -351,7 +351,7 @@ class PythonTypedFunctionWrapper(Wrapper):
             list(overload.closureVarLookups),
             [typeWrapper(self.closurePathToCellType(path, closureType)) for path in overload.closureVarLookups.values()],
             None,
-            conversionType=ConvertionContextType
+            conversion_type=ConvertionContextType
         )
 
         if not singleConvertedOverload:
@@ -636,7 +636,7 @@ class PythonTypedFunctionWrapper(Wrapper):
 
         argNames = [None for _ in argTypes] + list(kwargTypes)
 
-        return converter.defineNativeFunction(
+        return converter.define_native_function(
             f'implement_function.{self}{argTypes}.{kwargTypes}->{returnType}',
             ('implement_function.', self, returnType, self, tuple(argTypes), tuple(kwargTypes.items())),
             ([self] if provideClosureArgument else []) + list(argTypes) + list(kwargTypes.values()),
@@ -812,7 +812,7 @@ class PythonTypedFunctionWrapper(Wrapper):
 
         overloadIndex = overload.index
 
-        testSingleOverloadForm = context.converter.defineNativeFunction(
+        testSingleOverloadForm = context.converter.define_native_function(
             f'check_can_call_overload.{self}.{overloadIndex}.{conversionLevel.LEVEL}.{argTypes}.{kwargTypes}',
             ('check_can_call_overload', self, overloadIndex, conversionLevel.LEVEL,
                 tuple(argTypes), tuple(kwargTypes.items())),
@@ -905,7 +905,7 @@ class PythonTypedFunctionWrapper(Wrapper):
                     elif overloadRetType is NoReturnTypeSpecified:
                         overloadRetType = returnType.typeRepresentation
 
-                    testSingleOverloadForm = context.converter.defineNativeFunction(
+                    testSingleOverloadForm = context.converter.define_native_function(
                         f'implement_overload.{self}.{overloadIndex}.{conversionLevel.LEVEL}.{argTypes}.{kwargTypes}->{overloadRetType}',
                         ('implement_overload', self, overloadIndex, conversionLevel.LEVEL,
                          overloadRetType, tuple(argTypes), tuple(kwargTypes.items())),

--- a/typed_python/compiler/type_wrappers/set_wrapper.py
+++ b/typed_python/compiler/type_wrappers/set_wrapper.py
@@ -318,7 +318,7 @@ class SetWrapperBase(RefcountedWrapper):
         assert instance.isReference
 
         return (
-            context.converter.defineNativeFunction(
+            context.converter.define_native_function(
                 "destructor_" + str(self.typeRepresentation),
                 ('destructor', self),
                 [self],

--- a/typed_python/compiler/type_wrappers/tuple_of_wrapper.py
+++ b/typed_python/compiler/type_wrappers/tuple_of_wrapper.py
@@ -325,7 +325,7 @@ class TupleOrListOfWrapper(RefcountedWrapper):
         assert instance.isReference
 
         return (
-            context.converter.defineNativeFunction(
+            context.converter.define_native_function(
                 "destructor_" + str(self.typeRepresentation),
                 ('destructor', self),
                 [self],

--- a/typed_python/compiler/type_wrappers/tuple_wrapper.py
+++ b/typed_python/compiler/type_wrappers/tuple_wrapper.py
@@ -464,7 +464,7 @@ class TupleWrapper(Wrapper):
 
                 return context.constant(True)
             else:
-                native = context.converter.defineNativeFunction(
+                native = context.converter.define_native_function(
                     f'type_convert({sourceVal.expr_type} -> {targetVal.expr_type}, conversionLevel={conversionLevel.LEVEL})',
                     ('type_convert', sourceVal.expr_type, targetVal.expr_type, conversionLevel.LEVEL),
                     [self.typeRepresentation, sourceVal.expr_type],

--- a/typed_python/compiler/type_wrappers/typed_cell_wrapper.py
+++ b/typed_python/compiler/type_wrappers/typed_cell_wrapper.py
@@ -76,7 +76,7 @@ class TypedCellWrapper(RefcountedWrapper):
         assert instance.isReference
 
         return (
-            context.converter.defineNativeFunction(
+            context.converter.define_native_function(
                 "destructor_" + str(self.typeRepresentation),
                 ('destructor', self),
                 [self],

--- a/typed_python/compiler/typeof.py
+++ b/typed_python/compiler/typeof.py
@@ -38,7 +38,7 @@ class TypeOf:
 
         converter = typed_python.compiler.runtime.Runtime.singleton().converter
 
-        if callTarget is None and converter.isCurrentlyConverting():
+        if callTarget is None and converter.is_currently_converting():
             # return the 'empty' OneOf, which can't actually be constructed.
             return typed_python.OneOf()
 
@@ -61,11 +61,11 @@ class TypeOf:
 
         converter = typed_python.compiler.runtime.Runtime.singleton().converter
 
-        callTarget = converter.convertTypedFunctionCall(
+        callTarget = converter.convert_typed_function_call(
             type(funcObj),
             0,
             argumentSignature,
-            assertIsRoot=False
+            assert_is_root=False
         )
 
         return callTarget


### PR DESCRIPTION
## Motivation and Context
We pass a 'name' argument into `_installInflightFunctions`, which is misleading as every name associated with `self._inflight_function_conversions` is processed by this function.