### PR TITLE
Wrap function overload + closure + input wrappers + return type in a single packet

### DIFF
--- a/typed_python/__init__.py
+++ b/typed_python/__init__.py
@@ -42,7 +42,6 @@ from typed_python.type_function import TypeFunction
 from typed_python.hash import sha_hash
 from typed_python.SerializationContext import SerializationContext
 from typed_python.type_filter import TypeFilter
-from typed_python.compiler.typeof import TypeOf
 from typed_python._types import (
     Forward, TupleOf, ListOf, Tuple, NamedTuple, OneOf, ConstDict, SubclassOf,
     Alternative, Value, serialize, deserialize, serializeStream, deserializeStream,
@@ -78,6 +77,7 @@ from typed_python.generator import Generator  # noqa
 from typed_python.lib.map import map  # noqa
 from typed_python.lib.pmap import pmap  # noqa
 from typed_python.lib.reduce import reduce  # noqa
+from typed_python.compiler.typeof import TypeOf  # noqa
 
 _types.initializeGlobalStatics()
 

--- a/typed_python/compiler/compiler_input.py
+++ b/typed_python/compiler/compiler_input.py
@@ -1,0 +1,110 @@
+from typing import List
+from typed_python.compiler.python_object_representation import typedPythonTypeToTypeWrapper
+from typed_python.compiler.type_wrappers.python_typed_function_wrapper import (
+    PythonTypedFunctionWrapper, CannotBeDetermined, NoReturnTypeSpecified
+)
+from typed_python.internals import FunctionOverload
+
+
+class CompilerInput:
+    """
+    Represents a parcel of input code and its input types + closure, containing everything the
+    compiler needs in order to do the compilation. Typed_python supports function overloading,
+    so everything here is specific to a given 'overload' - a function for a given set of input
+    types, and inferred output type.
+
+    Args:
+        function_type: a typed_python.Function _type_.
+        overload_index: the integer index of the overload we are interested in.
+        input_wrappers: A list of types (or TypeWrappers) for each input argument.
+    """
+    def __init__(self, function_type, overload_index: int, input_wrappers=None) -> None:
+        self._overload: FunctionOverload = function_type.overloads[overload_index]
+        self._closure_type = function_type.ClosureType
+        self._input_wrappers: List = input_wrappers
+        self._realized_input_wrappers: List = None
+        self._return_type = None
+        self._return_type_calculated = False
+
+    def expand_input_wrappers(self) -> None:
+        """
+        Extend the list of wrappers (representing the input args) using the free variables in
+        the function closure.
+        """
+        realized_input_wrappers = []
+        for closure_var_path in self.closureVarLookups.values():
+            realized_input_wrappers.append(
+                typedPythonTypeToTypeWrapper(
+                    PythonTypedFunctionWrapper.closurePathToCellType(closure_var_path, self.closure_type)
+                )
+            )
+        realized_input_wrappers.extend(self.input_wrappers)
+        self._realized_input_wrappers = realized_input_wrappers
+
+    def compute_return_type(self) -> None:
+        """Determine the return type, if possible."""
+        return_type = PythonTypedFunctionWrapper.computeFunctionOverloadReturnType(self._overload,
+                                                                                   self.input_wrappers,
+                                                                                   {}
+                                                                                   )
+        if return_type is CannotBeDetermined:
+            return_type = object
+
+        elif return_type is NoReturnTypeSpecified:
+            return_type = None
+
+        self._return_type = return_type
+        self._return_type_calculated = True
+
+    def install_native_pointer(self, fp, returnType, argumentTypes) -> None:
+        return self._overload._installNativePointer(fp, returnType, argumentTypes)
+
+    @property
+    def return_type(self):
+        if not self._return_type_calculated:
+            self.compute_return_type()
+        return self._return_type
+
+    @property
+    def realized_input_wrappers(self):
+        return self._realized_input_wrappers
+
+    @property
+    def input_wrappers(self):
+        return self._input_wrappers
+
+    @input_wrappers.setter
+    def input_wrappers(self, wrappers: List):
+        self._input_wrappers = wrappers
+
+    @property
+    def closure_type(self):
+        return self._closure_type
+
+    @property
+    def args(self):
+        return self._overload.args
+
+    @property
+    def name(self):
+        return self._overload.name
+
+    @property
+    def functionCode(self):
+        return self._overload.functionCode
+
+    @property
+    def realizedGlobals(self):
+        return self._overload.realizedGlobals
+
+    @property
+    def functionGlobals(self):
+        return self._overload.functionGlobals
+
+    @property
+    def funcGlobalsInCells(self):
+        return self._overload.funcGlobalsInCells
+
+    @property
+    def closureVarLookups(self):
+        return self._overload.closureVarLookups

--- a/typed_python/compiler/compiler_input.py
+++ b/typed_python/compiler/compiler_input.py
@@ -1,9 +1,25 @@
-from typing import List
+import types
+
+import typed_python
 from typed_python.compiler.python_object_representation import typedPythonTypeToTypeWrapper
 from typed_python.compiler.type_wrappers.python_typed_function_wrapper import (
-    PythonTypedFunctionWrapper, CannotBeDetermined, NoReturnTypeSpecified
+    PythonTypedFunctionWrapper,
+    CannotBeDetermined,
+    NoReturnTypeSpecified,
 )
-from typed_python.internals import FunctionOverload
+from typed_python.compiler.type_wrappers.typed_tuple_masquerading_as_tuple_wrapper import (
+    TypedTupleMasqueradingAsTuple,
+)
+from typed_python.compiler.type_wrappers.named_tuple_masquerading_as_dict_wrapper import (
+    NamedTupleMasqueradingAsDict,
+)
+from typed_python.compiler.conversion_level import ConversionLevel
+from typed_python import Function, Value
+from typed_python.type_function import TypeFunction
+
+import typed_python.compiler.python_to_native_converter as python_to_native_converter
+
+typeWrapper = lambda t: python_to_native_converter.typedPythonTypeToTypeWrapper(t)
 
 
 class CompilerInput:
@@ -12,74 +28,31 @@ class CompilerInput:
     compiler needs in order to do the compilation. Typed_python supports function overloading,
     so everything here is specific to a given 'overload' - a function for a given set of input
     types, and inferred output type.
-
-    Args:
-        function_type: a typed_python.Function _type_.
-        overload_index: the integer index of the overload we are interested in.
-        input_wrappers: A list of types (or TypeWrappers) for each input argument.
     """
-    def __init__(self, function_type, overload_index: int, input_wrappers=None) -> None:
-        self._overload: FunctionOverload = function_type.overloads[overload_index]
-        self._closure_type = function_type.ClosureType
-        self._input_wrappers: List = input_wrappers
-        self._realized_input_wrappers: List = None
+    def __init__(self, overload, closure_type, input_wrappers):
+        self._overload = overload
+        self.closure_type = closure_type
+        self._input_wrappers = input_wrappers
+
+        # cached properties
+        self._realized_input_wrappers = None
         self._return_type = None
         self._return_type_calculated = False
 
-    def expand_input_wrappers(self) -> None:
-        """
-        Extend the list of wrappers (representing the input args) using the free variables in
-        the function closure.
-        """
-        realized_input_wrappers = []
-        for closure_var_path in self.closureVarLookups.values():
-            realized_input_wrappers.append(
-                typedPythonTypeToTypeWrapper(
-                    PythonTypedFunctionWrapper.closurePathToCellType(closure_var_path, self.closure_type)
-                )
-            )
-        realized_input_wrappers.extend(self.input_wrappers)
-        self._realized_input_wrappers = realized_input_wrappers
+    @property
+    def realized_input_wrappers(self):
+        if self._realized_input_wrappers is None:
+            self._realized_input_wrappers = self._compute_realized_input_wrappers()
+            assert self._realized_input_wrappers is not None
 
-    def compute_return_type(self) -> None:
-        """Determine the return type, if possible."""
-        return_type = PythonTypedFunctionWrapper.computeFunctionOverloadReturnType(self._overload,
-                                                                                   self.input_wrappers,
-                                                                                   {}
-                                                                                   )
-        if return_type is CannotBeDetermined:
-            return_type = object
-
-        elif return_type is NoReturnTypeSpecified:
-            return_type = None
-
-        self._return_type = return_type
-        self._return_type_calculated = True
-
-    def install_native_pointer(self, fp, returnType, argumentTypes) -> None:
-        return self._overload._installNativePointer(fp, returnType, argumentTypes)
+        return self._realized_input_wrappers
 
     @property
     def return_type(self):
         if not self._return_type_calculated:
-            self.compute_return_type()
+            self._return_type = self._compute_return_type()
+            self._return_type_calculated = True
         return self._return_type
-
-    @property
-    def realized_input_wrappers(self):
-        return self._realized_input_wrappers
-
-    @property
-    def input_wrappers(self):
-        return self._input_wrappers
-
-    @input_wrappers.setter
-    def input_wrappers(self, wrappers: List):
-        self._input_wrappers = wrappers
-
-    @property
-    def closure_type(self):
-        return self._closure_type
 
     @property
     def args(self):
@@ -108,3 +81,113 @@ class CompilerInput:
     @property
     def closureVarLookups(self):
         return self._overload.closureVarLookups
+
+    def _compute_realized_input_wrappers(self) -> None:
+        """
+        Extend the list of wrappers (representing the input args) using the free variables in
+        the function closure.
+        """
+        res = []
+        for closure_var_path in self.closureVarLookups.values():
+            res.append(
+                typedPythonTypeToTypeWrapper(
+                    PythonTypedFunctionWrapper.closurePathToCellType(closure_var_path, self.closure_type)
+                )
+            )
+        res.extend(self._input_wrappers)
+        return res
+
+    def _compute_return_type(self) -> None:
+        """Determine the return type, if possible."""
+        res = PythonTypedFunctionWrapper.computeFunctionOverloadReturnType(
+            self._overload, self._input_wrappers, {}
+        )
+
+        if res is CannotBeDetermined:
+            res = object
+
+        elif res is NoReturnTypeSpecified:
+            res = None
+
+        return res
+
+    def install_native_pointer(self, fp, returnType, argumentTypes) -> None:
+        return self._overload._installNativePointer(fp, returnType, argumentTypes)
+
+    @staticmethod
+    def make(functionType, overloadIx, arguments, argumentsAreTypes):
+        overload = functionType.overloads[overloadIx]
+
+        if len(arguments) != len(overload.args):
+            raise Exception(
+                "CompilerInput mismatch: overload has %s args, but we were given "
+                "%s arguments" % (len(overload.args), len(arguments))
+            )
+
+        inputWrappers = []
+
+        for i in range(len(arguments)):
+            specialization = pickSpecializationTypeFor(
+                overload.args[i], arguments[i], argumentsAreTypes
+            )
+
+            if specialization is None:
+                return None
+
+            inputWrappers.append(specialization)
+
+        return CompilerInput(overload, functionType.ClosureType, inputWrappers)
+
+
+def pickSpecializationTypeFor(overloadArg, argValue, argumentsAreTypes):
+    """Compute the typeWrapper we'll use for this particular argument based on 'argValue'.
+
+    Args:
+        overloadArg - the internals.FunctionOverloadArg instance representing this argument.
+            This tells us whether we're dealing with a normal positional/keyword argument or
+            a *arg / **kwarg, where the typeFilter applies to the items of the tuple but
+            not the tuple itself.
+        argValue - the value being passed for this argument. If 'argumentsAreTypes' is true,
+            then this is the actual type, not the value.
+
+    Returns:
+        the Wrapper or type instance to use for this argument.
+    """
+    if not argumentsAreTypes:
+        if overloadArg.isStarArg:
+            argType = TypedTupleMasqueradingAsTuple(
+                typed_python.Tuple(*[passingTypeForValue(v) for v in argValue])
+            )
+        elif overloadArg.isKwarg:
+            argType = NamedTupleMasqueradingAsDict(
+                typed_python.NamedTuple(
+                    **{k: passingTypeForValue(v) for k, v in argValue.items()}
+                )
+            )
+        else:
+            argType = typeWrapper(passingTypeForValue(argValue))
+    else:
+        argType = typeWrapper(argValue)
+
+    resType = PythonTypedFunctionWrapper.pickSpecializationTypeFor(overloadArg, argType)
+
+    if argType.can_convert_to_type(resType, ConversionLevel.Implicit) is False:
+        return None
+
+    if (overloadArg.isStarArg or overloadArg.isKwarg) and resType != argType:
+        return None
+
+    return resType
+
+
+def passingTypeForValue(arg):
+    if isinstance(arg, types.FunctionType):
+        return type(Function(arg))
+
+    elif isinstance(arg, type) and issubclass(arg, TypeFunction) and len(arg.MRO) == 2:
+        return Value(arg)
+
+    elif isinstance(arg, type):
+        return Value(arg)
+
+    return type(arg)

--- a/typed_python/compiler/python_to_native_converter.py
+++ b/typed_python/compiler/python_to_native_converter.py
@@ -616,10 +616,6 @@ class PythonToNativeConverter:
 
     def convertTypedFunctionCall(self, compiler_input: CompilerInput, assertIsRoot=False):
         """Expand the input wrappers using the closure types, find the return type, and convert."""
-        compiler_input.expand_input_wrappers()
-
-        compiler_input.compute_return_type()
-
         return self.convert(
             compiler_input.name,
             compiler_input.functionCode,

--- a/typed_python/compiler/python_to_native_converter.py
+++ b/typed_python/compiler/python_to_native_converter.py
@@ -615,7 +615,6 @@ class PythonToNativeConverter:
             return self.compilerCache.function_pointer_by_name(linkerName)
 
     def convertTypedFunctionCall(self, compiler_input: CompilerInput, assertIsRoot=False):
-        """Expand the input wrappers using the closure types, find the return type, and convert."""
         return self.convert(
             compiler_input.name,
             compiler_input.functionCode,

--- a/typed_python/compiler/runtime.py
+++ b/typed_python/compiler/runtime.py
@@ -15,25 +15,18 @@
 import threading
 import os
 import time
-import types
 import typed_python.compiler.python_to_native_converter as python_to_native_converter
 import typed_python.compiler.llvm_compiler as llvm_compiler
 import typed_python
 from typed_python.compiler.runtime_lock import runtimeLock
-from typed_python.compiler.conversion_level import ConversionLevel
 from typed_python.compiler.compiler_cache import CompilerCache
-from typed_python.compiler.compiler_input import CompilerInput
-from typed_python.type_function import TypeFunction
-from typed_python.compiler.type_wrappers.typed_tuple_masquerading_as_tuple_wrapper import TypedTupleMasqueradingAsTuple
-from typed_python.compiler.type_wrappers.named_tuple_masquerading_as_dict_wrapper import NamedTupleMasqueradingAsDict
+from typed_python.compiler.compiler_input import CompilerInput, typeWrapper
 from typed_python.compiler.type_wrappers.python_typed_function_wrapper import PythonTypedFunctionWrapper, NoReturnTypeSpecified
 from typed_python import Function, _types, Value
 from typed_python.compiler.merge_type_wrappers import mergeTypeWrappers
 
 _singleton = [None]
 _singletonLock = threading.RLock()
-
-typeWrapper = lambda t: python_to_native_converter.typedPythonTypeToTypeWrapper(t)
 
 _resultTypeCache = {}
 
@@ -193,60 +186,6 @@ class Runtime:
     def removeEventVisitor(self, visitor: RuntimeEventVisitor):
         self.converter.removeVisitor(visitor)
 
-    @staticmethod
-    def passingTypeForValue(arg):
-        if isinstance(arg, types.FunctionType):
-            return type(Function(arg))
-
-        elif isinstance(arg, type) and issubclass(arg, TypeFunction) and len(arg.MRO) == 2:
-            return Value(arg)
-
-        elif isinstance(arg, type):
-            return Value(arg)
-
-        return type(arg)
-
-    @staticmethod
-    def pickSpecializationTypeFor(overloadArg, argValue, argumentsAreTypes=False):
-        """Compute the typeWrapper we'll use for this particular argument based on 'argValue'.
-
-        Args:
-            overloadArg - the internals.FunctionOverloadArg instance representing this argument.
-                This tells us whether we're dealing with a normal positional/keyword argument or
-                a *arg / **kwarg, where the typeFilter applies to the items of the tuple but
-                not the tuple itself.
-            argValue - the value being passed for this argument. If 'argumentsAreTypes' is true,
-                then this is the actual type, not the value.
-
-        Returns:
-            the Wrapper or type instance to use for this argument.
-        """
-        if not argumentsAreTypes:
-            if overloadArg.isStarArg:
-                argType = TypedTupleMasqueradingAsTuple(
-                    typed_python.Tuple(*[Runtime.passingTypeForValue(v) for v in argValue])
-                )
-            elif overloadArg.isKwarg:
-                argType = NamedTupleMasqueradingAsDict(
-                    typed_python.NamedTuple(
-                        **{k: Runtime.passingTypeForValue(v) for k, v in argValue.items()}
-                    )
-                )
-            else:
-                argType = typeWrapper(Runtime.passingTypeForValue(argValue))
-        else:
-            argType = typeWrapper(argValue)
-
-        resType = PythonTypedFunctionWrapper.pickSpecializationTypeFor(overloadArg, argType)
-
-        if argType.can_convert_to_type(resType, ConversionLevel.Implicit) is False:
-            return None
-
-        if (overloadArg.isStarArg or overloadArg.isKwarg) and resType != argType:
-            return None
-
-        return resType
-
     def compileFunctionOverload(self, functionType, overloadIx, arguments, argumentsAreTypes=False):
         """Attempt to compile typedFunc.overloads[overloadIx]' with the given arguments.
 
@@ -263,11 +202,6 @@ class Runtime:
             a TypedCallTarget.
         """
 
-        # generate the parcel of code corresponding to an input to the compiler
-        compiler_input = CompilerInput(functionType, overloadIx)
-
-        assert len(arguments) == len(compiler_input.args)
-
         try:
             t0 = time.time()
             t1 = None
@@ -275,19 +209,13 @@ class Runtime:
             defCount = self.converter.getDefinitionCount()
 
             with self.lock:
-                inputWrappers = []
+                # generate the parcel of code corresponding to an input to the compiler
+                compiler_input = CompilerInput.make(
+                    functionType, overloadIx, arguments, argumentsAreTypes
+                )
 
-                for i in range(len(arguments)):
-                    inputWrappers.append(
-                        self.pickSpecializationTypeFor(compiler_input.args[i], arguments[i], argumentsAreTypes)
-                    )
-
-                if any(x is None for x in inputWrappers):
-                    # this signature is unmatchable with these arguments.
+                if compiler_input is None:
                     return None
-
-                # generate the input packet.
-                compiler_input.input_wrappers = inputWrappers
 
                 self.timesCompiled += 1
 

--- a/typed_python/compiler/typeof.py
+++ b/typed_python/compiler/typeof.py
@@ -1,8 +1,8 @@
 import typed_python
+
+from typed_python.compiler.compiler_input import CompilerInput
 from typed_python.compiler.type_wrappers.type_sets import SubclassOf, Either
-
-
-typeWrapper = lambda t: typed_python.compiler.python_to_native_converter.typedPythonTypeToTypeWrapper(t)
+from typed_python.compiler.python_object_representation import typedPythonTypeToTypeWrapper
 
 
 class TypeOf:
@@ -47,8 +47,8 @@ class TypeOf:
     def resultTypeForCall(self, argTypes, kwargTypes):
         funcObj = typed_python._types.prepareArgumentToBePassedToCompiler(self.F)
 
-        argTypes = [typeWrapper(a) for a in argTypes]
-        kwargTypes = {k: typeWrapper(v) for k, v in kwargTypes.items()}
+        argTypes = [typedPythonTypeToTypeWrapper(a) for a in argTypes]
+        kwargTypes = {k: typedPythonTypeToTypeWrapper(v) for k, v in kwargTypes.items()}
 
         overload = funcObj.overloads[0]
 
@@ -61,10 +61,10 @@ class TypeOf:
 
         converter = typed_python.compiler.runtime.Runtime.singleton().converter
 
+        compiler_input = CompilerInput(funcObj, overload_index=0, input_wrappers=argumentSignature)
+
         callTarget = converter.convertTypedFunctionCall(
-            type(funcObj),
-            0,
-            argumentSignature,
+            compiler_input,
             assertIsRoot=False
         )
 

--- a/typed_python/compiler/typeof.py
+++ b/typed_python/compiler/typeof.py
@@ -61,7 +61,11 @@ class TypeOf:
 
         converter = typed_python.compiler.runtime.Runtime.singleton().converter
 
-        compiler_input = CompilerInput(funcObj, overload_index=0, input_wrappers=argumentSignature)
+        compiler_input = CompilerInput.make(funcObj,
+                                            overloadIx=0,
+                                            arguments=argumentSignature,
+                                            argumentsAreTypes=True
+                                            )
 
         callTarget = converter.convertTypedFunctionCall(
             compiler_input,


### PR DESCRIPTION
## Motivation and Context
Separates the responsibilities of the code parcel that is input to the compiler and the compiler itself - the unit of compilation is 'one overload + all the data the compiler needs to do its job' and by passing this in as a class we can clarify the role of python_to_native_converter (and runtime).
 
Down the line, this lets us contemplate synthetic compiler inputs that didn't come via entrypoint, & getting rid of convertTypedFunctionCall entirely and adjusting the convert() function to accept this packet directly.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.