### PR TITLE
QoL improvements to python_to_native and compiler_cache

### DIFF
--- a/typed_python/compiler/expression_conversion_context.py
+++ b/typed_python/compiler/expression_conversion_context.py
@@ -119,7 +119,7 @@ class ExpressionConversionContext:
         # the first argument indicates whether this is an instance or type-level dispatch
         assert argTupleType.ElementTypes[0].Value in ('type', 'instance')
 
-        identHash = self.converter.hashObjectToIdentity(
+        identHash = self.converter.hash_object_to_identity(
             (clsType, methodName, retType, argTupleType, kwargTupleType)
         )
 
@@ -1141,7 +1141,7 @@ class ExpressionConversionContext:
                 funcGlobals[f.__code__.co_freevars[i]] = f.__closure__[i].cell_contents
                 globalsInCells.append(f.__code__.co_freevars[i])
 
-        call_target = self.functionContext.converter.convert(
+        call_target = self.functionContext.converter.convert_python_to_native(
             f.__name__,
             f.__code__,
             funcGlobals,
@@ -1185,7 +1185,7 @@ class ExpressionConversionContext:
         else:
             returnType = typeWrapper(overload.returnType) if overload.returnType is not None else None
 
-        call_target = self.functionContext.converter.convert(
+        call_target = self.functionContext.converter.convert_python_to_native(
             overload.name,
             overload.functionCode,
             overload.realizedGlobals,
@@ -1474,7 +1474,7 @@ class ExpressionConversionContext:
         return None
 
     def expressionAsFunctionCall(self, name, args, generatingFunction, identity, outputType=None, alwaysRaises=False):
-        callTarget = self.converter.defineNonPythonFunction(
+        callTarget = self.converter.define_non_python_function(
             name,
             ("expression", identity),
             typed_python.compiler.function_conversion_context.ExpressionFunctionConversionContext(

--- a/typed_python/compiler/function_conversion_context.py
+++ b/typed_python/compiler/function_conversion_context.py
@@ -621,9 +621,9 @@ class ConversionContextBase:
 
         returnSlot.convert_copy_initialize(output)
 
-        context.converter.triggerVirtualDestructor(generatorSubclass)
+        context.converter.trigger_virtual_destructor(generatorSubclass)
 
-        context.converter.triggerVirtualMethodInstantiation(
+        context.converter.trigger_virtual_method_instantiation(
             generatorSubclass,
             "__fastnext__",
             PointerTo(T),
@@ -631,7 +631,7 @@ class ConversionContextBase:
             NamedTuple()
         )
 
-        context.converter.triggerVirtualMethodInstantiation(
+        context.converter.trigger_virtual_method_instantiation(
             generatorSubclass,
             "__next__",
             T,

--- a/typed_python/compiler/llvm_compiler.py
+++ b/typed_python/compiler/llvm_compiler.py
@@ -124,7 +124,7 @@ class Compiler:
             serializedGlobalVariableDefinitions,
             module.functionNameToType,
             module.globalDependencies,
-            {name: self.converter.totalFunctionComplexity(name) for name in functions},
+            {name: self.converter.total_function_complexity(name) for name in functions},
             {name: self.converter._functions_by_name[name] for name in functions},
             {name: SerializationContext().serialize(self.converter._function_definitions[name]) for name in functions},
         )

--- a/typed_python/compiler/llvm_compiler_test.py
+++ b/typed_python/compiler/llvm_compiler_test.py
@@ -154,7 +154,7 @@ def test_loaded_modules_persist():
         "    return f(x) * 100",
         "g(1000)",
         "def get_loaded_modules():",
-        "    return len(Runtime.singleton().converter.loadedUncachedModules)"
+        "    return len(Runtime.singleton().converter.loaded_uncached_modules)"
     ])
     VERSION1 = {'x.py': xmodule}
     assert evaluateExprInFreshProcess(VERSION1, 'x.get_loaded_modules()') == 1

--- a/typed_python/compiler/native_ast_to_llvm.py
+++ b/typed_python/compiler/native_ast_to_llvm.py
@@ -516,7 +516,7 @@ class FunctionConverter:
         #  a list of the global LLVM names that the function depends on.
         self.global_names = []
         self.module = module
-        self.converter = converter
+        self.converter: Converter = converter
         self.builder = builder
         self.arg_assignments = arg_assignments
         self.output_type = output_type
@@ -665,9 +665,9 @@ class FunctionConverter:
             if func.module is not self.module:
                 # first, see if we'd like to inline this module
                 if (
-                    self.converter.totalFunctionComplexity(target.name) < CROSS_MODULE_INLINE_COMPLEXITY
+                    self.converter.total_function_complexity(target.name) < CROSS_MODULE_INLINE_COMPLEXITY
                 ):
-                    func = self.converter.repeatFunctionInModule(target.name, self.module)
+                    func = self.converter.repeat_function_in_module(target.name, self.module)
                 else:
                     if target.name not in self.external_function_references:
                         self.external_function_references[target.name] = \
@@ -675,14 +675,14 @@ class FunctionConverter:
 
                     func = self.external_function_references[target.name]
         else:
-            assert self.compilerCache is not None and self.compilerCache.hasSymbol(target.name)
+            assert self.compilerCache is not None and self.compilerCache.has_symbol(target.name)
             # this function is defined in a shared object that we've loaded from a prior
             # invocation. Again, first make an inlining decision.
             if (
-                self.compilerCache.complexityForSymbol(target.name) < CROSS_MODULE_INLINE_COMPLEXITY
+                self.compilerCache.complexity_for_symbol(target.name) < CROSS_MODULE_INLINE_COMPLEXITY
             ):
-                self.converter.generateDefinition(target.name)
-                func = self.converter.repeatFunctionInModule(target.name, self.module)
+                self.converter.generate_definition(target.name)
+                func = self.converter.repeat_function_in_module(target.name, self.module)
             else:
                 if target.name not in self.external_function_references:
                     func_type = llvmlite.ir.FunctionType(
@@ -1518,7 +1518,7 @@ class Converter:
 
         self.compilerCache = compilerCache
 
-    def totalFunctionComplexity(self, name):
+    def total_function_complexity(self, name):
         """Return the total number of instructions contained in a function.
 
         The function must already have been defined in a prior pass. We use this
@@ -1535,19 +1535,19 @@ class Converter:
 
         return res
 
-    def generateDefinition(self, name: str) -> None:
+    def generate_definition(self, name: str) -> None:
         """Pull the TypedCallTarget matching `name` from the cache, and use to rebuild
         the function definition. Add to _function_definitions and _functions_by_name.
         """
         assert self.compilerCache is not None
 
-        definition = self.compilerCache.getDefinition(name)
-        llvm_func = self.compilerCache.getIR(name)
+        definition = self.compilerCache.get_definition(name)
+        llvm_func = self.compilerCache.get_IR(name)
 
         self._functions_by_name[name] = llvm_func
         self._function_definitions[name] = definition
 
-    def repeatFunctionInModule(self, name, module):
+    def repeat_function_in_module(self, name, module):
         """Request that the function given by 'name' be inlined into 'module'.
 
         It must already have been defined in another module.

--- a/typed_python/compiler/python_to_native_converter.py
+++ b/typed_python/compiler/python_to_native_converter.py
@@ -12,39 +12,50 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-import types
 import logging
-
-from typed_python.hash import Hash
+import types
 from types import ModuleType
-from typing import Dict, Optional
-from typed_python import Class
-import typed_python.python_ast as python_ast
+from typing import Dict, List, Optional, Tuple, Type
+
+from sortedcontainers import SortedSet
+
 import typed_python._types as _types
 import typed_python.compiler
 import typed_python.compiler.native_ast as native_ast
-from typed_python.compiler.native_function_pointer import NativeFunctionPointer
-from sortedcontainers import SortedSet
+import typed_python.python_ast as python_ast
+from typed_python import Class
+from typed_python.compiler.compiler_cache import CompilerCache
 from typed_python.compiler.directed_graph import DirectedGraph
-from typed_python.compiler.type_wrappers.wrapper import Wrapper
-from typed_python.compiler.type_wrappers.class_wrapper import ClassWrapper
-from typed_python.compiler.python_object_representation import typedPythonTypeToTypeWrapper
-from typed_python.compiler.function_conversion_context import FunctionConversionContext, FunctionOutput, FunctionYield
+from typed_python.compiler.function_conversion_context import (FunctionConversionContext, FunctionOutput, FunctionYield)
+from typed_python.compiler.llvm_compiler import Compiler
 from typed_python.compiler.native_function_conversion_context import NativeFunctionConversionContext
+from typed_python.compiler.native_function_pointer import NativeFunctionPointer
+from typed_python.compiler.python_object_representation import typedPythonTypeToTypeWrapper
+from typed_python.compiler.type_wrappers.class_wrapper import ClassWrapper
 from typed_python.compiler.type_wrappers.python_typed_function_wrapper import (
-    PythonTypedFunctionWrapper, CannotBeDetermined, NoReturnTypeSpecified
-)
+    CannotBeDetermined, NoReturnTypeSpecified, PythonTypedFunctionWrapper)
+from typed_python.compiler.type_wrappers.wrapper import Wrapper
 from typed_python.compiler.typed_call_target import TypedCallTarget
+from typed_python.hash import Hash
+from typed_python.internals import ClassMetaclass
 
-typeWrapper = lambda t: typed_python.compiler.python_object_representation.typedPythonTypeToTypeWrapper(t)
+
+__all__ = ['PythonToNativeConverter']
+
+type_wrapper = lambda t: typed_python.compiler.python_object_representation.typedPythonTypeToTypeWrapper(t)
 
 
 VALIDATE_FUNCTION_DEFINITIONS_STABLE = False
 
 
 class FunctionDependencyGraph:
+    """
+    A wrapper for DirectedGraph with identity levels and the ability to tag nodes for
+    recomputation. The nodes of the graph are function hashes, and the edges represent
+    dependency.
+    """
     def __init__(self):
-        self._dependencies = DirectedGraph()
+        self.dependency_graph = DirectedGraph()
 
         # the search depth in the dependency to find 'identity'
         # the _first_ time we ever saw it. We prefer to update
@@ -58,13 +69,13 @@ class FunctionDependencyGraph:
         # (priority, node) pairs that need to recompute
         self._dirty_inflight_functions_with_order = SortedSet(key=lambda pair: pair[0])
 
-    def dropNode(self, node):
-        self._dependencies.dropNode(node, False)
+    def drop_node(self, node):
+        self.dependency_graph.dropNode(node, False)
         if node in self._identity_levels:
             del self._identity_levels[node]
         self._dirty_inflight_functions.discard(node)
 
-    def getNextDirtyNode(self):
+    def get_next_dirty_node(self):
         while self._dirty_inflight_functions_with_order:
             priority, identity = self._dirty_inflight_functions_with_order.pop()
 
@@ -73,13 +84,13 @@ class FunctionDependencyGraph:
 
                 return identity
 
-    def addRoot(self, identity, dirty=True):
+    def add_root(self, identity, dirty=True):
         if identity not in self._identity_levels:
             self._identity_levels[identity] = 0
             if dirty:
-                self.markDirty(identity)
+                self.mark_dirty(identity)
 
-    def addEdge(self, caller, callee, dirty=True):
+    def add_edge(self, caller, callee, dirty=True):
         if caller not in self._identity_levels:
             raise Exception(f"unknown identity {caller} found in the graph")
 
@@ -87,21 +98,21 @@ class FunctionDependencyGraph:
             self._identity_levels[callee] = self._identity_levels[caller] + 1
 
             if dirty:
-                self.markDirty(callee, isNew=True)
+                self.mark_dirty(callee, isNew=True)
 
-        self._dependencies.addEdge(caller, callee)
+        self.dependency_graph.addEdge(caller, callee)
 
-    def getNamesDependedOn(self, caller):
-        return self._dependencies.outgoing(caller)
+    def get_names_depended_on(self, caller):
+        return self.dependency_graph.outgoing(caller)
 
-    def markDirtyWithLowPriority(self, callee):
+    def mark_dirty_with_low_priority(self, callee):
         # mark this dirty, but call it back after new functions.
         self._dirty_inflight_functions.add(callee)
 
         level = self._identity_levels[callee]
         self._dirty_inflight_functions_with_order.add((-1000000 + level, callee))
 
-    def markDirty(self, callee, isNew=False):
+    def mark_dirty(self, callee, isNew=False):
         self._dirty_inflight_functions.add(callee)
 
         if isNew:
@@ -113,32 +124,77 @@ class FunctionDependencyGraph:
 
         self._dirty_inflight_functions_with_order.add((level, callee))
 
-    def functionReturnSignatureChanged(self, identity):
-        for caller in self._dependencies.incoming(identity):
-            self.markDirty(caller)
+    def function_return_signature_changed(self, identity):
+        for caller in self.dependency_graph.incoming(identity):
+            self.mark_dirty(caller)
 
 
 class PythonToNativeConverter:
-    def __init__(self, llvmCompiler, compilerCache):
-        object.__init__(self)
+    """
+    What do you do?
+    - init
 
-        self.llvmCompiler = llvmCompiler
-        self.compilerCache = compilerCache
+    Parses Python functions into an intermediate representation of the AST. These representations
+    are held in self._definitions, and added how?!
+
+    'installed' but new (and hence not fully converted) definitions are stored in
+    _new_native_functions, and are sent downstream when build_and_link_new_module is called.
+
+
+    Holds optional
+
+
+    Usage is effectively, in compileFunctionOverload, we do convert_typed_function_call,
+    then demasquerade_call_target_output, then generate_call_converter, then
+    build_and_link_new_module,
+    then function_pointer_by_name.
+
+
+    x = understanding
+
+    'identity' is the hexdigest of the function hash
+    'link_name' is the symbol name, prefix + func_name + hash
+
+    Attributes:
+        llvm_compiler: The WHAT?
+        compiler_cache: The WHAT?
+        generate_debug_checks: ?
+        _all_defined_names: ?
+        _all_cached_names:
+        _link_name_for_identity: ?
+        _identity_for_link_name: ?
+        _definitions: definition blablabla
+        _targets: ?
+        _inflight_definitions: ?
+        _inflight_function_conversions: ?
+        _identifier_to_pyfunc: ?
+        _times_calculated: ?
+        _new_native_functions:
+       _visitors: A list of context managers which run on each new function installed with
+            _install_inflight_functions, giving info on e.g. compilation counts.
+        _currently_converting:
+        _dependencies: A directed graph in which nodes are function hashes and edges are a dependence.
+    """
+
+    def __init__(self, llvm_compiler: Compiler, compiler_cache: CompilerCache):
+        self.llvm_compiler = llvm_compiler
+        self.compiler_cache = compiler_cache
 
         # all LoadedModule objects that we have created. We need to keep them alive so
         # that any python metadata objects the've created stay alive as well. Ultimately, this
         # may not be the place we put these objects (for instance, you could imagine a
         # 'dummy' compiler cache or something). But for now, we need to keep them alive.
-        self.loadedUncachedModules = []
+        self.loaded_uncached_modules = []
 
         # if True, then insert additional code to check for undefined behavior.
-        self.generateDebugChecks = False
+        self.generate_debug_checks = False
 
-        self._link_name_for_identity = {}
-        self._identity_for_link_name = {}
+        self._link_name_for_identity: Dict[str, str] = {}
+        self._identity_for_link_name: Dict[str, str] = {}
         self._definitions: Dict[str, native_ast.Function] = {}
         self._targets: Dict[str, TypedCallTarget] = {}
-        self._inflight_definitions = {}
+        # NB i don't think the Wrapper is ever actually used.
+        self._inflight_definitions: Dict[str, Tuple[native_ast.Function, Type[Wrapper]]] = {}
         self._inflight_function_conversions: Dict[str, FunctionConversionContext] = {}
         self._identifier_to_pyfunc = {}
         self._times_calculated = {}
@@ -151,32 +207,540 @@ class PythonToNativeConverter:
         # the identity of the function we're currently evaluating.
         # we use this to track which functions need to get rebuilt when
         # other functions change types.
-        self._currentlyConverting = None
+        self._currently_converting = None
 
         # tuple of (baseClass, childClass, slotIndex) containing
         # virtual methods that need to get instantiated during the
         # current compilation unit.
         self._delayedVMIs = []
-        self._delayedDestructors = []
+        self._delayed_destructors = []
 
         self._installedVMIs = set()
-        self._installedDestructors = set()
+        self._installed_destructors = set()
 
         self._dependencies = FunctionDependencyGraph()
 
-    def isCurrentlyConverting(self):
+    def convert_typed_function_call(self,
+                                    function_type,
+                                    overload_index: int,
+                                    input_wrappers: List[Type[Wrapper]],
+                                    assert_is_root=False) -> Optional[TypedCallTarget]:
+        """Does what?
+        Args:
+            function_type: Normally a subclass of typed_python._types.Function? sometimes not a class at all?
+            overload_index: The index of function_type.overloads to access, corresponding to a specific set of input argument types
+            input_wrappers: The input wrappers? TODO not always a Wrapper, sometimes just a type?!
+            assert_is_root: If True, then assert that no other functions are using
+                the converter right now.
+        Trash! TODO fix
+        Returns:
+            bla
+        """
+        overload = function_type.overloads[overload_index]
+
+        realized_input_wrappers = []
+
+        closure_type = function_type.ClosureType
+
+        for closure_var_name, closure_var_path in overload.closureVarLookups.items():
+            realized_input_wrappers.append(
+                type_wrapper(
+                    PythonTypedFunctionWrapper.closurePathToCellType(closure_var_path, closure_type)
+                )
+            )
+
+        realized_input_wrappers.extend(input_wrappers)
+
+        return_type = PythonTypedFunctionWrapper.computeFunctionOverloadReturnType(
+            overload,
+            input_wrappers,
+            {}
+        )
+
+        if return_type is CannotBeDetermined:
+            return_type = object
+
+        if return_type is NoReturnTypeSpecified:
+            return_type = None
+
+        return self.convert_python_to_native(
+            overload.name,
+            overload.functionCode,
+            overload.realizedGlobals,
+            overload.functionGlobals,
+            overload.funcGlobalsInCells,
+            list(overload.closureVarLookups),
+            realized_input_wrappers,
+            return_type,
+            assert_is_root=assert_is_root
+        )
+
+    def convert_python_to_native(
+        self,
+        func_name: str,
+        func_code: types.CodeType,
+        func_globals: Dict,
+        func_glocals_raw,
+        func_globals_from_cells,
+        closure_vars,
+        input_types,
+        output_type,
+        assert_is_root=False,
+        conversion_type=None
+    ):
+        """Convert a single pure python function using args of 'input_types'.
+
+        It will return no more than 'output_type'. if output_type is None we produce
+        the tightest output type possible.
+
+        Args:
+            func_name: the name of the function
+            func_code: a Code object representing the code to compile
+            func_globals: the globals object from the relevant function
+            func_globals_raw: the original globals object (with no merging or filtering done)
+                which we use to figure out the location of global variables that are not in cells.
+            func_globals_from_cells:  a list of the names that are globals that are actually accessed
+                as cells.
+            closure_vars: a list of the names of the variables that are accessed as free variables. TODO check
+            input_types - a type for each free variable in the function closure, and
+                then again for each input argument
+            output_type - the output type of the function, if known. if this is None,
+                then we use type inference to produce the tightest type we can.
+                If not None, then we will produce this type or throw an exception.
+            assert_is_root - if True, then assert that no other functions are using
+                the converter right now.
+            conversion_type - if None, this is a normal function conversion. Otherwise,
+                this must be a subclass of FunctionConversionContext
+        """
+        assert isinstance(func_name, str)
+        assert isinstance(func_code, types.CodeType)
+        assert isinstance(func_globals, dict)
+
+        input_types = tuple([typedPythonTypeToTypeWrapper(i) for i in input_types])
+
+        identity_hash = (
+            Hash.from_integer(1)
+            + self.hash_object_to_identity((
+                func_code,
+                func_name,
+                input_types,
+                output_type,
+                closure_vars,
+                conversion_type
+            )) +
+            self._hash_globals(func_globals, func_code, func_globals_from_cells)
+        )
+
+        assert not identity_hash.isPoison()
+
+        identity = identity_hash.hexdigest
+
+        name = self._identity_hash_to_function_name(func_name, identity)
+
+        self._define_link_name(identity, name)
+
+        if identity not in self._identifier_to_pyfunc:
+            self._identifier_to_pyfunc[identity] = (
+                func_name, func_code, func_globals, closure_vars, input_types, output_type, conversion_type
+            )
+
+        is_root = len(self._inflight_function_conversions) == 0
+
+        if assert_is_root:
+            assert is_root
+
+        target = self._get_target(name)
+
+        if self._currently_converting is not None:
+            self._dependencies.add_edge(self._currently_converting, identity, dirty=(target is None))
+        else:
+            self._dependencies.add_root(identity, dirty=(target is None))
+
+        if target is not None:
+            return target
+
+        if identity not in self._inflight_function_conversions:
+            function_converter = self._create_conversion_context(
+                identity,
+                func_name,
+                func_code,
+                func_globals,
+                func_glocals_raw,
+                closure_vars,
+                input_types,
+                output_type,
+                conversion_type
+            )
+            self._inflight_function_conversions[identity] = function_converter
+
+        if is_root:
+            try:
+                self._resolve_all_inflight_functions()
+                self._install_inflight_functions()
+                return self._get_target(name)
+            finally:
+                self._inflight_function_conversions.clear()
+
+        else:
+            # above us on the stack, we are walking a set of function conversions.
+            # if we have ever calculated this function before, we'll have a call
+            # target with an output type and we can return that. Otherwise we have to
+            # return None, which will cause callers to replace this with a throw
+            # until we have had a chance to do a full pass of conversion.
+            if self._get_target(name) is not None:
+                raise RuntimeError(f"Unexpected conversion error for {name}")
+            return None
+
+    def demasquerade_call_target_output(self, call_target: TypedCallTarget) -> Optional[TypedCallTarget]:
+        """Ensure we are returning the correct 'interpreterType' from callTarget.
+
+        In some cases, we may return a 'masquerade' type in compiled code. This is fine
+        for other compiled code, but the interpreter needs us to transform the result back
+        to the right interpreter type. For instance, we may be returning a *args tuple.
+
+
+        Args:
+            call_target: the input TypedCallTarget to demasquerade (or return unchanged)
+        Returns:
+            a new TypedCallTarget where the output type has the right return type.
+        """
+        if call_target.output_type is None:
+            return call_target
+
+        if call_target.output_type.interpreterTypeRepresentation == call_target.output_type.typeRepresentation:
+            return call_target
+
+        def generator(context, out, *args):
+            assert out is not None, "we should have an output because no masquerade types are pass-by-value"
+
+            res = context.call_typed_call_target(call_target, args)
+
+            out.convert_copy_initialize(res.convert_masquerade_to_untyped())
+
+        res = self.define_native_function(
+            "demasquerade_" + call_target.name,
+            ("demasquerade", call_target.name),
+            call_target.input_types,
+            type_wrapper(call_target.output_type.interpreterTypeRepresentation),
+            generator
+        )
+
+        return res
+
+    def generate_call_converter(self, call_target: TypedCallTarget) -> str:
+        """Given a call target that's optimized for llvm-level dispatch (with individual
+        arguments packed into registers), produce a (native) call-target that
+        we can dispatch to from our C extension, where arguments are packed into
+        an array.
+
+        For instance, we are given
+            T f(A1, A2, A3 ...)
+        and want to produce
+            f(T*, X**)
+        where X is the union of A1, A2, etc.
+
+        Args:
+            call_target: a TypedCallTarget giving the function we need
+                to generate an alternative entrypoint for
+        Returns:
+            the linker name of the defined native function
+        """
+        identifier = "call_converter_" + call_target.name
+        link_name = call_target.name + ".dispatch"
+
+        # we already made a definition for this in this process so don't do it again
+        if link_name in self._definitions:
+            return link_name
+
+        # we already defined it in another process so don't do it again
+        if self.compiler_cache is not None and self.compiler_cache.has_symbol(link_name):
+            return link_name
+
+        # N.B. there aren't targets for call converters. We make the definition directly.
+        args = []
+        for i in range(len(call_target.input_types)):
+            if not call_target.input_types[i].is_empty:
+                argtype = call_target.input_types[i].getNativeLayoutType()
+
+                untyped_ptr = native_ast.var('input').ElementPtrIntegers(i).load()
+
+                if call_target.input_types[i].is_pass_by_ref:
+                    # we've been handed a pointer, and it's already a pointer
+                    args.append(untyped_ptr.cast(argtype.pointer()))
+                else:
+                    args.append(untyped_ptr.cast(argtype.pointer()).load())
+
+        if call_target.output_type is not None and call_target.output_type.is_pass_by_ref:
+            body = call_target.call(
+                native_ast.var('return').cast(call_target.output_type.getNativeLayoutType().pointer()),
+                *args
+            )
+        else:
+            body = call_target.call(*args)
+
+            if not (call_target.output_type is None or call_target.output_type.is_empty):
+                body = native_ast.var('return').cast(call_target.output_type.getNativeLayoutType().pointer()).store(body)
+
+        body = native_ast.FunctionBody.Internal(body=body)
+
+        definition = native_ast.Function(
+            args=(
+                ('return', native_ast.Type.Void().pointer()),
+                ('input', native_ast.Type.Void().pointer().pointer())
+            ),
+            body=body,
+            output_type=native_ast.Type.Void()
+        )
+
+        self._link_name_for_identity[identifier] = link_name
+        self._identity_for_link_name[link_name] = identifier
+
+        self._definitions[link_name] = definition
+        self._new_native_functions.add(link_name)
+
+        return link_name
+
+    def build_and_link_new_module(self) -> None:
+        """Pull all in-flight conversions and compile as a module.
+        This grabs all new functions, where the python->native conversion has been completed,
+        and collates these + their dependencies and global variables into a module, performing the
+        native -> llvm conversion. The list of in-flight functions is cleared once parsed to avoid
+        double-compilation.
+        """
+
+        definitions = self._extract_new_function_definitions()
+
+        if not definitions:
+            return
+
+        if self.compiler_cache is None:
+            loaded_module = self.llvm_compiler.buildModule(definitions)  # TODO handle None
+            loaded_module.linkGlobalVariables()
+            self.loaded_uncached_modules.append(loaded_module)
+            return
+
+        # get a set of function names that we depend on
+        externally_used = set()
+        dependency_edgelist = []
+
+        for func_name in definitions:
+            ident = self._identity_for_link_name.get(func_name)
+            if ident is not None:
+                for dep in self._dependencies.get_names_depended_on(ident):
+                    depLN = self._link_name_for_identity.get(dep)
+                    dependency_edgelist.append([func_name, depLN])
+                    if depLN not in definitions:
+                        externally_used.add(depLN)
+
+        binary = self.llvm_compiler.buildSharedObject(definitions)
+
+        self.compiler_cache.add_module(
+            binary,
+            {name: self._get_target(name) for name in definitions if self._has_target(name)},
+            externally_used,
+            dependency_edgelist
+        )
+
+    def define_non_python_function(self, name: str, identity_tuple: Tuple, context) -> Optional[TypedCallTarget]:
+        """Define a non-python generating function (if we haven't defined it before already)
+
+            name: the name to actually give the function.
+            identity_tuple: a unique (sha)hashable tuple
+            context: a FunctionConversionContext lookalike
+
+        Returns:
+            A TypedCallTarget, or None if it's not known yet
+        """
+        identity = self.hash_object_to_identity(identity_tuple).hexdigest
+        linkName = self._identity_hash_to_function_name(name, identity, "runtime.")
+
+        self._define_link_name(identity, linkName)
+
+        target = self._get_target(linkName)
+
+        if self._currently_converting is not None:
+            self._dependencies.add_edge(self._currently_converting, identity, dirty=(target is None))
+        else:
+            self._dependencies.add_root(identity, dirty=(target is None))
+
+        if target is not None:
+            return target
+
+        self._inflight_function_conversions[identity] = context
+
+        if context.knownOutputType() is not None or context.alwaysRaises():
+            self._set_target(
+                linkName,
+                self._get_typed_call_target(
+                    name,
+                    context.getInputTypes(),
+                    context.knownOutputType(),
+                    always_raises=context.alwaysRaises(),
+                    function_metadata=context.functionMetadata,
+                )
+            )
+
+        if self._currently_converting is None:
+            # force the function to resolve immediately
+            self._resolve_all_inflight_functions()
+            self._install_inflight_functions()
+            self._inflight_function_conversions.clear()
+
+        return self._get_target(linkName)
+
+    def define_native_function(self,
+                               name: str,
+                               identity: Tuple,
+                               input_types,
+                               output_type,
+                               generatingFunction) -> Optional[TypedCallTarget]:
+        """Define a native function if we haven't defined it before already.
+
+
+        Args:
+            name: the name to actually give the function.
+            identity: a tuple consisting of strings, ints, type wrappers, and tuples of same
+            input_types: list of Wrapper objects for the incoming types
+            output_type: Wrapper object for the output type, or None if the function doesn't
+                ever return
+            generatingFunction: a function producing a native_function_definition.
+                It should accept an expression_conversion_context, an expression for the output
+                if it's not pass-by-value (or None if it is), and a bunch of TypedExpressions
+                and produce code that always ends in a terminal expression, (or if it's pass by value,
+                flows off the end of the function)
+
+        Returns:
+            A TypedCallTarget. 'generatingFunction' may call this recursively if it wants.
+        """
+        if output_type is not None:
+            output_type = type_wrapper(output_type)
+
+        input_types = [type_wrapper(x) for x in input_types]
+
+        identity = (
+            Hash.from_integer(2) +
+            self.hash_object_to_identity(identity) +
+            self.hash_object_to_identity(output_type) +
+            self.hash_object_to_identity(input_types)
+        ).hexdigest
+
+        return self.define_non_python_function(
+            name,
+            identity,
+            NativeFunctionConversionContext(
+                self, input_types, output_type, generatingFunction, identity
+            )
+        )
+
+    def compile_single_class_dispatch(self, interface_class: ClassMetaclass, implementing_class: ClassMetaclass, slot_index: int):
+        if (interface_class, implementing_class, slot_index) in self._installedVMIs:
+            return
+
+        name, ret_type, arg_type_tuple, kwarg_type_tuple = _types.getClassMethodDispatchSignature(interface_class,
+                                                                                                  implementing_class,
+                                                                                                  slot_index)
+
+        # we are compiling the function 'name' in 'implementingClass' to be installed when
+        # viewing an instance of 'implementingClass' as 'interfaceClass' that's function
+        # 'name' called with signature '(*argTypeTuple, **kwargTypeTuple) -> retType'
+        typed_call_target = ClassWrapper.compileVirtualMethodInstantiation(
+            self,
+            interface_class,
+            implementing_class,
+            name,
+            ret_type,
+            arg_type_tuple,
+            kwarg_type_tuple
+        )
+
+        assert typed_call_target is not None
+
+        self.build_and_link_new_module()
+
+        fp = self.function_pointer_by_name(typed_call_target.name)
+
+        if fp is None:
+            raise Exception(f"Couldn't find a function pointer for {typed_call_target.name}")
+
+        _types.installClassMethodDispatch(interface_class, implementing_class, slot_index, fp.fp)
+
+        self._installedVMIs.add(
+            (interface_class, implementing_class, slot_index)
+        )
+
+    def compile_class_destructor(self, cls):
+        if cls in self._installed_destructors:
+            return
+
+        typed_call_target = type_wrapper(cls).compileDestructor(self)
+
+        assert typed_call_target is not None
+
+        self.build_and_link_new_module()
+
+        fp = self.function_pointer_by_name(typed_call_target.name)
+
+        _types.installClassDestructor(cls, fp.fp)
+        self._installed_destructors.add(cls)
+
+    def function_pointer_by_name(self, func_name) -> NativeFunctionPointer:
+        """Find a NativeFunctionPointer for a given link-time name.
+
+        Args:
+            func_name (str) - the name of the compiled symbol we want.
+
+        Returns:
+            a NativeFunctionPointer or None
+        """
+        if self.compiler_cache is None:
+            # the llvm compiler holds it all
+            return self.llvm_compiler.function_pointer_by_name(func_name)
+        else:
+            # the llvm compiler is just building shared objects, but the
+            # compiler cache has all the pointers.
+            return self.compiler_cache.function_pointer_by_name(func_name)
+
+    def hash_object_to_identity(self, hashable, is_module_val=False):
+        if isinstance(hashable, Hash):
+            return hashable
+
+        if isinstance(hashable, int):
+            return Hash.from_integer(hashable)
+
+        if isinstance(hashable, str):
+            return Hash.from_string(hashable)
+
+        if hashable is None:
+            return Hash.from_integer(1) + Hash.from_integer(0)
+
+        if isinstance(hashable, (dict, list)) and is_module_val:
+            # don't look into dicts and lists at module level
+            return Hash.from_integer(2)
+
+        if isinstance(hashable, (tuple, list)):
+            res = Hash.from_integer(len(hashable))
+            for t in hashable:
+                res += self.hash_object_to_identity(t, is_module_val)
+            return res
+
+        if isinstance(hashable, Wrapper):
+            return hashable.identityHash()
+
+        return Hash(_types.identityHash(hashable))
+
+    def is_currently_converting(self):
         return len(self._inflight_function_conversions) > 0
 
-    def getDefinitionCount(self):
+    def get_definition_count(self):
         return len(self._definitions)
 
-    def addVisitor(self, visitor):
+    def add_visitor(self, visitor):
         self._visitors.append(visitor)
 
-    def removeVisitor(self, visitor):
+    def remove_visitor(self, visitor):
         self._visitors.remove(visitor)
 
-    def identityToName(self, identity):
+    def identity_to_name(self, identity):
         """Convert a function identity to the link-time name for the function.
 
         Args:
@@ -188,41 +752,50 @@ class PythonToNativeConverter:
         """
         return self._link_name_for_identity.get(identity)
 
-    def buildAndLinkNewModule(self):
-        definitions = self.extract_new_function_definitions()
+    def trigger_virtual_destructor(self, instance_type):
+        self._delayed_destructors.append(instance_type)
 
-        if not definitions:
-            return
+    def trigger_virtual_method_instantiation(self, instance_type, method_name, return_type, arg_tuple_type, kwarg_tuple_type):
+        """Instantiate a virtual method as part of this batch of compilation.
 
-        if self.compilerCache is None:
-            loadedModule = self.llvmCompiler.buildModule(definitions)
-            loadedModule.linkGlobalVariables()
-            self.loadedUncachedModules.append(loadedModule)
-            return
+        Normally, compiling 'virtual' methods (method instantiations on subclasses
+        that are known as a base class to the compiler) happens lazily.  In some cases
+        (for instance, generators) we want to force compilation of specific methods
+        when we define the class, since otherwise we end up with irregular performance
+        because we're lazily triggering an expensive operation.
 
-        # get a set of function names that we depend on
-        externallyUsed = set()
-        dependency_edgelist = []
+        This method forces the current compilation operation to compile and link
+        instantiating 'methodName' on instances of 'instanceType'.
+        """
+        for baseClass in instance_type.__mro__:
+            if issubclass(baseClass, Class) and baseClass is not Class:
+                slot = _types.allocateClassMethodDispatch(
+                    baseClass,
+                    method_name,
+                    return_type,
+                    arg_tuple_type,
+                    kwarg_tuple_type
+                )
 
-        for funcName in definitions:
-            ident = self._identity_for_link_name.get(funcName)
-            if ident is not None:
-                for dep in self._dependencies.getNamesDependedOn(ident):
-                    depLN = self._link_name_for_identity.get(dep)
-                    dependency_edgelist.append([funcName, depLN])
-                    if depLN not in definitions:
-                        externallyUsed.add(depLN)
+                self._delayedVMIs.append(
+                    (baseClass, instance_type, slot)
+                )
 
-        binary = self.llvmCompiler.buildSharedObject(definitions)
+    def flush_delayed_VMIs(self):
+        while self._delayedVMIs or self._delayed_destructors:
+            vmis = self._delayedVMIs
+            self._delayedVMIs = []
 
-        self.compilerCache.addModule(
-            binary,
-            {name: self.getTarget(name) for name in definitions if self.hasTarget(name)},
-            externallyUsed,
-            dependency_edgelist
-        )
+            for baseClass, instanceClass, dispatchSlot in vmis:
+                self.compile_single_class_dispatch(baseClass, instanceClass, dispatchSlot)
 
-    def extract_new_function_definitions(self):
+            delayedDestructors = self._delayed_destructors
+            self._delayed_destructors = []
+
+            for T in delayedDestructors:
+                self.compile_class_destructor(T)
+
+    def _extract_new_function_definitions(self):
         """Return a list of all new function definitions from the last conversion."""
         res = {}
 
@@ -233,14 +806,14 @@ class PythonToNativeConverter:
 
         return res
 
-    def identityHashToFunctionName(self, name, identityHash, prefix="tp."):
+    def _identity_hash_to_function_name(self, name, identity_hash, prefix="tp."):
         assert isinstance(name, str)
-        assert isinstance(identityHash, str)
+        assert isinstance(identity_hash, str)
         assert isinstance(prefix, str)
 
-        return prefix + name + "." + identityHash
+        return prefix + name + "." + identity_hash
 
-    def createConversionContext(
+    def _create_conversion_context(
         self,
         identity,
         funcName,
@@ -269,120 +842,38 @@ class PythonToNativeConverter:
             pyast,
         )
 
-    def defineLinkName(self, identity, linkName):
+    def _define_link_name(self, identity, link_name):
         if identity in self._link_name_for_identity:
-            if self._link_name_for_identity[identity] != linkName:
+            if self._link_name_for_identity[identity] != link_name:
                 raise Exception(
                     f"For identity {identity}:\n\n"
-                    f"{self._link_name_for_identity[identity]}\n\n!=\n\n{linkName}"
+                    f"{self._link_name_for_identity[identity]}\n\n!=\n\n{link_name}"
                 )
-            assert self._identity_for_link_name[linkName] == identity
+            assert self._identity_for_link_name[link_name] == identity
         else:
-            self._link_name_for_identity[identity] = linkName
-            self._identity_for_link_name[linkName] = identity
+            self._link_name_for_identity[identity] = link_name
+            self._identity_for_link_name[link_name] = identity
 
-    def hasTarget(self, linkName):
-        return self.getTarget(linkName) is not None
+    def _has_target(self, link_name):
+        return self._get_target(link_name) is not None
 
-    def deleteTarget(self, linkName):
-        self._targets.pop(linkName)
+    def _delete_target(self, link_name):
+        self._targets.pop(link_name)
 
-    def setTarget(self, linkName, target):
+    def _set_target(self, link_name, target):
         assert (isinstance(target, TypedCallTarget))
-        self._targets[linkName] = target
+        self._targets[link_name] = target
 
-    def getTarget(self, linkName) -> Optional[TypedCallTarget]:
-        if linkName in self._targets:
-            return self._targets[linkName]
+    def _get_target(self, link_name) -> Optional[TypedCallTarget]:
+        if link_name in self._targets:
+            return self._targets[link_name]
 
-        if self.compilerCache is not None and self.compilerCache.hasSymbol(linkName):
-            return self.compilerCache.getTarget(linkName)
+        if self.compiler_cache is not None and self.compiler_cache.has_symbol(link_name):
+            return self.compiler_cache.get_target(link_name)
 
         return None
 
-    def defineNonPythonFunction(self, name, identityTuple, context):
-        """Define a non-python generating function (if we haven't defined it before already)
-
-            name - the name to actually give the function.
-            identityTuple - a unique (sha)hashable tuple
-            context - a FunctionConversionContext lookalike
-
-        returns a TypedCallTarget, or None if it's not known yet
-        """
-        identity = self.hashObjectToIdentity(identityTuple).hexdigest
-        linkName = self.identityHashToFunctionName(name, identity, "runtime.")
-
-        self.defineLinkName(identity, linkName)
-
-        target = self.getTarget(linkName)
-
-        if self._currentlyConverting is not None:
-            self._dependencies.addEdge(self._currentlyConverting, identity, dirty=(target is None))
-        else:
-            self._dependencies.addRoot(identity, dirty=(target is None))
-
-        if target is not None:
-            return target
-
-        self._inflight_function_conversions[identity] = context
-
-        if context.knownOutputType() is not None or context.alwaysRaises():
-            self.setTarget(
-                linkName,
-                self.getTypedCallTarget(
-                    name,
-                    context.getInputTypes(),
-                    context.knownOutputType(),
-                    alwaysRaises=context.alwaysRaises(),
-                    functionMetadata=context.functionMetadata,
-                )
-            )
-
-        if self._currentlyConverting is None:
-            # force the function to resolve immediately
-            self._resolveAllInflightFunctions()
-            self._installInflightFunctions()
-            self._inflight_function_conversions.clear()
-
-        return self.getTarget(linkName)
-
-    def defineNativeFunction(self, name, identity, input_types, output_type, generatingFunction):
-        """Define a native function if we haven't defined it before already.
-
-            name - the name to actually give the function.
-            identity - a tuple consisting of strings, ints, type wrappers, and tuples of same
-            input_types - list of Wrapper objects for the incoming types
-            output_type - Wrapper object for the output type, or None if the function doesn't
-                ever return
-            generatingFunction - a function producing a native_function_definition.
-                It should accept an expression_conversion_context, an expression for the output
-                if it's not pass-by-value (or None if it is), and a bunch of TypedExpressions
-                and produce code that always ends in a terminal expression, (or if it's pass by value,
-                flows off the end of the function)
-
-        returns a TypedCallTarget. 'generatingFunction' may call this recursively if it wants.
-        """
-        if output_type is not None:
-            output_type = typeWrapper(output_type)
-
-        input_types = [typeWrapper(x) for x in input_types]
-
-        identity = (
-            Hash.from_integer(2) +
-            self.hashObjectToIdentity(identity) +
-            self.hashObjectToIdentity(output_type) +
-            self.hashObjectToIdentity(input_types)
-        ).hexdigest
-
-        return self.defineNonPythonFunction(
-            name,
-            identity,
-            NativeFunctionConversionContext(
-                self, input_types, output_type, generatingFunction, identity
-            )
-        )
-
-    def getTypedCallTarget(self, name, input_types, output_type, alwaysRaises=False, functionMetadata=None):
+    def _get_typed_call_target(self, name, input_types, output_type, always_raises=False, function_metadata=None) -> TypedCallTarget:
         native_input_types = [a.getNativePassingType() for a in input_types if not a.is_empty]
         if output_type is None:
             native_output_type = native_ast.Type.Void()
@@ -404,8 +895,8 @@ class PythonToNativeConverter:
             ),
             input_types,
             output_type,
-            alwaysRaises=alwaysRaises,
-            functionMetadata=functionMetadata
+            alwaysRaises=always_raises,
+            functionMetadata=function_metadata
         )
 
         return res
@@ -413,119 +904,9 @@ class PythonToNativeConverter:
     def _code_to_ast(self, f):
         return python_ast.convertFunctionToAlgebraicPyAst(f)
 
-    def demasqueradeCallTargetOutput(self, callTarget: TypedCallTarget):
-        """Ensure we are returning the correct 'interpreterType' from callTarget.
-
-        In some cases, we may return a 'masquerade' type in compiled code. This is fine
-        for other compiled code, but the interpreter needs us to transform the result back
-        to the right interpreter type. For instance, we may be returning a *args tuple.
-
-        Returns:
-            a new TypedCallTarget where the output type has the right return type.
-        """
-        if callTarget.output_type is None:
-            return callTarget
-
-        if callTarget.output_type.interpreterTypeRepresentation == callTarget.output_type.typeRepresentation:
-            return callTarget
-
-        def generator(context, out, *args):
-            assert out is not None, "we should have an output because no masquerade types are pass-by-value"
-
-            res = context.call_typed_call_target(callTarget, args)
-
-            out.convert_copy_initialize(res.convert_masquerade_to_untyped())
-
-        res = self.defineNativeFunction(
-            "demasquerade_" + callTarget.name,
-            ("demasquerade", callTarget.name),
-            callTarget.input_types,
-            typeWrapper(callTarget.output_type.interpreterTypeRepresentation),
-            generator
-        )
-
-        return res
-
-    def generateCallConverter(self, callTarget: TypedCallTarget):
-        """Given a call target that's optimized for llvm-level dispatch (with individual
-        arguments packed into registers), produce a (native) call-target that
-        we can dispatch to from our C extension, where arguments are packed into
-        an array.
-
-        For instance, we are given
-            T f(A1, A2, A3 ...)
-        and want to produce
-            f(T*, X**)
-        where X is the union of A1, A2, etc.
-
-        Args:
-            callTarget - a TypedCallTarget giving the function we need
-                to generate an alternative entrypoint for
-        Returns:
-            the linker name of the defined native function
-        """
-        identifier = "call_converter_" + callTarget.name
-        linkName = callTarget.name + ".dispatch"
-
-        # # we already made a definition for this in this process so don't do it again
-        if linkName in self._definitions:
-            return linkName
-
-        # # we already defined it in another process so don't do it again
-        if self.compilerCache is not None and self.compilerCache.hasSymbol(linkName):
-            return linkName
-
-        # N.B. there aren't targets for call converters. We make the definition directly.
-
-        # if self.getTarget(linkName):
-        #     return linkName
-
-        args = []
-        for i in range(len(callTarget.input_types)):
-            if not callTarget.input_types[i].is_empty:
-                argtype = callTarget.input_types[i].getNativeLayoutType()
-
-                untypedPtr = native_ast.var('input').ElementPtrIntegers(i).load()
-
-                if callTarget.input_types[i].is_pass_by_ref:
-                    # we've been handed a pointer, and it's already a pointer
-                    args.append(untypedPtr.cast(argtype.pointer()))
-                else:
-                    args.append(untypedPtr.cast(argtype.pointer()).load())
-
-        if callTarget.output_type is not None and callTarget.output_type.is_pass_by_ref:
-            body = callTarget.call(
-                native_ast.var('return').cast(callTarget.output_type.getNativeLayoutType().pointer()),
-                *args
-            )
-        else:
-            body = callTarget.call(*args)
-
-            if not (callTarget.output_type is None or callTarget.output_type.is_empty):
-                body = native_ast.var('return').cast(callTarget.output_type.getNativeLayoutType().pointer()).store(body)
-
-        body = native_ast.FunctionBody.Internal(body=body)
-
-        definition = native_ast.Function(
-            args=(
-                ('return', native_ast.Type.Void().pointer()),
-                ('input', native_ast.Type.Void().pointer().pointer())
-            ),
-            body=body,
-            output_type=native_ast.Type.Void()
-        )
-
-        self._link_name_for_identity[identifier] = linkName
-        self._identity_for_link_name[linkName] = identifier
-
-        self._definitions[linkName] = definition
-        self._new_native_functions.add(linkName)
-
-        return linkName
-
-    def _resolveAllInflightFunctions(self):
+    def _resolve_all_inflight_functions(self):
         while True:
-            identity = self._dependencies.getNextDirtyNode()
+            identity = self._dependencies.get_next_dirty_node()
             if not identity:
                 return
 
@@ -534,7 +915,7 @@ class PythonToNativeConverter:
             hasDefinitionBeforeConversion = identity in self._inflight_definitions
 
             try:
-                self._currentlyConverting = identity
+                self._currently_converting = identity
 
                 self._times_calculated[identity] = self._times_calculated.get(identity, 0) + 1
 
@@ -548,18 +929,18 @@ class PythonToNativeConverter:
                 for i in self._inflight_function_conversions:
                     if i in self._link_name_for_identity:
                         name = self._link_name_for_identity[i]
-                        if self.hasTarget(name):
-                            self.deleteTarget(name)
+                        if self._has_target(name):
+                            self._delete_target(name)
                         ln = self._link_name_for_identity.pop(i)
                         self._identity_for_link_name.pop(ln)
 
-                    self._dependencies.dropNode(i)
+                    self._dependencies.drop_node(i)
 
                 self._inflight_function_conversions.clear()
                 self._inflight_definitions.clear()
                 raise
             finally:
-                self._currentlyConverting = None
+                self._currently_converting = None
 
             dirtyUpstream = False
 
@@ -572,203 +953,26 @@ class PythonToNativeConverter:
 
                 if functionConverter.typesAreUnstable():
                     functionConverter.resetTypeInstabilityFlag()
-                    self._dependencies.markDirtyWithLowPriority(identity)
+                    self._dependencies.mark_dirty_with_low_priority(identity)
                     dirtyUpstream = True
 
                 name = self._link_name_for_identity[identity]
 
-                self.setTarget(
+                self._set_target(
                     name,
-                    self.getTypedCallTarget(
+                    self._get_typed_call_target(
                         name,
                         functionConverter._input_types,
                         actual_output_type,
-                        alwaysRaises=functionConverter.alwaysRaises(),
-                        functionMetadata=functionConverter.functionMetadata,
+                        always_raises=functionConverter.alwaysRaises(),
+                        function_metadata=functionConverter.functionMetadata,
                     ),
                 )
 
             if dirtyUpstream:
-                self._dependencies.functionReturnSignatureChanged(identity)
+                self._dependencies.function_return_signature_changed(identity)
 
-    def triggerVirtualDestructor(self, instanceType):
-        self._delayedDestructors.append(instanceType)
-
-    def triggerVirtualMethodInstantiation(self, instanceType, methodName, returnType, argTupleType, kwargTupleType):
-        """Instantiate a virtual method as part of this batch of compilation.
-
-        Normally, compiling 'virtual' methods (method instantiations on subclasses
-        that are known as a base class to the compiler) happens lazily.  In some cases
-        (for instance, generators) we want to force compilation of specific methods
-        when we define the class, since otherwise we end up with irregular performance
-        because we're lazily triggering an expensive operation.
-
-        This method forces the current compilation operation to compile and link
-        instantiating 'methodName' on instances of 'instanceType'.
-        """
-        for baseClass in instanceType.__mro__:
-            if issubclass(baseClass, Class) and baseClass is not Class:
-                slot = _types.allocateClassMethodDispatch(
-                    baseClass,
-                    methodName,
-                    returnType,
-                    argTupleType,
-                    kwargTupleType
-                )
-
-                self._delayedVMIs.append(
-                    (baseClass, instanceType, slot)
-                )
-
-    def flushDelayedVMIs(self):
-        while self._delayedVMIs or self._delayedDestructors:
-            vmis = self._delayedVMIs
-            self._delayedVMIs = []
-
-            for baseClass, instanceClass, dispatchSlot in vmis:
-                self.compileSingleClassDispatch(baseClass, instanceClass, dispatchSlot)
-
-            delayedDestructors = self._delayedDestructors
-            self._delayedDestructors = []
-
-            for T in delayedDestructors:
-                self.compileClassDestructor(T)
-
-    def compileSingleClassDispatch(self, interfaceClass, implementingClass, slotIndex):
-        if (interfaceClass, implementingClass, slotIndex) in self._installedVMIs:
-            return
-
-        name, retType, argTypeTuple, kwargTypeTuple = _types.getClassMethodDispatchSignature(interfaceClass, implementingClass, slotIndex)
-
-        # we are compiling the function 'name' in 'implementingClass' to be installed when
-        # viewing an instance of 'implementingClass' as 'interfaceClass' that's function
-        # 'name' called with signature '(*argTypeTuple, **kwargTypeTuple) -> retType'
-        typedCallTarget = ClassWrapper.compileVirtualMethodInstantiation(
-            self,
-            interfaceClass,
-            implementingClass,
-            name,
-            retType,
-            argTypeTuple,
-            kwargTypeTuple
-        )
-
-        assert typedCallTarget is not None
-
-        self.buildAndLinkNewModule()
-
-        fp = self.functionPointerByName(typedCallTarget.name)
-
-        if fp is None:
-            raise Exception(f"Couldn't find a function pointer for {typedCallTarget.name}")
-
-        _types.installClassMethodDispatch(interfaceClass, implementingClass, slotIndex, fp.fp)
-
-        self._installedVMIs.add(
-            (interfaceClass, implementingClass, slotIndex)
-        )
-
-    def compileClassDestructor(self, cls):
-        if cls in self._installedDestructors:
-            return
-
-        typedCallTarget = typeWrapper(cls).compileDestructor(self)
-
-        assert typedCallTarget is not None
-
-        self.buildAndLinkNewModule()
-
-        fp = self.functionPointerByName(typedCallTarget.name)
-
-        _types.installClassDestructor(cls, fp.fp)
-        self._installedDestructors.add(cls)
-
-    def functionPointerByName(self, func_name) -> NativeFunctionPointer:
-        """Find a NativeFunctionPointer for a given link-time name.
-
-        Args:
-            func_name (str) - the name of the compiled symbol we want.
-
-        Returns:
-            a NativeFunctionPointer or None
-        """
-        if self.compilerCache is None:
-            # the llvm compiler holds it all
-            return self.llvmCompiler.function_pointer_by_name(func_name)
-        else:
-            # the llvm compiler is just building shared objects, but the
-            # compiler cache has all the pointers.
-            return self.compilerCache.function_pointer_by_name(func_name)
-
-    def convertTypedFunctionCall(self, functionType, overloadIx, inputWrappers, assertIsRoot=False):
-        overload = functionType.overloads[overloadIx]
-
-        realizedInputWrappers = []
-
-        closureType = functionType.ClosureType
-
-        for closureVarName, closureVarPath in overload.closureVarLookups.items():
-            realizedInputWrappers.append(
-                typeWrapper(
-                    PythonTypedFunctionWrapper.closurePathToCellType(closureVarPath, closureType)
-                )
-            )
-
-        realizedInputWrappers.extend(inputWrappers)
-
-        returnType = PythonTypedFunctionWrapper.computeFunctionOverloadReturnType(
-            overload,
-            inputWrappers,
-            {}
-        )
-
-        if returnType is CannotBeDetermined:
-            returnType = object
-
-        if returnType is NoReturnTypeSpecified:
-            returnType = None
-
-        return self.convert(
-            overload.name,
-            overload.functionCode,
-            overload.realizedGlobals,
-            overload.functionGlobals,
-            overload.funcGlobalsInCells,
-            list(overload.closureVarLookups),
-            realizedInputWrappers,
-            returnType,
-            assertIsRoot=assertIsRoot
-        )
-
-    def hashObjectToIdentity(self, hashable, isModuleVal=False):
-        if isinstance(hashable, Hash):
-            return hashable
-
-        if isinstance(hashable, int):
-            return Hash.from_integer(hashable)
-
-        if isinstance(hashable, str):
-            return Hash.from_string(hashable)
-
-        if hashable is None:
-            return Hash.from_integer(1) + Hash.from_integer(0)
-
-        if isinstance(hashable, (dict, list)) and isModuleVal:
-            # don't look into dicts and lists at module level
-            return Hash.from_integer(2)
-
-        if isinstance(hashable, (tuple, list)):
-            res = Hash.from_integer(len(hashable))
-            for t in hashable:
-                res += self.hashObjectToIdentity(t, isModuleVal)
-            return res
-
-        if isinstance(hashable, Wrapper):
-            return hashable.identityHash()
-
-        return Hash(_types.identityHash(hashable))
-
-    def hashGlobals(self, funcGlobals, code, funcGlobalsFromCells):
+    def _hash_globals(self, funcGlobals, code, funcGlobalsFromCells):
         """Hash a given piece of code's accesses to funcGlobals.
 
         We're trying to make sure that if we have a reference to module 'x'
@@ -779,161 +983,46 @@ class PythonToNativeConverter:
         res = Hash.from_integer(0)
 
         for dotSeq in _types.getCodeGlobalDotAccesses(code):
-            res += self.hashDotSeq(dotSeq, funcGlobals)
+            res += self._hash_dot_seq(dotSeq, funcGlobals)
 
         for globalName in funcGlobalsFromCells:
-            res += self.hashDotSeq([globalName], funcGlobals)
+            res += self._hash_dot_seq([globalName], funcGlobals)
 
         return res
 
-    def hashDotSeq(self, dotSeq, funcGlobals):
+    def _hash_dot_seq(self, dotSeq, funcGlobals):
         if not dotSeq or dotSeq[0] not in funcGlobals:
             return Hash.from_integer(0)
 
         item = funcGlobals[dotSeq[0]]
 
         if not isinstance(item, ModuleType) or len(dotSeq) == 1:
-            return Hash.from_string(dotSeq[0]) + self.hashObjectToIdentity(item, True)
+            return Hash.from_string(dotSeq[0]) + self.hash_object_to_identity(item, True)
 
         if not hasattr(item, dotSeq[1]):
             return Hash.from_integer(0)
 
-        return Hash.from_string(dotSeq[0] + "." + dotSeq[1]) + self.hashObjectToIdentity(getattr(item, dotSeq[1]), True)
+        return Hash.from_string(dotSeq[0] + "." + dotSeq[1]) + self.hash_object_to_identity(getattr(item, dotSeq[1]), True)
 
-    def convert(
-        self,
-        funcName,
-        funcCode,
-        funcGlobals,
-        funcGlobalsRaw,
-        funcGlobalsFromCells,
-        closureVars,
-        input_types,
-        output_type,
-        assertIsRoot=False,
-        conversionType=None
-    ):
-        """Convert a single pure python function using args of 'input_types'.
-
-        It will return no more than 'output_type'. if output_type is None we produce
-        the tightest output type possible.
-
-        Args:
-            funcName - the name of the function
-            funcCode - a Code object representing the code to compile
-            funcGlobals - the globals object from the relevant function
-            funcGlobalsRaw - the original globals object (with no merging or filtering done)
-                which we use to figure out the location of global variables that are not in cells.
-            funcGlobalsFromCells - a list of the names that are globals that are actually accessed
-                as cells.
-            input_types - a type for each free variable in the function closure, and
-                then again for each input argument
-            output_type - the output type of the function, if known. if this is None,
-                then we use type inference to produce the tightest type we can.
-                If not None, then we will produce this type or throw an exception.
-            assertIsRoot - if True, then assert that no other functions are using
-                the converter right now.
-            conversionType - if None, this is a normal function conversion. Otherwise,
-                this must be a subclass of FunctionConversionContext
-        """
-        assert isinstance(funcName, str)
-        assert isinstance(funcCode, types.CodeType)
-        assert isinstance(funcGlobals, dict)
-
-        input_types = tuple([typedPythonTypeToTypeWrapper(i) for i in input_types])
-
-        identityHash = (
-            Hash.from_integer(1)
-            + self.hashObjectToIdentity((
-                funcCode,
-                funcName,
-                input_types,
-                output_type,
-                closureVars,
-                conversionType
-            )) +
-            self.hashGlobals(funcGlobals, funcCode, funcGlobalsFromCells)
-        )
-
-        assert not identityHash.isPoison()
-
-        identity = identityHash.hexdigest
-
-        name = self.identityHashToFunctionName(funcName, identity)
-
-        self.defineLinkName(identity, name)
-
-        if identity not in self._identifier_to_pyfunc:
-            self._identifier_to_pyfunc[identity] = (
-                funcName, funcCode, funcGlobals, closureVars, input_types, output_type, conversionType
-            )
-
-        isRoot = len(self._inflight_function_conversions) == 0
-
-        if assertIsRoot:
-            assert isRoot
-
-        target = self.getTarget(name)
-
-        if self._currentlyConverting is not None:
-            self._dependencies.addEdge(self._currentlyConverting, identity, dirty=(target is None))
-        else:
-            self._dependencies.addRoot(identity, dirty=(target is None))
-
-        if target is not None:
-            return target
-
-        if identity not in self._inflight_function_conversions:
-            functionConverter = self.createConversionContext(
-                identity,
-                funcName,
-                funcCode,
-                funcGlobals,
-                funcGlobalsRaw,
-                closureVars,
-                input_types,
-                output_type,
-                conversionType
-            )
-            self._inflight_function_conversions[identity] = functionConverter
-
-        if isRoot:
-            try:
-                self._resolveAllInflightFunctions()
-                self._installInflightFunctions()
-                return self.getTarget(name)
-            finally:
-                self._inflight_function_conversions.clear()
-
-        else:
-            # above us on the stack, we are walking a set of function conversions.
-            # if we have ever calculated this function before, we'll have a call
-            # target with an output type and we can return that. Otherwise we have to
-            # return None, which will cause callers to replace this with a throw
-            # until we have had a chance to do a full pass of conversion.
-            if self.getTarget(name) is not None:
-                raise RuntimeError(f"Unexpected conversion error for {name}")
-            return None
-
-    def _installInflightFunctions(self):
+    def _install_inflight_functions(self):
         """Add all function definitions corresponding to keys in inflight_function_conversions to the relevant dictionaries."""
         if VALIDATE_FUNCTION_DEFINITIONS_STABLE:
             # this should always be true, but its expensive so we have it off by default
             for identifier, functionConverter in self._inflight_function_conversions.items():
                 try:
-                    self._currentlyConverting = identifier
+                    self._currently_converting = identifier
 
                     nativeFunction, actual_output_type = functionConverter.convertToNativeFunction()
 
                     assert nativeFunction == self._inflight_definitions[identifier]
                 finally:
-                    self._currentlyConverting = None
+                    self._currently_converting = None
 
         for identifier, functionConverter in self._inflight_function_conversions.items():
             outboundTargets = []
-            for outboundFuncId in self._dependencies.getNamesDependedOn(identifier):
+            for outboundFuncId in self._dependencies.get_names_depended_on(identifier):
                 name = self._link_name_for_identity[outboundFuncId]
-                target = self.getTarget(name)
+                target = self._get_target(name)
                 if target is not None:
                     outboundTargets.append(target)
                 else:
@@ -978,7 +1067,7 @@ class PythonToNativeConverter:
             if identifier not in self._inflight_definitions:
                 raise Exception(
                     f"Expected a definition for {identifier} depended on by:\n"
-                    + "\n".join("    " + str(i) for i in self._dependencies._dependencies.incoming(identifier))
+                    + "\n".join("    " + str(i) for i in self._dependencies.dependency_graph.incoming(identifier))
                 )
 
             nativeFunction, actual_output_type = self._inflight_definitions.get(identifier)

--- a/typed_python/compiler/runtime.py
+++ b/typed_python/compiler/runtime.py
@@ -231,10 +231,10 @@ class Runtime:
             self.verbosityLevel = 0
 
     def addEventVisitor(self, visitor: RuntimeEventVisitor):
-        self.converter.addVisitor(visitor)
+        self.converter.add_visitor(visitor)
 
     def removeEventVisitor(self, visitor: RuntimeEventVisitor):
-        self.converter.removeVisitor(visitor)
+        self.converter.remove_visitor(visitor)
 
     @staticmethod
     def passingTypeForValue(arg):
@@ -313,7 +313,7 @@ class Runtime:
             t0 = time.time()
             t1 = None
             t2 = None
-            defCount = self.converter.getDefinitionCount()
+            defCount = self.converter.get_definition_count()
 
             with self.lock:
                 inputWrappers = []
@@ -329,24 +329,24 @@ class Runtime:
 
                 self.timesCompiled += 1
 
-                callTarget = self.converter.convertTypedFunctionCall(
+                callTarget = self.converter.convert_typed_function_call(
                     functionType,
                     overloadIx,
                     inputWrappers,
-                    assertIsRoot=True
+                    assert_is_root=True
                 )
 
-                callTarget = self.converter.demasqueradeCallTargetOutput(callTarget)
+                callTarget = self.converter.demasquerade_call_target_output(callTarget)
 
                 assert callTarget is not None
 
-                wrappingCallTargetName = self.converter.generateCallConverter(callTarget)
+                wrappingCallTargetName = self.converter.generate_call_converter(callTarget)
 
                 t1 = time.time()
-                self.converter.buildAndLinkNewModule()
+                self.converter.build_and_link_new_module()
                 t2 = time.time()
 
-                fp = self.converter.functionPointerByName(wrappingCallTargetName)
+                fp = self.converter.function_pointer_by_name(wrappingCallTargetName)
 
                 overload._installNativePointer(
                     fp.fp,
@@ -354,7 +354,7 @@ class Runtime:
                     [i.typeRepresentation for i in callTarget.input_types]
                 )
 
-                self.converter.flushDelayedVMIs()
+                self.converter.flush_delayed_VMIs()
 
                 return callTarget
         finally:
@@ -363,14 +363,14 @@ class Runtime:
                     f"typed_python runtime spent {time.time()-t0:.3f} seconds "
                     + (f"({t2 - t1:.3f})" if t2 is not None else "")
                     + " adding " +
-                    f"{self.converter.getDefinitionCount() - defCount} functions."
+                    f"{self.converter.get_definition_count() - defCount} functions."
                 )
 
     def compileClassDispatch(self, interfaceClass, implementingClass, slotIndex):
         t0 = time.time()
 
         with self.lock:
-            self.converter.compileSingleClassDispatch(
+            self.converter.compile_single_class_dispatch(
                 interfaceClass, implementingClass, slotIndex
             )
 
@@ -392,7 +392,7 @@ class Runtime:
         t0 = time.time()
 
         with self.lock:
-            self.converter.compileClassDestructor(cls)
+            self.converter.compile_class_destructor(cls)
 
         if self.verbosityLevel > 0:
             print(
@@ -505,7 +505,7 @@ def Entrypoint(pyFunc):
         # check if we are already in the middle of the compilation process, due to the Entrypointed
         # code being called through a module import, and throw an error if so.
         if is_importing():
-            compiling_func = Runtime.singleton().converter._currentlyConverting
+            compiling_func = Runtime.singleton().converter._currently_converting
             compiling_func_link_name = Runtime.singleton().converter._link_name_for_identity[compiling_func]
             error_message = f"Can't import Entrypointed code {pyFunc.__module__}.{pyFunc.__qualname__} \
                 while {compiling_func_link_name} is being compiled."

--- a/typed_python/compiler/type_wrappers/alternative_wrapper.py
+++ b/typed_python/compiler/type_wrappers/alternative_wrapper.py
@@ -103,7 +103,7 @@ class AlternativeWrapperMixin(ClassOrAlternativeWrapperMixin):
             typeWrapper(SubclassOf(self.typeRepresentation)),
             lambda outPtr:
             outPtr.expr.store(
-                context.converter.defineNativeFunction(
+                context.converter.define_native_function(
                     "concrete_typeof_" + str(self.typeRepresentation),
                     ('concrete_typeof', self),
                     [self],
@@ -306,7 +306,7 @@ class AlternativeWrapper(AlternativeWrapperMixin, RefcountedWrapper):
 
     def on_refcount_zero(self, context, instance):
         return (
-            context.converter.defineNativeFunction(
+            context.converter.define_native_function(
                 "destructor_" + str(self.typeRepresentation),
                 ('destructor', self),
                 [self],
@@ -364,7 +364,7 @@ class AlternativeWrapper(AlternativeWrapperMixin, RefcountedWrapper):
         else:
             outputType = mergeTypeWrappers(possibleTypes)
 
-            native = context.converter.defineNativeFunction(
+            native = context.converter.define_native_function(
                 'getattr(' + self.typeRepresentation.__name__ + ", " + attribute + ")",
                 ('getattr', self, attribute),
                 [self],
@@ -526,7 +526,7 @@ class ConcreteAlternativeWrapper(AlternativeWrapperMixin, RefcountedWrapper):
         return context.push(
             self,
             lambda new_alt:
-                context.converter.defineNativeFunction(
+                context.converter.define_native_function(
                     'construct(' + str(self) + ")",
                     ('util', self, 'construct'),
                     tupletype.ElementTypes,

--- a/typed_python/compiler/type_wrappers/class_wrapper.py
+++ b/typed_python/compiler/type_wrappers/class_wrapper.py
@@ -528,7 +528,7 @@ class ClassWrapper(ClassOrAlternativeWrapperMixin, RefcountedWrapper):
             )
 
     def compileDestructor(self, converter):
-        return converter.defineNativeFunction(
+        return converter.define_native_function(
             "destructor_" + str(self.typeRepresentation),
             ('destructor', self),
             [self],
@@ -841,7 +841,7 @@ class ClassWrapper(ClassOrAlternativeWrapperMixin, RefcountedWrapper):
         argSignatureStrings = [str(x) for x in matchArgTypes[1:]]
         argSignatureStrings.extend([f"{k}={v}" for k, v in kwargTypes.items()])
 
-        dispatchToOverloads = context.converter.defineNativeFunction(
+        dispatchToOverloads = context.converter.define_native_function(
             f'call_method.{self}.{methodName}({",".join(argSignatureStrings)})',
             ('call_method', self, methodName, tuple(matchArgTypes), tuple(kwargTypes.items())),
             list(argTypes) + list(kwargTypes.values()),
@@ -926,7 +926,7 @@ class ClassWrapper(ClassOrAlternativeWrapperMixin, RefcountedWrapper):
 
                     assert isinstance(overloadRetType, type), type(overloadRetType)
 
-                    testSingleOverloadForm = context.converter.defineNativeFunction(
+                    testSingleOverloadForm = context.converter.define_native_function(
                         f'call_overload.{self}.{methodName}.{overloadIndex}.'
                         f'{conversionLevel.LEVEL}.{argTypes[1:]}.{kwargTypes}->{overloadRetType}',
                         ('call_overload', self, methodName, overloadIndex, conversionLevel.LEVEL,
@@ -1393,7 +1393,7 @@ class ClassWrapper(ClassOrAlternativeWrapperMixin, RefcountedWrapper):
         return context.push(
             self,
             lambda new_class:
-                context.converter.defineNativeFunction(
+                context.converter.define_native_function(
                     'construct(' + self.typeRepresentation.__name__ + ")("
                     + ",".join([
                         (argNames[i] + '=' if argNames[i] is not None else "") +

--- a/typed_python/compiler/type_wrappers/const_dict_wrapper.py
+++ b/typed_python/compiler/type_wrappers/const_dict_wrapper.py
@@ -406,7 +406,7 @@ class ConstDictWrapper(RefcountedWrapper):
             return runtime_functions.free.call(instance.nonref_expr.cast(native_ast.UInt8Ptr))
         else:
             return (
-                context.converter.defineNativeFunction(
+                context.converter.define_native_function(
                     "destructor_" + str(self.constDictType),
                     ('destructor', self),
                     [self],

--- a/typed_python/compiler/type_wrappers/dict_wrapper.py
+++ b/typed_python/compiler/type_wrappers/dict_wrapper.py
@@ -145,7 +145,7 @@ class DictWrapperBase(RefcountedWrapper):
         assert instance.isReference
 
         return (
-            context.converter.defineNativeFunction(
+            context.converter.define_native_function(
                 "destructor_" + str(self.typeRepresentation),
                 ('destructor', self),
                 [self],

--- a/typed_python/compiler/type_wrappers/held_class_wrapper.py
+++ b/typed_python/compiler/type_wrappers/held_class_wrapper.py
@@ -174,7 +174,7 @@ class HeldClassWrapper(ClassOrAlternativeWrapperMixin, Wrapper):
         return context.push(
             self,
             lambda new_class:
-                context.converter.defineNativeFunction(
+                context.converter.define_native_function(
                     'construct(' + self.typeRepresentation.__name__ + ")("
                     + ",".join([
                         (argNames[i] + '=' if argNames[i] is not None else "") +
@@ -469,7 +469,7 @@ class HeldClassWrapper(ClassOrAlternativeWrapperMixin, Wrapper):
         if not right.expr_type.can_convert_to_type(left.expr_type, ConversionLevel.Signature):
             return context.constant(False)
 
-        native = context.converter.defineNativeFunction(
+        native = context.converter.define_native_function(
             f'held_class_equality_check({left.expr_type} -> {right.expr_type})',
             ('held_class_equality_check', left.expr_type, right.expr_type),
             [left.expr_type, right.expr_type],

--- a/typed_python/compiler/type_wrappers/list_of_wrapper.py
+++ b/typed_python/compiler/type_wrappers/list_of_wrapper.py
@@ -77,7 +77,7 @@ class ListOfWrapper(TupleOrListOfWrapper):
                 if count is None:
                     return
 
-                native = context.converter.defineNativeFunction(
+                native = context.converter.define_native_function(
                     'pop(' + self.typeRepresentation.__name__ + ")",
                     ('util', self, 'pop'),
                     [self, int],
@@ -104,7 +104,7 @@ class ListOfWrapper(TupleOrListOfWrapper):
 
                 return context.pushPod(
                     None,
-                    context.converter.defineNativeFunction(
+                    context.converter.define_native_function(
                         'resize(' + self.typeRepresentation.__name__ + ")",
                         ('util', self, 'resize'),
                         [self, int],
@@ -123,7 +123,7 @@ class ListOfWrapper(TupleOrListOfWrapper):
 
                 return context.pushPod(
                     None,
-                    context.converter.defineNativeFunction(
+                    context.converter.define_native_function(
                         'resize(' + self.typeRepresentation.__name__ + ")",
                         ('util', self, 'resize'),
                         [self, int, self.underlyingWrapperType],
@@ -144,7 +144,7 @@ class ListOfWrapper(TupleOrListOfWrapper):
 
                 return context.pushPod(
                     None,
-                    context.converter.defineNativeFunction(
+                    context.converter.define_native_function(
                         'append(' + self.typeRepresentation.__name__ + ")",
                         ('util', self, 'append'),
                         [self, self.underlyingWrapperType],
@@ -158,7 +158,7 @@ class ListOfWrapper(TupleOrListOfWrapper):
                 return context.push(
                     self,
                     lambda out:
-                        context.converter.defineNativeFunction(
+                        context.converter.define_native_function(
                             'copy(' + self.typeRepresentation.__name__ + ")",
                             ('util', self, 'copy'),
                             [self],
@@ -170,7 +170,7 @@ class ListOfWrapper(TupleOrListOfWrapper):
             if len(args) == 0:
                 return context.pushPod(
                     None,
-                    context.converter.defineNativeFunction(
+                    context.converter.define_native_function(
                         'clear(' + self.typeRepresentation.__name__ + ")",
                         ('util', self, 'clear'),
                         [self],
@@ -187,7 +187,7 @@ class ListOfWrapper(TupleOrListOfWrapper):
 
                 return context.pushPod(
                     None,
-                    context.converter.defineNativeFunction(
+                    context.converter.define_native_function(
                         'reserve(' + self.typeRepresentation.__name__ + ")",
                         ('util', self, 'reserve'),
                         [self, int],
@@ -199,7 +199,7 @@ class ListOfWrapper(TupleOrListOfWrapper):
             if len(args) == 0:
                 return context.pushPod(
                     int,
-                    context.converter.defineNativeFunction(
+                    context.converter.define_native_function(
                         'reserved(' + self.typeRepresentation.__name__ + ")",
                         ('util', self, 'reserved'),
                         [self],
@@ -346,7 +346,7 @@ class ListOfWrapper(TupleOrListOfWrapper):
 
     def convert_default_initialize(self, context, tgt):
         context.pushEffect(
-            context.converter.defineNativeFunction(
+            context.converter.define_native_function(
                 'empty(' + self.typeRepresentation.__name__ + ")",
                 ('util', self, 'empty'),
                 [],
@@ -399,7 +399,7 @@ class ListOfWrapper(TupleOrListOfWrapper):
             return context.push(
                 self,
                 lambda out:
-                    context.converter.defineNativeFunction(
+                    context.converter.define_native_function(
                         'copy(' + str(self) + "," + str(args[0].expr_type) + ")",
                         ('util', self, 'copy'),
                         [args[0].expr_type],

--- a/typed_python/compiler/type_wrappers/one_of_wrapper.py
+++ b/typed_python/compiler/type_wrappers/one_of_wrapper.py
@@ -474,7 +474,7 @@ class OneOfWrapper(Wrapper):
     def convert_to_self_with_target(self, context, targetVal, otherExpr, conversionLevel, mayThrowOnFailure=False):
         assert targetVal.isReference
 
-        native = context.converter.defineNativeFunction(
+        native = context.converter.define_native_function(
             f'type_convert({otherExpr.expr_type} -> {targetVal.expr_type}, conversionLevel={conversionLevel.LEVEL})',
             ('type_convert', otherExpr.expr_type, targetVal.expr_type, conversionLevel.LEVEL),
             [PointerTo(self.typeRepresentation), otherExpr.expr_type],

--- a/typed_python/compiler/type_wrappers/python_typed_function_wrapper.py
+++ b/typed_python/compiler/type_wrappers/python_typed_function_wrapper.py
@@ -342,7 +342,7 @@ class PythonTypedFunctionWrapper(Wrapper):
         # import this wrapper. Note that we have to import it here to break the import cycles.
         # there's definitely a better way to organize this code.
 
-        singleConvertedOverload = context.functionContext.converter.convert(
+        singleConvertedOverload = context.functionContext.converter.convert_python_to_native(
             overload.name,
             overload.functionCode,
             overload.realizedGlobals,
@@ -351,7 +351,7 @@ class PythonTypedFunctionWrapper(Wrapper):
             list(overload.closureVarLookups),
             [typeWrapper(self.closurePathToCellType(path, closureType)) for path in overload.closureVarLookups.values()],
             None,
-            conversionType=ConvertionContextType
+            conversion_type=ConvertionContextType
         )
 
         if not singleConvertedOverload:
@@ -507,7 +507,7 @@ class PythonTypedFunctionWrapper(Wrapper):
 
             # just one overload will do. We can just instantiate this particular function
             # with a signature that comes from the method overload signature itself.
-            singleConvertedOverload = context.functionContext.converter.convert(
+            singleConvertedOverload = context.functionContext.converter.convert_python_to_native(
                 overload.name,
                 overload.functionCode,
                 overload.realizedGlobals,
@@ -634,7 +634,7 @@ class PythonTypedFunctionWrapper(Wrapper):
 
         argNames = [None for _ in argTypes] + list(kwargTypes)
 
-        res = converter.defineNativeFunction(
+        res = converter.define_native_function(
             f'implement_function.{self}{argTypes}.{kwargTypes}->{returnType}',
             ('implement_function.', self, returnType, self, tuple(argTypes), tuple(kwargTypes.items())),
             ([self] if provideClosureArgument else []) + list(argTypes) + list(kwargTypes.values()),
@@ -729,7 +729,7 @@ class PythonTypedFunctionWrapper(Wrapper):
                             kwargTypes
                         )
 
-                        callTarget = converter.convert(
+                        callTarget = converter.convert_python_to_native(
                             o.name,
                             o.functionCode,
                             o.realizedGlobals,
@@ -799,7 +799,7 @@ class PythonTypedFunctionWrapper(Wrapper):
 
         overloadIndex = overload.index
 
-        testSingleOverloadForm = context.converter.defineNativeFunction(
+        testSingleOverloadForm = context.converter.define_native_function(
             f'check_can_call_overload.{self}.{overloadIndex}.{conversionLevel}.{argTypes}.{kwargTypes}',
             ('check_can_call_overload', self, overloadIndex, conversionLevel.LEVEL,
                 tuple(argTypes), tuple(kwargTypes.items())),
@@ -893,7 +893,7 @@ class PythonTypedFunctionWrapper(Wrapper):
                             overloadRetType = returnType.typeRepresentation
 
                     if overloadRetType is None:
-                        testSingleOverloadForm = context.converter.defineNativeFunction(
+                        testSingleOverloadForm = context.converter.define_native_function(
                             f'implement_overload.{self}.{overloadIndex}.{conversionLevel}.{argTypes}.{kwargTypes}-> <exception>',
                             ('implement_overload', self, overloadIndex, conversionLevel.LEVEL,
                              overloadRetType, tuple(argTypes), tuple(kwargTypes.items())),
@@ -914,7 +914,7 @@ class PythonTypedFunctionWrapper(Wrapper):
                             + args
                         )
                     else:
-                        testSingleOverloadForm = context.converter.defineNativeFunction(
+                        testSingleOverloadForm = context.converter.define_native_function(
                             f'implement_overload.{self}.{overloadIndex}.{conversionLevel}.{argTypes}'
                             f'.{kwargTypes}->{overloadRetType}',
                             ('implement_overload', self, overloadIndex, conversionLevel.LEVEL,

--- a/typed_python/compiler/type_wrappers/set_wrapper.py
+++ b/typed_python/compiler/type_wrappers/set_wrapper.py
@@ -321,7 +321,7 @@ class SetWrapper(RefcountedWrapper):
         assert instance.isReference
 
         return (
-            context.converter.defineNativeFunction(
+            context.converter.define_native_function(
                 "destructor_" + str(self.typeRepresentation),
                 ('destructor', self),
                 [self],

--- a/typed_python/compiler/type_wrappers/tuple_of_wrapper.py
+++ b/typed_python/compiler/type_wrappers/tuple_of_wrapper.py
@@ -339,7 +339,7 @@ class TupleOrListOfWrapper(RefcountedWrapper):
         assert instance.isReference
 
         return (
-            context.converter.defineNativeFunction(
+            context.converter.define_native_function(
                 "destructor_" + str(self.typeRepresentation),
                 ('destructor', self),
                 [self],

--- a/typed_python/compiler/type_wrappers/tuple_wrapper.py
+++ b/typed_python/compiler/type_wrappers/tuple_wrapper.py
@@ -500,7 +500,7 @@ class TupleWrapper(Wrapper):
 
                 return context.constant(True)
             else:
-                native = context.converter.defineNativeFunction(
+                native = context.converter.define_native_function(
                     f'type_convert({sourceVal.expr_type} -> {targetVal.expr_type}, conversionLevel={conversionLevel.LEVEL})',
                     ('type_convert', sourceVal.expr_type, targetVal.expr_type, conversionLevel.LEVEL),
                     [self.typeRepresentation, sourceVal.expr_type],
@@ -603,7 +603,7 @@ class TupleWrapper(Wrapper):
 
             context.pushReturnValue(context.constant(False))
 
-        containsMethod = context.converter.defineNativeFunction(
+        containsMethod = context.converter.define_native_function(
             f'tuple.contains.{self}.{toFind.expr_type}',
             ('tuple.contains', self, toFind.expr_type),
             (self, toFind.expr_type),

--- a/typed_python/compiler/type_wrappers/typed_cell_wrapper.py
+++ b/typed_python/compiler/type_wrappers/typed_cell_wrapper.py
@@ -76,7 +76,7 @@ class TypedCellWrapper(RefcountedWrapper):
         assert instance.isReference
 
         return (
-            context.converter.defineNativeFunction(
+            context.converter.define_native_function(
                 "destructor_" + str(self.typeRepresentation),
                 ('destructor', self),
                 [self],

--- a/typed_python/compiler/typeof.py
+++ b/typed_python/compiler/typeof.py
@@ -38,7 +38,7 @@ class TypeOf:
 
         converter = typed_python.compiler.runtime.Runtime.singleton().converter
 
-        if callTarget is None and converter.isCurrentlyConverting():
+        if callTarget is None and converter.is_currently_converting():
             # return the 'empty' OneOf, which can't actually be constructed.
             return typed_python.OneOf()
 
@@ -61,11 +61,11 @@ class TypeOf:
 
         converter = typed_python.compiler.runtime.Runtime.singleton().converter
 
-        callTarget = converter.convertTypedFunctionCall(
+        callTarget = converter.convert_typed_function_call(
             type(funcObj),
             0,
             argumentSignature,
-            assertIsRoot=False
+            assert_is_root=False
         )
 
         return callTarget


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
Miscellaneous style improvements to python_to_native_converter and compiler_cache, notably:
- enforce snake_case everywhere (for PEP8 compliance)
- separate public and private methods
- better docstrings and type hints for IDEs. 

## How Has This Been Tested?
`pytest`

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.