### PR TITLE
Add function complexities and intermediates to cache

### DIFF
--- a/typed_python/compiler/compiler_cache_test.py
+++ b/typed_python/compiler/compiler_cache_test.py
@@ -16,6 +16,7 @@ import tempfile
 import threading
 import os
 import pytest
+
 from typed_python.test_util import evaluateExprInFreshProcess
 
 MAIN_MODULE = """

--- a/typed_python/compiler/llvm_compiler.py
+++ b/typed_python/compiler/llvm_compiler.py
@@ -123,7 +123,10 @@ class Compiler:
             mod,
             serializedGlobalVariableDefinitions,
             module.functionNameToType,
-            module.globalDependencies
+            module.globalDependencies,
+            {name: self.converter.totalFunctionComplexity(name) for name in functions},
+            {name: self.converter._functions_by_name[name] for name in functions},
+            {name: SerializationContext().serialize(self.converter._function_definitions[name]) for name in functions},
         )
 
     def function_pointer_by_name(self, name):

--- a/typed_python/compiler/python_to_native_converter.py
+++ b/typed_python/compiler/python_to_native_converter.py
@@ -17,7 +17,7 @@ import logging
 
 from typed_python.hash import Hash
 from types import ModuleType
-from typing import Dict
+from typing import Dict, Optional
 from typed_python import Class
 import typed_python.python_ast as python_ast
 import typed_python._types as _types
@@ -288,10 +288,10 @@ class PythonToNativeConverter:
         self._targets.pop(linkName)
 
     def setTarget(self, linkName, target):
-        assert(isinstance(target, TypedCallTarget))
+        assert (isinstance(target, TypedCallTarget))
         self._targets[linkName] = target
 
-    def getTarget(self, linkName) -> TypedCallTarget:
+    def getTarget(self, linkName) -> Optional[TypedCallTarget]:
         if linkName in self._targets:
             return self._targets[linkName]
 


### PR DESCRIPTION
NB: depends on  #440.

## Motivation and Context

In order to inline cached functions we must store the native and llvm layer intermediates, along with the complexities. This will reduce cache load time but should increase compiled function speed and predictability.

## Approach
The optimal approach would be to regenerate the necessary intermediates from the information given at the native layer, but as it stands i don't think we don't have enough information to do so. So instead we track the necessary intermediates in the BinarySharedObject which gets read/written to disk.

## How Has This Been Tested?
full pytest suite, debugging statements (now removed) to ensure the correct codepath is hit.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.