### PR TITLE
fixed bug where "any" acted as "all"

### DIFF
--- a/typed_python/compiler/tests/any_all_compilation_test.py
+++ b/typed_python/compiler/tests/any_all_compilation_test.py
@@ -32,3 +32,5 @@ def test_compiles_any_and_all():
         assert callAll(T([1, 2, 3])) == all(T([1, 2, 3]))
         assert callAny(T([0, 0, 0])) == any(T([0, 0, 0]))
         assert callAll(T([0, 0, 0])) == all(T([0, 0, 0]))
+        assert callAny(T([0, 1, 2])) == any(T([0, 1, 2]))
+        assert callAll(T([0, 1, 2])) == all(T([0, 1, 2]))

--- a/typed_python/compiler/type_wrappers/all_any_wrapper.py
+++ b/typed_python/compiler/type_wrappers/all_any_wrapper.py
@@ -59,4 +59,4 @@ class AnyWrapper(Wrapper):
         return native_ast.Type.Struct()
 
     def convert_call(self, context, expr, args, kwargs):
-        return context.call_py_function(all, args, kwargs)
+        return context.call_py_function(any, args, kwargs)


### PR DESCRIPTION
One word bug fix in all_any_wrapper.py

<!-- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!-- Why is this change required? -->
<!-- What problem does it solve? -->
<!--  If it fixes an open issue, please link to the issue here.-->
The AnyWrapper had been mistakenly calling "all" instead of "any". This was not caught by the test which only checked empty and full lists. I made the one word change and added another case to the existing test to cover the difference.

## How Has This Been Tested?
<!-- Describe in reasonable detail how you tested your changes. -->
<!-- If appropriate, include details of your testing environment, -->
<!-- tests ran to see how your change affects other areas of the code, etc. -->
pytest

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.