### PR TITLE
Prune the graph of inflight functions to not include the ones we don't need

### DIFF
--- a/typed_python/SerializationContext.py
+++ b/typed_python/SerializationContext.py
@@ -44,9 +44,16 @@ def pickledByStr(module_name: str, name: str) -> None:
     This mimics pickle's behavior when given a string from __reduce__. The
     string is interpreted as the name of a global variable, and pickle.whichmodules
     is used to search the module namespace, generating module_name.
+
+    Note that 'name' might contain '.' inside of it, since its a 'local name'.
     """
     module = importlib.import_module(module_name)
-    return getattr(module, name)
+
+    instance = module
+    for subName in name.split('.'):
+        instance = getattr(instance, subName)
+
+    return instance
 
 
 def createFunctionWithLocalsAndGlobals(code, globals):

--- a/typed_python/__init__.py
+++ b/typed_python/__init__.py
@@ -79,8 +79,6 @@ from typed_python.generator import Generator  # noqa
 from typed_python.lib.map import map  # noqa
 from typed_python.lib.pmap import pmap  # noqa
 from typed_python.lib.reduce import reduce  # noqa
-from typed_python.lib.timestamp import Timestamp # noqa
-from typed_python.lib.datetime.date_time import UTC, NYC, TimeOfDay, DateTime, Date, PytzTimezone # noqa
 
 _types.initializeGlobalStatics()
 

--- a/typed_python/compiler/compiler_cache.py
+++ b/typed_python/compiler/compiler_cache.py
@@ -15,9 +15,12 @@
 import os
 import uuid
 import shutil
-from typed_python.compiler.loaded_module import LoadedModule
-from typed_python.compiler.binary_shared_object import BinarySharedObject
 
+from typing import Optional, List
+
+from typed_python.compiler.binary_shared_object import LoadedBinarySharedObject, BinarySharedObject
+from typed_python.compiler.directed_graph import DirectedGraph
+from typed_python.compiler.typed_call_target import TypedCallTarget
 from typed_python.SerializationContext import SerializationContext
 from typed_python import Dict, ListOf
 
@@ -52,146 +55,173 @@ class CompilerCache:
 
         ensureDirExists(cacheDir)
 
-        self.loadedModules = Dict(str, LoadedModule)()
+        self.loadedBinarySharedObjects = Dict(str, LoadedBinarySharedObject)()
         self.nameToModuleHash = Dict(str, str)()
 
-        self.modulesMarkedValid = set()
-        self.modulesMarkedInvalid = set()
+        self.moduleManifestsLoaded = set()
 
         for moduleHash in os.listdir(self.cacheDir):
             if len(moduleHash) == 40:
                 self.loadNameManifestFromStoredModuleByHash(moduleHash)
 
-        self.targetsLoaded = {}
+        # the set of functions with an associated module in loadedBinarySharedObjects
+        self.targetsLoaded: Dict[str, TypedCallTarget] = {}
 
-    def hasSymbol(self, linkName):
+        # the set of functions with linked and validated globals (i.e. ready to be run).
+        self.targetsValidated = set()
+
+        self.function_dependency_graph = DirectedGraph()
+        # dict from function linkname to list of global names (should be llvm keys in serialisedGlobalDefinitions)
+        self.global_dependencies = Dict(str, ListOf(str))()
+
+    def hasSymbol(self, linkName: str) -> bool:
+        """NB this will return True even if the linkName is ultimately unretrievable."""
         return linkName in self.nameToModuleHash
 
-    def getTarget(self, linkName):
-        assert self.hasSymbol(linkName)
-
+    def getTarget(self, linkName: str) -> TypedCallTarget:
+        if not self.hasSymbol(linkName):
+            raise ValueError(f'symbol not found for linkName {linkName}')
         self.loadForSymbol(linkName)
-
         return self.targetsLoaded[linkName]
 
-    def markModuleHashInvalid(self, hashstr):
-        with open(os.path.join(self.cacheDir, hashstr, "marked_invalid"), "w"):
-            pass
+    def dependencies(self, linkName: str) -> Optional[List[str]]:
+        """Returns all the function names that `linkName` depends on"""
+        return list(self.function_dependency_graph.outgoing(linkName))
 
-    def loadForSymbol(self, linkName):
+    def loadForSymbol(self, linkName: str) -> None:
+        """Loads the whole module, and any submodules, into LoadedBinarySharedObjects"""
         moduleHash = self.nameToModuleHash[linkName]
 
         self.loadModuleByHash(moduleHash)
 
-    def loadModuleByHash(self, moduleHash):
+        if linkName not in self.targetsValidated:
+            dependantFuncs = self.dependencies(linkName) + [linkName]
+            globalsToLink = {}  # dict from modulehash to list of globals.
+            for funcName in dependantFuncs:
+                if funcName not in self.targetsValidated:
+                    funcModuleHash = self.nameToModuleHash[funcName]
+                    # append to the list of globals to link for a given module.  TODO: optimise this, don't double-link.
+                    globalsToLink[funcModuleHash] = globalsToLink.get(funcModuleHash, []) + self.global_dependencies.get(funcName, [])
+
+            for moduleHash, globs in globalsToLink.items():  # this works because loadModuleByHash loads submodules too.
+                if globs:
+                    definitionsToLink = {x: self.loadedBinarySharedObjects[moduleHash].serializedGlobalVariableDefinitions[x]
+                                         for x in globs
+                                         }
+                    self.loadedBinarySharedObjects[moduleHash].linkGlobalVariables(definitionsToLink)
+                    if not self.loadedBinarySharedObjects[moduleHash].validateGlobalVariables(definitionsToLink):
+                        raise RuntimeError('failed to validate globals when loading:', linkName)
+
+            self.targetsValidated.update(dependantFuncs)
+
+    def loadModuleByHash(self, moduleHash: str) -> None:
         """Load a module by name.
 
         As we load, place all the newly imported typed call targets into
         'nameToTypedCallTarget' so that the rest of the system knows what functions
         have been uncovered.
         """
-        if moduleHash in self.loadedModules:
-            return True
+        if moduleHash in self.loadedBinarySharedObjects:
+            return
 
         targetDir = os.path.join(self.cacheDir, moduleHash)
 
-        try:
-            with open(os.path.join(targetDir, "type_manifest.dat"), "rb") as f:
-                callTargets = SerializationContext().deserialize(f.read())
+        # TODO (Will) - store these names as module consts, use one .dat only
+        with open(os.path.join(targetDir, "type_manifest.dat"), "rb") as f:
+            callTargets = SerializationContext().deserialize(f.read())
 
-            with open(os.path.join(targetDir, "globals_manifest.dat"), "rb") as f:
-                globalVarDefs = SerializationContext().deserialize(f.read())
+        with open(os.path.join(targetDir, "globals_manifest.dat"), "rb") as f:
+            serializedGlobalVarDefs = SerializationContext().deserialize(f.read())
 
-            with open(os.path.join(targetDir, "native_type_manifest.dat"), "rb") as f:
-                functionNameToNativeType = SerializationContext().deserialize(f.read())
+        with open(os.path.join(targetDir, "native_type_manifest.dat"), "rb") as f:
+            functionNameToNativeType = SerializationContext().deserialize(f.read())
 
-            with open(os.path.join(targetDir, "submodules.dat"), "rb") as f:
-                submodules = SerializationContext().deserialize(f.read(), ListOf(str))
-        except Exception:
-            self.markModuleHashInvalid(moduleHash)
-            return False
+        with open(os.path.join(targetDir, "submodules.dat"), "rb") as f:
+            submodules = SerializationContext().deserialize(f.read(), ListOf(str))
 
-        if not LoadedModule.validateGlobalVariables(globalVarDefs):
-            self.markModuleHashInvalid(moduleHash)
-            return False
+        with open(os.path.join(targetDir, "function_dependencies.dat"), "rb") as f:
+            dependency_edgelist = SerializationContext().deserialize(f.read())
+
+        with open(os.path.join(targetDir, "global_dependencies.dat"), "rb") as f:
+            globalDependencies = SerializationContext().deserialize(f.read())
 
         # load the submodules first
         for submodule in submodules:
-            if not self.loadModuleByHash(submodule):
-                return False
+            self.loadModuleByHash(submodule)
 
         modulePath = os.path.join(targetDir, "module.so")
 
         loaded = BinarySharedObject.fromDisk(
             modulePath,
-            globalVarDefs,
-            functionNameToNativeType
+            serializedGlobalVarDefs,
+            functionNameToNativeType,
+            globalDependencies
+
         ).loadFromPath(modulePath)
 
-        self.loadedModules[moduleHash] = loaded
+        self.loadedBinarySharedObjects[moduleHash] = loaded
 
         self.targetsLoaded.update(callTargets)
 
-        return True
+        assert not any(key in self.global_dependencies for key in globalDependencies)  # should only happen if there's a hash collision.
+        self.global_dependencies.update(globalDependencies)
 
-    def addModule(self, binarySharedObject, nameToTypedCallTarget, linkDependencies):
+        # update the cache's dependency graph with our new edges.
+        for function_name, dependant_function_name in dependency_edgelist:
+            self.function_dependency_graph.addEdge(source=function_name, dest=dependant_function_name)
+
+    def addModule(self, binarySharedObject, nameToTypedCallTarget, linkDependencies, dependencyEdgelist):
         """Add new code to the compiler cache.
 
         Args:
-            binarySharedObject - a BinarySharedObject containing the actual assembler
-                we've compiled
-            nameToTypedCallTarget - a dict from linkname to TypedCallTarget telling us
-                the formal python types for all the objects
-            linkDependencies - a set of linknames we depend on directly.
+            binarySharedObject: a BinarySharedObject containing the actual assembler
+                we've compiled.
+            nameToTypedCallTarget: a dict from linkname to TypedCallTarget telling us
+                the formal python types for all the objects.
+            linkDependencies: a set of linknames we depend on directly.
+            dependencyEdgelist (list): a list of source, dest pairs giving the set of dependency graph for the
+                module.
         """
         dependentHashes = set()
 
         for name in linkDependencies:
             dependentHashes.add(self.nameToModuleHash[name])
 
-        path, hashToUse = self.writeModuleToDisk(binarySharedObject, nameToTypedCallTarget, dependentHashes)
+        path, hashToUse = self.writeModuleToDisk(binarySharedObject, nameToTypedCallTarget, dependentHashes, dependencyEdgelist)
 
-        self.loadedModules[hashToUse] = (
+        self.loadedBinarySharedObjects[hashToUse] = (
             binarySharedObject.loadFromPath(os.path.join(path, "module.so"))
         )
 
         for n in binarySharedObject.definedSymbols:
             self.nameToModuleHash[n] = hashToUse
 
-    def loadNameManifestFromStoredModuleByHash(self, moduleHash):
-        if moduleHash in self.modulesMarkedValid:
-            return True
+        # link & validate all globals for the new module
+        self.loadedBinarySharedObjects[hashToUse].linkGlobalVariables()
+        if not self.loadedBinarySharedObjects[hashToUse].validateGlobalVariables(
+                self.loadedBinarySharedObjects[hashToUse].serializedGlobalVariableDefinitions):
+            raise RuntimeError('failed to validate globals in new module:', hashToUse)
+
+    def loadNameManifestFromStoredModuleByHash(self, moduleHash) -> None:
+        if moduleHash in self.moduleManifestsLoaded:
+            return
 
         targetDir = os.path.join(self.cacheDir, moduleHash)
-
-        # ignore 'marked invalid'
-        if os.path.exists(os.path.join(targetDir, "marked_invalid")):
-            # just bail - don't try to read it now
-
-            # for the moment, we don't try to clean up the cache, because
-            # we can't be sure that some process is not still reading the
-            # old files.
-            self.modulesMarkedInvalid.add(moduleHash)
-            return False
 
         with open(os.path.join(targetDir, "submodules.dat"), "rb") as f:
             submodules = SerializationContext().deserialize(f.read(), ListOf(str))
 
         for subHash in submodules:
-            if not self.loadNameManifestFromStoredModuleByHash(subHash):
-                self.markModuleHashInvalid(subHash)
-                return False
+            self.loadNameManifestFromStoredModuleByHash(subHash)
 
         with open(os.path.join(targetDir, "name_manifest.dat"), "rb") as f:
             self.nameToModuleHash.update(
                 SerializationContext().deserialize(f.read(), Dict(str, str))
             )
 
-        self.modulesMarkedValid.add(moduleHash)
+        self.moduleManifestsLoaded.add(moduleHash)
 
-        return True
-
-    def writeModuleToDisk(self, binarySharedObject, nameToTypedCallTarget, submodules):
+    def writeModuleToDisk(self, binarySharedObject, nameToTypedCallTarget, submodules, dependencyEdgelist):
         """Write out a disk representation of this module.
 
         This includes writing both the shared object, a manifest of the function names
@@ -244,10 +274,16 @@ class CompilerCache:
 
         # write the type manifest
         with open(os.path.join(tempTargetDir, "globals_manifest.dat"), "wb") as f:
-            f.write(SerializationContext().serialize(binarySharedObject.globalVariableDefinitions))
+            f.write(SerializationContext().serialize(binarySharedObject.serializedGlobalVariableDefinitions))
 
         with open(os.path.join(tempTargetDir, "submodules.dat"), "wb") as f:
             f.write(SerializationContext().serialize(ListOf(str)(submodules), ListOf(str)))
+
+        with open(os.path.join(tempTargetDir, "function_dependencies.dat"), "wb") as f:
+            f.write(SerializationContext().serialize(dependencyEdgelist))  # might need a listof
+
+        with open(os.path.join(tempTargetDir, "global_dependencies.dat"), "wb") as f:
+            f.write(SerializationContext().serialize(binarySharedObject.globalDependencies))
 
         try:
             os.rename(tempTargetDir, targetDir)
@@ -264,7 +300,7 @@ class CompilerCache:
         if moduleHash is None:
             raise Exception("Can't find a module for " + linkName)
 
-        if moduleHash not in self.loadedModules:
+        if moduleHash not in self.loadedBinarySharedObjects:
             self.loadForSymbol(linkName)
 
-        return self.loadedModules[moduleHash].functionPointers[linkName]
+        return self.loadedBinarySharedObjects[moduleHash].functionPointers[linkName]

--- a/typed_python/compiler/directed_graph.py
+++ b/typed_python/compiler/directed_graph.py
@@ -44,6 +44,10 @@ class DirectedGraph:
             return False
         return dest in self.sourceToDest[source]
 
+    def clearOutgoing(self, node):
+        for child in list(self.outgoing(node)):
+            self.dropEdge(node, child)
+
     def outgoing(self, node):
         return self.sourceToDest.get(node, set())
 

--- a/typed_python/compiler/global_variable_definition.py
+++ b/typed_python/compiler/global_variable_definition.py
@@ -87,5 +87,4 @@ class GlobalVariableDefinition:
         return self.name == other.name and self.type == other.type and self.metadata == other.metadata
 
     def __str__(self):
-        metadata_str = str(self.metadata) if len(str(self.metadata)) < 100 else str(self.metadata)[:100] + "..."
-        return f"GlobalVariableDefinition(name={self.name}, type={self.type}, metadata={metadata_str})"
+        return f"GlobalVariableDefinition(name={self.name}, type={self.type}, metadata={pad(str(self.metadata))})"

--- a/typed_python/compiler/global_variable_definition.py
+++ b/typed_python/compiler/global_variable_definition.py
@@ -79,3 +79,13 @@ class GlobalVariableDefinition:
         self.name = name
         self.type = typ
         self.metadata = metadata
+
+    def __eq__(self, other):
+        if not isinstance(other, GlobalVariableDefinition):
+            return False
+
+        return self.name == other.name and self.type == other.type and self.metadata == other.metadata
+
+    def __str__(self):
+        metadata_str = str(self.metadata) if len(str(self.metadata)) < 100 else str(self.metadata)[:100] + "..."
+        return f"GlobalVariableDefinition(name={self.name}, type={self.type}, metadata={metadata_str})"

--- a/typed_python/compiler/llvm_compiler.py
+++ b/typed_python/compiler/llvm_compiler.py
@@ -84,17 +84,13 @@ def create_execution_engine(inlineThreshold):
 
 
 class Compiler:
-    def __init__(self, inlineThreshold):
+    def __init__(self, inlineThreshold, compilerCache):
         self.engine, self.module_pass_manager = create_execution_engine(inlineThreshold)
-        self.converter = native_ast_to_llvm.Converter()
+        self.converter = native_ast_to_llvm.Converter(compilerCache)
         self.functions_by_name = {}
         self.inlineThreshold = inlineThreshold
         self.verbose = False
         self.optimize = True
-
-    def markExternal(self, functionNameToType):
-        """Provide type signatures for a set of external functions."""
-        self.converter.markExternal(functionNameToType)
 
     def mark_converter_verbose(self):
         self.converter.verbose = True

--- a/typed_python/compiler/llvm_compiler_test.py
+++ b/typed_python/compiler/llvm_compiler_test.py
@@ -115,7 +115,7 @@ def test_create_binary_shared_object():
         {'__test_f_2': f}
     )
 
-    assert len(bso.globalVariableDefinitions) == 1
+    assert len(bso.serializedGlobalVariableDefinitions) == 1
 
     with tempfile.TemporaryDirectory() as tf:
         loaded = bso.load(tf)

--- a/typed_python/compiler/loaded_module.py
+++ b/typed_python/compiler/loaded_module.py
@@ -28,6 +28,8 @@ class LoadedModule:
 
         self.functionPointers[ModuleDefinition.GET_GLOBAL_VARIABLES_NAME](self.pointers.pointerUnsafe(0))
 
+        self.installedGlobalVariableDefinitions = {}
+
     @staticmethod
     def validateGlobalVariables(serializedGlobalVariableDefinitions: Dict[str, bytes]) -> bool:
         """Check that each global variable definition is sensible.
@@ -82,6 +84,8 @@ class LoadedModule:
             assert self.pointers[i], f"Failed to get a pointer to {self.orderedDefs[i].name}"
 
             meta = SerializationContext().deserialize(self.orderedDefs[i]).metadata
+
+            self.installedGlobalVariableDefinitions[i] = meta
 
             if meta.matches.StringConstant:
                 self.pointers[i].cast(str).initialize(meta.value)

--- a/typed_python/compiler/loaded_module.py
+++ b/typed_python/compiler/loaded_module.py
@@ -1,39 +1,46 @@
+from typing import Dict, List
 from typed_python.compiler.module_definition import ModuleDefinition
-from typed_python import PointerTo, ListOf, Class
+from typed_python import PointerTo, ListOf, Class, SerializationContext
 from typed_python import _types
 
 
 class LoadedModule:
     """Represents a bundle of compiled functions that are now loaded in memory.
-
     Members:
         functionPointers - a map from name to NativeFunctionPointer giving the
             public interface of the module
-        globalVariableDefinitions - a map from name to GlobalVariableDefinition
+        serializedGlobalVariableDefinitions - a map from LLVM-assigned global name to serialized GlobalVariableDefinition
             giving the loadable strings
     """
     GET_GLOBAL_VARIABLES_NAME = ModuleDefinition.GET_GLOBAL_VARIABLES_NAME
 
-    def __init__(self, functionPointers, globalVariableDefinitions):
+    def __init__(self, functionPointers, serializedGlobalVariableDefinitions):
         self.functionPointers = functionPointers
+        assert ModuleDefinition.GET_GLOBAL_VARIABLES_NAME in self.functionPointers
 
-        self.globalVariableDefinitions = globalVariableDefinitions
+        self.serializedGlobalVariableDefinitions = serializedGlobalVariableDefinitions
+        self.orderedDefs = [
+            self.serializedGlobalVariableDefinitions[name] for name in sorted(self.serializedGlobalVariableDefinitions)
+        ]
+        self.orderedDefNames = sorted(list(self.serializedGlobalVariableDefinitions.keys()))
+        self.pointers = ListOf(PointerTo(int))()
+        self.pointers.resize(len(self.orderedDefs))
+
+        self.functionPointers[ModuleDefinition.GET_GLOBAL_VARIABLES_NAME](self.pointers.pointerUnsafe(0))
 
     @staticmethod
-    def validateGlobalVariables(globalVariableDefinitions):
+    def validateGlobalVariables(serializedGlobalVariableDefinitions: Dict[str, bytes]) -> bool:
         """Check that each global variable definition is sensible.
-
         Sometimes we may successfully deserialize a global variable from a cached
         module, but then some dictionary member is not valid because it was removed
         or has the wrong type. In this case, we need to evict this module from
         the cache because it's no longer valid.
 
         Args:
-            globalVariableDefinitions - a dict from string to GlobalVariableMetadata
+            serializedGlobalVariableDefinitions: a dict from string to a serialized GlobalVariableMetadata
         """
-        for gvd in globalVariableDefinitions.values():
-            meta = gvd.metadata
-
+        for gvd in serializedGlobalVariableDefinitions.values():
+            meta = SerializationContext().deserialize(gvd).metadata
             if meta.matches.PointerToTypedPythonObjectAsMemberOfDict:
                 if not isinstance(meta.sourceDict, dict):
                     return False
@@ -54,54 +61,45 @@ class LoadedModule:
 
         return True
 
-    def linkGlobalVariables(self):
-        """Walk over all global variables in the module and make sure they are populated.
-
+    def linkGlobalVariables(self, variable_names: List[str] = None) -> None:
+        """Walk over all global variables in `variable_names` and make sure they are populated.
         Each module has a bunch of global variables that contain references to things
         like type objects, string objects, python module members, etc.
-
-        The metadata about these is stored in 'self.globalVariableDefinitions' whose keys
+        The metadata about these is stored in 'self.serializedGlobalVariableDefinitions' whose keys
         are names and whose values are GlobalVariableMetadata instances.
-
         Every module we compile exposes a member named ModuleDefinition.GET_GLOBAL_VARIABLES_NAME
         which takes a pointer to a list of pointers and fills it out with the global variables.
-
         When the module is loaded, all the variables are initialized to zero. This function
         walks over them and populates them, effectively linking them into the current binary.
         """
-        assert ModuleDefinition.GET_GLOBAL_VARIABLES_NAME in self.functionPointers
 
-        orderedDefs = [
-            self.globalVariableDefinitions[name] for name in sorted(self.globalVariableDefinitions)
-        ]
+        if variable_names is None:
+            i_vals = range(len(self.orderedDefs))
+        else:
+            i_vals = [self.orderedDefNames.index(x) for x in variable_names]
 
-        pointers = ListOf(PointerTo(int))()
-        pointers.resize(len(orderedDefs))
+        for i in i_vals:
+            assert self.pointers[i], f"Failed to get a pointer to {self.orderedDefs[i].name}"
 
-        self.functionPointers[ModuleDefinition.GET_GLOBAL_VARIABLES_NAME](pointers.pointerUnsafe(0))
-
-        for i in range(len(orderedDefs)):
-            assert pointers[i], f"Failed to get a pointer to {orderedDefs[i].name}"
-
-            meta = orderedDefs[i].metadata
+            meta = SerializationContext().deserialize(self.orderedDefs[i]).metadata
 
             if meta.matches.StringConstant:
-                pointers[i].cast(str).initialize(meta.value)
+                self.pointers[i].cast(str).initialize(meta.value)
 
             if meta.matches.IntegerConstant:
-                pointers[i].cast(int).initialize(meta.value)
+                self.pointers[i].cast(int).initialize(meta.value)
 
             elif meta.matches.BytesConstant:
-                pointers[i].cast(bytes).initialize(meta.value)
+                self.pointers[i].cast(bytes).initialize(meta.value)
 
             elif meta.matches.PointerToPyObject:
-                pointers[i].cast(object).initialize(meta.value)
+                self.pointers[i].cast(object).initialize(meta.value)
 
             elif meta.matches.PointerToTypedPythonObject:
-                pointers[i].cast(meta.type).initialize(meta.value)
+                self.pointers[i].cast(meta.type).initialize(meta.value)
 
             elif meta.matches.PointerToTypedPythonObjectAsMemberOfDict:
-                pointers[i].cast(meta.type).initialize(meta.sourceDict[meta.name])
+                self.pointers[i].cast(meta.type).initialize(meta.sourceDict[meta.name])
 
             elif meta.matches.ClassMethodDispatchSlot:
                 slotIx = _types.allocateClassMethodDispatch(
@@ -111,17 +109,17 @@ class LoadedModule:
                     meta.argTupleType,
                     meta.kwargTupleType
                 )
-                pointers[i].cast(int).initialize(slotIx)
+                self.pointers[i].cast(int).initialize(slotIx)
 
             elif meta.matches.IdOfPyObject:
-                pointers[i].cast(int).initialize(id(meta.value))
+                self.pointers[i].cast(int).initialize(id(meta.value))
 
             elif meta.matches.ClassVtable:
-                pointers[i].cast(int).initialize(
+                self.pointers[i].cast(int).initialize(
                     _types._vtablePointer(meta.value)
                 )
 
             elif meta.matches.RawTypePointer:
-                pointers[i].cast(int).initialize(
+                self.pointers[i].cast(int).initialize(
                     _types.getTypePointer(meta.value)
                 )

--- a/typed_python/compiler/module_definition.py
+++ b/typed_python/compiler/module_definition.py
@@ -18,15 +18,19 @@ from typed_python import sha_hash
 class ModuleDefinition:
     """A single module of compiled llvm code.
 
-    Members:
-        moduleText - a string containing the llvm IR for the module
-        functionList - a list of the names of exported functions
-        globalDefinitions - a dict from name to a GlobalDefinition
+    Attributes:
+        moduleText (str): a string containing the llvm IR for the module
+        functionList (list): a list of the names of exported functions
+        globalDefinitions (dict): a dict from name to a GlobalDefinition
+        globalDependencies (dict): a dict from function link_name to a list of globals the
+            function depends on
+        hash (str): The module hash, generated from the llvm IR.
     """
     GET_GLOBAL_VARIABLES_NAME = ".get_global_variables"
 
-    def __init__(self, moduleText, functionNameToType, globalVariableDefinitions):
+    def __init__(self, moduleText, functionNameToType, globalVariableDefinitions, globalDependencies):
         self.moduleText = moduleText
         self.functionNameToType = functionNameToType
         self.globalVariableDefinitions = globalVariableDefinitions
+        self.globalDependencies = globalDependencies
         self.hash = sha_hash(moduleText)

--- a/typed_python/compiler/native_ast_to_llvm.py
+++ b/typed_python/compiler/native_ast_to_llvm.py
@@ -12,12 +12,12 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-import typed_python.compiler.native_ast as native_ast
-from typed_python.compiler.module_definition import ModuleDefinition
-from typed_python.compiler.global_variable_definition import GlobalVariableDefinition
 import llvmlite.ir
 import os
-
+import typed_python.compiler.native_ast as native_ast
+from typed_python.compiler.global_variable_definition import GlobalVariableDefinition
+from typed_python.compiler.module_definition import ModuleDefinition
+from typing import Dict
 llvm_i8ptr = llvmlite.ir.IntType(8).as_pointer()
 llvm_i8 = llvmlite.ir.IntType(8)
 llvm_i32 = llvmlite.ir.IntType(32)
@@ -512,7 +512,8 @@ class FunctionConverter:
         # dict from name to GlobalVariableDefinition
         self.globalDefinitions = globalDefinitions
         self.globalDefinitionLlvmValues = globalDefinitionLlvmValues
-
+        #  a list of the global LLVM names that the function depends on.
+        self.global_names = []
         self.module = module
         self.converter = converter
         self.builder = builder
@@ -631,7 +632,16 @@ class FunctionConverter:
         )
         return self.builder.bitcast(exception_ptr, llvm_i8ptr)
 
-    def namedCallTargetToLLVM(self, target):
+    def namedCallTargetToLLVM(self, target: native_ast.NamedCallTarget) -> TypedLLVMValue:
+        """
+        Generate llvm IR code for a given target.
+
+        There are three options for code generation:
+        1. The target is external, i.e something like pyobj_len, np_add_traceback - system-level functions. We add to
+            external_function_references.
+        2. The function is in function_definitions, in which case we grab the function definition and make an inlining decision.
+        3. We have a compiler cache, and the function is in it. We add to external_function_references.
+        """
         if target.external:
             if target.name not in self.external_function_references:
                 func_type = llvmlite.ir.FunctionType(
@@ -650,7 +660,6 @@ class FunctionConverter:
             func = self.external_function_references[target.name]
         elif target.name in self.converter._function_definitions:
             func = self.converter._functions_by_name[target.name]
-
             if func.module is not self.module:
                 # first, see if we'd like to inline this module
                 if (
@@ -664,7 +673,7 @@ class FunctionConverter:
 
                     func = self.external_function_references[target.name]
         else:
-            # TODO: decide whether to inline based on something in the compiler cache
+            # TODO (Will): decide whether to inline cached code
             assert self.compilerCache is not None and self.compilerCache.hasSymbol(target.name)
             # this function is defined in a shared object that we've loaded from a prior
             # invocation
@@ -802,6 +811,7 @@ class FunctionConverter:
             return self.stack_slots[expr.name]
 
         if expr.matches.GlobalVariable:
+            self.global_names.append(expr.name)
             if expr.name in self.globalDefinitions:
                 assert expr.metadata == self.globalDefinitions[expr.name].metadata, (
                     expr.metadata, self.globalDefinitions[expr.name].metadata
@@ -1485,11 +1495,11 @@ def populate_needed_externals(external_function_references, module):
 
 
 class Converter:
-    def __init__(self, compilerCache):
+    def __init__(self, compilerCache=None):
         object.__init__(self)
         self._modules = {}
-        self._functions_by_name = {}
-        self._function_definitions = {}
+        self._functions_by_name: Dict[str, llvmlite.ir.Function] = {}
+        self._function_definitions: Dict[str, native_ast.Function] = {}
 
         # total number of instructions in each function, by name
         self._function_complexity = {}
@@ -1504,7 +1514,7 @@ class Converter:
     def totalFunctionComplexity(self, name):
         """Return the total number of instructions contained in a function.
 
-        The function must already have been defined in a prior parss. We use this
+        The function must already have been defined in a prior pass. We use this
         information to decide which functions to repeat in new module definitions.
         """
         if name in self._function_complexity:
@@ -1538,9 +1548,7 @@ class Converter:
         assert isinstance(funcType, llvmlite.ir.FunctionType)
 
         self._functions_by_name[name] = llvmlite.ir.Function(module, funcType, name)
-
         self._inlineRequests.append(name)
-
         return self._functions_by_name[name]
 
     def add_functions(self, names_to_definitions):
@@ -1596,7 +1604,8 @@ class Converter:
 
         globalDefinitions = {}
         globalDefinitionsLlvmValues = {}
-
+        # we need a separate dictionary owing to the possibility of global var reuse across functions.
+        globalDependencies = {}
         while names_to_definitions:
             for name in sorted(names_to_definitions):
                 definition = names_to_definitions.pop(name)
@@ -1613,7 +1622,7 @@ class Converter:
                         TypedLLVMValue(func.args[i], definition.args[i][1])
 
                 block = func.append_basic_block('entry')
-                builder = llvmlite.ir.IRBuilder(block)  # this shares state with func
+                builder = llvmlite.ir.IRBuilder(block)
 
                 try:
                     func_converter = FunctionConverter(
@@ -1633,6 +1642,8 @@ class Converter:
                     res = func_converter.convert(definition.body.body)
 
                     func_converter.finalize()
+
+                    globalDependencies[func.name] = func_converter.global_names
 
                     if res is not None:
                         assert res.llvm_value is None
@@ -1667,7 +1678,8 @@ class Converter:
         return ModuleDefinition(
             str(module),
             functionTypes,
-            globalDefinitions
+            globalDefinitions,
+            globalDependencies
         )
 
     def defineGlobalMetadataAccessor(self, module, globalDefinitions, globalDefinitionsLlvmValues):

--- a/typed_python/compiler/native_ast_to_llvm.py
+++ b/typed_python/compiler/native_ast_to_llvm.py
@@ -501,14 +501,13 @@ class FunctionConverter:
                  module,
                  globalDefinitions,
                  globalDefinitionLlvmValues,
-                 function,
                  converter,
                  builder,
                  arg_assignments,
                  output_type,
-                 external_function_references
+                 external_function_references,
+                 compilerCache,
                  ):
-        self.function = function
 
         # dict from name to GlobalVariableDefinition
         self.globalDefinitions = globalDefinitions
@@ -522,6 +521,7 @@ class FunctionConverter:
         self.external_function_references = external_function_references
         self.tags_initialized = {}
         self.stack_slots = {}
+        self.compilerCache = compilerCache
 
     def tags_as(self, new_tags):
         class scoper():
@@ -648,7 +648,24 @@ class FunctionConverter:
                         llvmlite.ir.Function(self.module, func_type, target.name)
 
             func = self.external_function_references[target.name]
-        elif target.name in self.converter._externallyDefinedFunctionTypes:
+        elif target.name in self.converter._function_definitions:
+            func = self.converter._functions_by_name[target.name]
+
+            if func.module is not self.module:
+                # first, see if we'd like to inline this module
+                if (
+                    self.converter.totalFunctionComplexity(target.name) < CROSS_MODULE_INLINE_COMPLEXITY
+                ):
+                    func = self.converter.repeatFunctionInModule(target.name, self.module)
+                else:
+                    if target.name not in self.external_function_references:
+                        self.external_function_references[target.name] = \
+                            llvmlite.ir.Function(self.module, func.function_type, func.name)
+
+                    func = self.external_function_references[target.name]
+        else:
+            # TODO: decide whether to inline based on something in the compiler cache
+            assert self.compilerCache is not None and self.compilerCache.hasSymbol(target.name)
             # this function is defined in a shared object that we've loaded from a prior
             # invocation
             if target.name not in self.external_function_references:
@@ -665,22 +682,6 @@ class FunctionConverter:
                 )
 
             func = self.external_function_references[target.name]
-        else:
-            func = self.converter._functions_by_name[target.name]
-
-            if func.module is not self.module:
-                # first, see if we'd like to inline this module
-                if (
-                    self.converter.totalFunctionComplexity(target.name) < CROSS_MODULE_INLINE_COMPLEXITY
-                    and self.converter.canBeInlined(target.name)
-                ):
-                    func = self.converter.repeatFunctionInModule(target.name, self.module)
-                else:
-                    if target.name not in self.external_function_references:
-                        self.external_function_references[target.name] = \
-                            llvmlite.ir.Function(self.module, func.function_type, func.name)
-
-                    func = self.external_function_references[target.name]
 
         return TypedLLVMValue(
             func,
@@ -1484,15 +1485,11 @@ def populate_needed_externals(external_function_references, module):
 
 
 class Converter:
-    def __init__(self):
+    def __init__(self, compilerCache):
         object.__init__(self)
         self._modules = {}
         self._functions_by_name = {}
         self._function_definitions = {}
-
-        # a map from function name to function type for functions that
-        # are defined in external shared objects and linked in to this one.
-        self._externallyDefinedFunctionTypes = {}
 
         # total number of instructions in each function, by name
         self._function_complexity = {}
@@ -1502,12 +1499,7 @@ class Converter:
         self._printAllNativeCalls = os.getenv("TP_COMPILER_LOG_NATIVE_CALLS")
         self.verbose = False
 
-    def markExternal(self, functionNameToType):
-        """Provide type signatures for a set of external functions."""
-        self._externallyDefinedFunctionTypes.update(functionNameToType)
-
-    def canBeInlined(self, name):
-        return name not in self._externallyDefinedFunctionTypes
+        self.compilerCache = compilerCache
 
     def totalFunctionComplexity(self, name):
         """Return the total number of instructions contained in a function.
@@ -1621,19 +1613,19 @@ class Converter:
                         TypedLLVMValue(func.args[i], definition.args[i][1])
 
                 block = func.append_basic_block('entry')
-                builder = llvmlite.ir.IRBuilder(block)
+                builder = llvmlite.ir.IRBuilder(block)  # this shares state with func
 
                 try:
                     func_converter = FunctionConverter(
                         module,
                         globalDefinitions,
                         globalDefinitionsLlvmValues,
-                        func,
                         self,
                         builder,
                         arg_assignments,
                         definition.output_type,
-                        external_function_references
+                        external_function_references,
+                        self.compilerCache,
                     )
 
                     func_converter.setup()

--- a/typed_python/compiler/runtime.py
+++ b/typed_python/compiler/runtime.py
@@ -207,7 +207,7 @@ class Runtime:
             )
         else:
             self.compilerCache = None
-        self.llvm_compiler = llvm_compiler.Compiler(inlineThreshold=100)
+        self.llvm_compiler = llvm_compiler.Compiler(inlineThreshold=100, compilerCache=self.compilerCache)
         self.converter = python_to_native_converter.PythonToNativeConverter(
             self.llvm_compiler,
             self.compilerCache

--- a/typed_python/compiler/tests/numpy_interaction_test.py
+++ b/typed_python/compiler/tests/numpy_interaction_test.py
@@ -1,4 +1,4 @@
-from typed_python import ListOf, Entrypoint
+from typed_python import ListOf, Entrypoint, SerializationContext
 import numpy
 import numpy.linalg
 
@@ -44,3 +44,12 @@ def test_listof_from_sliced_numpy_array():
     y = x[::2]
 
     assert ListOf(int)(y) == [0, 2]
+
+
+def test_can_serialize_numpy_ufunc():
+    assert numpy.sin == SerializationContext().deserialize(SerializationContext().serialize(numpy.sin))
+
+
+def test_can_serialize_numpy_array():
+    x = numpy.ones(10)
+    assert (x == SerializationContext().deserialize(SerializationContext().serialize(x))).all()

--- a/typed_python/compiler/tests/type_of_instances_compilation_test.py
+++ b/typed_python/compiler/tests/type_of_instances_compilation_test.py
@@ -17,13 +17,13 @@ def test_type_of_class_is_specific():
 
 def test_type_of_alternative_is_specific():
     for members in [{}, {'a': int}]:
-        A = Alternative("A", A=members)
+        Alt = Alternative("Alt", A=members)
 
         @Entrypoint
-        def typeOfArg(x: A):
+        def typeOfArg(x: Alt):
             return type(x)
 
-        assert typeOfArg(A.A()) is A.A
+        assert typeOfArg(Alt.A()) is Alt.A
 
 
 def test_type_of_concrete_alternative_is_specific():

--- a/typed_python/lib/datetime/date_time.py
+++ b/typed_python/lib/datetime/date_time.py
@@ -269,7 +269,7 @@ class Date(Class, Final):
         return Date(self.year, self.month, 1)
 
     def quarterOfYear(self):
-        return (self.date.month - 1) // 3 + 1
+        return (self.month - 1) // 3 + 1
 
     def next(self, step: int = 1):
         """Returns the date `step` days ahead of `self`.

--- a/typed_python/lib/datetime/date_time_test.py
+++ b/typed_python/lib/datetime/date_time_test.py
@@ -1,6 +1,7 @@
 import pytest
 import pytz
 import datetime
+from typed_python import NamedTuple
 from typed_python.lib.datetime.date_time import (
     Date,
     DateTime,
@@ -15,8 +16,8 @@ from typed_python.lib.datetime.date_time import (
     OneFoldOnlyError,
     PytzTimezone,
 )
-from typed_python import Timestamp, NamedTuple
 from typed_python.lib.datetime.date_parser_test import get_datetimes_in_range
+from typed_python.lib.timestamp import Timestamp
 
 
 def test_last_weekday_of_month():

--- a/typed_python/types_serialization_test.py
+++ b/typed_python/types_serialization_test.py
@@ -3061,3 +3061,27 @@ class TypesSerializationTest(unittest.TestCase):
         print(x)
         # TODO: make this True
         # assert x[0].f.__closure__[0].cell_contents is x
+
+    def test_serialize_pyobj_with_custom_reduce(self):
+        class CustomReduceObject:
+            def __reduce__(self):
+                return 'CustomReduceObject'
+
+        assert CustomReduceObject == SerializationContext().deserialize(SerializationContext().serialize(CustomReduceObject))
+
+    def test_serialize_pyobj_in_MRTG_with_custom_reduce(self):
+        def getX():
+            class InnerCustomReduceObject:
+                def __reduce__(self):
+                    return 'InnerCustomReduceObject'
+
+                def f(self):
+                    return x
+
+            x = (InnerCustomReduceObject, InnerCustomReduceObject)
+
+            return x
+
+        x = callFunctionInFreshProcess(getX, (), showStdout=True)
+
+        assert x == SerializationContext().deserialize(SerializationContext().serialize(x))

--- a/typed_python/types_serialization_test.py
+++ b/typed_python/types_serialization_test.py
@@ -15,6 +15,8 @@
 import sys
 import os
 import importlib
+from functools import lru_cache
+
 from abc import ABC, abstractmethod, ABCMeta
 from typed_python.test_util import callFunctionInFreshProcess
 import typed_python.compiler.python_ast_util as python_ast_util
@@ -55,6 +57,13 @@ from typed_python._types import (
 )
 
 module_level_testfun = dummy_test_module.testfunction
+
+
+class GlobalClassWithLruCache:
+    @staticmethod
+    @lru_cache(maxsize=None)
+    def f(x):
+        return x
 
 
 def moduleLevelFunctionUsedByExactlyOneSerializationTest():
@@ -3085,3 +3094,10 @@ class TypesSerializationTest(unittest.TestCase):
         x = callFunctionInFreshProcess(getX, (), showStdout=True)
 
         assert x == SerializationContext().deserialize(SerializationContext().serialize(x))
+
+    def test_serialize_class_static_lru_cache(self):
+        s = SerializationContext()
+
+        assert (
+            s.deserialize(s.serialize(GlobalClassWithLruCache.f)) is GlobalClassWithLruCache.f
+        )


### PR DESCRIPTION
(by @braxtonmckee)
## Motivation and Context

When we first call a python function 'f' with a specific set of arguments, we may not know its return type the first time we try to convert it.  To ensure we have a stable typing graph, we repeatedly update the active functions in our graph until the type graph is stable.

This can lead to many copies of the same function, or even multiple signatures of the same function, only one of which we'll use.

This change prunes those away before we submit them to the LLVM layer.

## How Has This Been Tested?
Running `test_dispatch_to_function_overload` with `TP_COMPILER_VERBOSE=1 `with and without this commit causes 13 functions to be converted rather than 17, with a slight speedup.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.